### PR TITLE
Improve object picker

### DIFF
--- a/client/app/views/account.coffee
+++ b/client/app/views/account.coffee
@@ -207,6 +207,7 @@ module.exports = class exports.AccountView extends BaseView
     onAddBackgroundClicked: ->
         params =
             type: 'singlePhoto'
+            defaultTab: 'photoUpload'
 
         new ObjectPicker params, (newPhotoChosen, dataUrl) =>
 

--- a/client/app/views/object-picker-image.coffee
+++ b/client/app/views/object-picker-image.coffee
@@ -27,7 +27,8 @@ module.exports = class ObjectPickerImage extends BaseView
         @panel    = @el
         ####
         # construct the long list of images
-        @longList = new LongList(@panel, @modal)
+        @el.addEventListener 'panelSelect', =>
+            @longList = new LongList(@panel, @modal)
 
 
     getObject : () ->
@@ -54,4 +55,3 @@ module.exports = class ObjectPickerImage extends BaseView
 
     resizeHandler: () ->
         @longList.resizeHandler()
-

--- a/client/app/views/object-picker.coffee
+++ b/client/app/views/object-picker.coffee
@@ -84,9 +84,7 @@ module.exports = class PhotoPickerCroper extends Modal
         # init tabs
         tabControler.initializeTabs(body)
         @_listenTabsSelection()
-        #@_selectDefaultTab(@imagePanel.name)
-        @_selectDefaultTab(@uploadPanel.name)
-        # @_selectDefaultTab(@albumPanel.name)
+        @_selectDefaultTab(@params.defaultTab || @imagePanel.name)
         ####
         # init the cropper
         @imgToCrop.addEventListener('load', @_onImgToCropLoaded, false)

--- a/client/app/views/object-picker.coffee
+++ b/client/app/views/object-picker.coffee
@@ -209,8 +209,8 @@ module.exports = class PhotoPickerCroper extends Modal
             ctx.drawImage( img, d.sx, d.sy, d.sWidth,
                            d.sHeight, 0, 0, IMAGE_DIMENSION, IMAGE_DIMENSION)
         else
-            canvas.width  = img.width
-            canvas.height = img.height
+            canvas.width  = img.naturalWidth
+            canvas.height = img.naturalHeight
             ctx.drawImage img, 0, 0
         return dataUrl =  canvas.toDataURL 'image/jpeg'
 


### PR DESCRIPTION
This PR introduces some enhancements to the image object picker:
* allow the object picker to be positionned to a choosen tab at opening
* export a full-frame image when selected instead of a partil image when no cropping is enabled as post-action