### PR TITLE
Update fr.coffee

### DIFF
--- a/client/app/locales/fr.coffee
+++ b/client/app/locales/fr.coffee
@@ -17,7 +17,7 @@ module.exports =
     "memory consumption"        : "Utilisation mémoire"
     "disk consumption"          : "Utilisation disque"
     "you have no notifications" : "Vous n'avez aucune notification"
-    "dismiss all"               : "Ignorer toutes"
+    "dismiss all"               : "Tout ignorer"
     "add application"         : "Ajouter l'application ?"
     "install"                   : "Installer"
     "your app"                 : "Votre application !"


### PR DESCRIPTION
"Ignorer 'toutes" qui convenait pour les infos de mises à jour est remplacé par "Tout ignorer" car l'option peut aussi concerner les messages notifiés.
Il s'agissait d'éviter ce malencontreux message https://framapic.org/b39sn3Nk3KgC/vbABc4nW