### PR TITLE
[enh] Enable app deployment via Git

### DIFF
--- a/build/client/app/locales/en.js
+++ b/build/client/app/locales/en.js
@@ -162,7 +162,7 @@ module.exports = {
   "tasky description": "Super fast and simple tag-based task manager.",
   "todos description": "Write your tasks, order them and complete them efficiently.",
   "term description": "A terminal app for your Cozy.",
-  "ghost description": "share your stories with the world with this app based on the Ghost Blogging Platform.",
+  "ghost description": "Share your stories with the world with this app based on the Ghost Blogging Platform.",
   "reminder title email": "Reminder",
   "reminder title email expanded": "Reminder: %{description} - %{date} (%{calendar})",
   "reminder message expanded": "Reminder: %{description}\nStart: %{start} (%{timezone})\nEnd: %{end} (%{timezone})\nPlace: %{place}\nDetails: %{details}",

--- a/build/client/app/locales/fr.js
+++ b/build/client/app/locales/fr.js
@@ -162,6 +162,7 @@ module.exports = {
   "tasky description": "Un gestionnaire de tâches, basé sur les tags, rapide et simple.",
   "todos description": "Écrivez et ordonnez vos tâches efficacement.",
   "term description": "Un terminal pour votre Cozy.",
+  "ghost description": "Partagez vos histoires avec le monde entier avec la plateforme de blog Ghost.",
   "reminder title email": "[Cozy-Calendar] Rappel",
   "reminder message": "Rappel : %{message}",
   "warning unofficial app": "Cette application est une application communautaire et n'est pas maintenue par l'équipe Cozy.\nPour signaler un problème, merci de le rapporter sur <a href='https://forum.cozy.io'>notre forum</a>.",

--- a/build/server/lib/icon.js
+++ b/build/server/lib/icon.js
@@ -65,7 +65,7 @@ icons.getIconInfos = function(appli) {
   var basePath, iconInfos, name, repoName, root;
   if (appli != null) {
     name = appli.name.toLowerCase();
-    if (appli.git != null) {
+    if ((appli.git != null) && appli.git.match(/^https/)) {
       repoName = (appli.git.split('/')[4]).replace('.git', '');
     } else {
       repoName = name;

--- a/build/server/lib/manifest.js
+++ b/build/server/lib/manifest.js
@@ -20,7 +20,7 @@ exports.Manifest = (function() {
 
   Manifest.prototype.download = function(app, callback) {
     var Provider, provider, providerName;
-    if (app.local) {
+    if (app.local || app.git.match(/^\/usr\/local\/cozy/)) {
       this.config = app;
       return callback(null);
     } else if (app.git != null) {

--- a/build/server/lib/manifest.js
+++ b/build/server/lib/manifest.js
@@ -21,7 +21,7 @@ exports.Manifest = (function() {
   Manifest.prototype.download = function(app, callback) {
     var Provider, provider, providerName;
     if (app.local || app.git.match(/^\/usr\/local\/cozy/)) {
-      this.config = app;
+      this.config = require(app.git + "/package.json");
       return callback(null);
     } else if (app.git != null) {
       providerName = app.git.match(/(github\.com|gitlab\.cozycloud\.cc)/);

--- a/client/app/views/config_application.coffee
+++ b/client/app/views/config_application.coffee
@@ -11,7 +11,8 @@ module.exports = class ApplicationRow extends BaseView
 
     getRenderData: ->
         app: _.extend {}, @model.attributes,
-            website: @model.get('website') or @model.get('git')[...-4]
+            website: @model.get('website') \
+                or @model.get('git').replace(/\.git$/, '')
 
     events:
         "click .remove-app"        : "onRemoveClicked"

--- a/server/lib/icon.coffee
+++ b/server/lib/icon.coffee
@@ -59,7 +59,7 @@ icons.getPath = (root, appli) ->
 icons.getIconInfos = (appli) ->
     if appli?
         name = appli.name.toLowerCase()
-        if appli.git?
+        if appli.git? and appli.git.match /^https/
             repoName = (appli.git.split('/')[4]).replace '.git', ''
         else
             repoName = name

--- a/server/lib/manifest.coffee
+++ b/server/lib/manifest.coffee
@@ -11,7 +11,7 @@ class exports.Manifest
 
         # If manifest is already part of the app request, use it
         if app.local or app.git.match /^\/usr\/local\/cozy/
-            @config = app
+            @config = require "#{app.git}/package.json"
             callback null
 
         # Or fetch it from git

--- a/server/lib/manifest.coffee
+++ b/server/lib/manifest.coffee
@@ -10,7 +10,7 @@ class exports.Manifest
     download: (app, callback) ->
 
         # If manifest is already part of the app request, use it
-        if app.local
+        if app.local or app.git.match /^\/usr\/local\/cozy/
             @config = app
             callback null
 


### PR DESCRIPTION
## Idea

Being able to `git push` to the proxy and deploy an app this way.

```
$ git remote add cozy https://mycozy.cozycloud.cc/repo/myapp
$ git push cozy master
Username for 'https://mycozy.cozycloud.cc': 
Password for 'https://my@email.org@mycozy.cozycloud.cc':
remote: Counting objects: 75, done.
remote: Compressing objects: 100% (53/53), done.
remote: Total 62 (delta 27), reused 44 (delta 9)
remote: 
remote: info - Deploying 'myapp'
remote: info - Application 'myapp' has been deployed
remote:
Unpacking objects: 100% (62/62), done.
To https://mycozy.cozycloud.cc/repo/myapp
* [new branch]      master     -> cozy/master
```

## Details for cozy-home

The Home is modified to retrieve App manifest from a local package.json (and not necessarily from GitHub/Gitlab), since it has already been checked out when the user has pushed its sources.

To merge along with:
* https://github.com/cozy/cozy-proxy/pull/118
* https://github.com/cozy/cozy-monitor/pull/75
* https://github.com/cozy/cozy-controller/pull/58

**It lacks of test for now, please keep this PR open**