### PR TITLE
Fix wiki url in help page

### DIFF
--- a/client/app/templates/help.jade
+++ b/client/app/templates/help.jade
@@ -13,7 +13,7 @@
 
             p.help-text.mt2= t('help wiki title') + " "
             P.help-text
-                a(href="https://github.com/cozy-setup/wiki") github.com/cozy-setup/wiki
+                a(href="https://github.com/cozy/cozy-setup/wiki") github.com/cozy/cozy-setup/wiki
 
     .mod.w50.left.pa2
         div(style="text-align: right;")


### PR DESCRIPTION
Fixing the wrong wiki URL in https://---.cozycloud.cc/#help

Not tested, but this is the only place in the source code where I found the wiki URL (except the build/ dir)