### PR TITLE
Fix layout problems

### DIFF
--- a/client/app/initialize.coffee
+++ b/client/app/initialize.coffee
@@ -38,13 +38,10 @@ class exports.Application
         @routers.main = new MainRouter()
         Backbone.history.start()
 
-        @routers.main.navigate 'home', true
-
         # Configure realtime (to show automatic update of applications).
         SocketListener = require 'lib/socket_listener'
         SocketListener.socket.on 'installerror', (err) ->
             console.log "An error occured while attempting to install app"
             console.log err
-
 
 new exports.Application

--- a/client/app/styles/main.styl
+++ b/client/app/styles/main.styl
@@ -711,7 +711,7 @@ body
     margin-right 0.5%
     margin-top 0.5%
     cursor pointer
-    transition all 0.3s
+    transition background 0.3s
     text-align left
     border-bottom 1px solid lightgrey - 10%
     border-right 1px solid lightgrey - 10%

--- a/client/app/styles/main.styl
+++ b/client/app/styles/main.styl
@@ -12,17 +12,15 @@
 .home-body
     width 100%
     height 100%
-    padding 0
+    padding 36px 0 0 0
     margin 0
     background bgcolor
     background #FDFDFD
     overflow hidden
     box-sizing border-box
-    padding-top 36px
 
 body
     box-sizing border-box
-
 
 .navbar
     position fixed

--- a/client/app/styles/main.styl
+++ b/client/app/styles/main.styl
@@ -18,6 +18,13 @@
     background #FDFDFD
     overflow hidden
     box-sizing border-box
+    display: flex
+    flex-direction: column
+    justify-content: flex-start
+    align-items: stretch
+
+#app-frames
+    height 100%
 
 body
     box-sizing border-box
@@ -61,7 +68,6 @@ body
 #content
     height 100%
     overflow auto
-    margin-bottom 10px
     transition 0.6s background-image ease-in-out
     background-position center center
     background-repeat no-repeat

--- a/client/app/views/main.coffee
+++ b/client/app/views/main.coffee
@@ -73,7 +73,7 @@ module.exports = class HomeView extends BaseView
                 name = background.replace '-', '_'
                 val = "url('/img/backgrounds/#{name}.jpg')"
             else
-                val = "url('/api/backgrounds/#{background}/picture.jpg')"
+                val = "url('/api/backgrounds/#{background}>A/picture.jpg')"
 
             @content.css 'background-image', val
 
@@ -206,7 +206,13 @@ module.exports = class HomeView extends BaseView
 
         frame = @$("##{slug}-frame")
         onLoad = =>
+
+            # We display back the iframes
+            @frames.css 'top', '0'
+            @frames.css 'left', '0'
+            @frames.css 'position', 'inherit'
             @frames.show()
+
             @content.hide()
             @backButton.show()
 
@@ -219,14 +225,24 @@ module.exports = class HomeView extends BaseView
             name = '' if not name?
             window.document.title = "Cozy - #{name}"
             $("#current-application").html name
-            @resetLayoutSizes()
+            #@resetLayoutSizes()
 
             @$("#app-btn-#{slug} .spinner").hide()
             @$("#app-btn-#{slug} .icon").show()
 
 
         if frame.length is 0
-            frame = @createApplicationIframe(slug, hash)
+            frame = @createApplicationIframe slug, hash
+
+            # We show frames right now because to load properly the app
+            # requires a proper height.
+            @frames.show()
+
+            # Then we hide the frames by moving them far.
+            @frames.css 'top', '-9999px'
+            @frames.css 'left', '-9999px'
+            @frames.css 'position', 'absolute'
+
             frame.on 'load', onLoad
 
         # if the app was already open, we want to change its hash
@@ -265,21 +281,13 @@ module.exports = class HomeView extends BaseView
             app?.routers.main.navigate "/apps/#{slug}/#{newhash}", false
 
             # Ugly trick required because some app state changes requires
-            # to redraw the iframe
+            # to redraw the iframe.
             @resetLayoutSizes()
 
     ### Configuration ###
 
     # Small trick to size properly iframe.
     resetLayoutSizes: =>
-        @frames.height $(window).height() - 36
-
-        if $(window).width() > 640
-            @content.height $(window).height() - 36
-        else
-            @content.height 100
-            @content.height $(window).height()
-
         # Ugly trick to for redrawing of iframes.
         @frames.find('iframe').height "99%"
         setTimeout =>

--- a/client/app/views/main.coffee
+++ b/client/app/views/main.coffee
@@ -250,18 +250,23 @@ module.exports = class HomeView extends BaseView
             location = iframe$.prop('contentWindow').location
             newhash  = location.hash.replace '#', ''
             @onAppHashChanged slug, newhash
+
         @resetLayoutSizes()
         # declare the iframe to the intent manager.
         # TODO : when each iFrame will
         # have its own domain, then precise it
         # (ex : https://app1.joe.cozycloud.cc:8080)
-        @intentManager.registerIframe(iframe,'*')
+        @intentManager.registerIframe iframe, '*'
+
         return iframe$
 
     onAppHashChanged: (slug, newhash) =>
         if slug is @selectedApp
             app?.routers.main.navigate "/apps/#{slug}/#{newhash}", false
-        @resetLayoutSizes()
+
+            # Ugly trick required because some app state changes requires
+            # to redraw the iframe
+            @resetLayoutSizes()
 
     ### Configuration ###
 
@@ -272,4 +277,12 @@ module.exports = class HomeView extends BaseView
         if $(window).width() > 640
             @content.height $(window).height() - 36
         else
+            @content.height 100
             @content.height $(window).height()
+
+        # Ugly trick to for redrawing of iframes.
+        @frames.find('iframe').height "99%"
+        setTimeout =>
+            @frames.find('iframe').height "100%"
+        , 10
+

--- a/client/app/views/main.coffee
+++ b/client/app/views/main.coffee
@@ -52,8 +52,8 @@ module.exports = class HomeView extends BaseView
         @backButton = @$ '.back-button'
         @backButton.hide()
 
-        $(window).resize @resetLayoutSizes
-        @resetLayoutSizes()
+        $(window).resize @forceIframeRendering
+        @forceIframeRendering()
 
 
     ### Functions ###
@@ -73,7 +73,7 @@ module.exports = class HomeView extends BaseView
                 name = background.replace '-', '_'
                 val = "url('/img/backgrounds/#{name}.jpg')"
             else
-                val = "url('/api/backgrounds/#{background}>A/picture.jpg')"
+                val = "url('/api/backgrounds/#{background}/picture.jpg')"
 
             @content.css 'background-image', val
 
@@ -113,7 +113,7 @@ module.exports = class HomeView extends BaseView
             view.$el.show()
 
             @currentView = view
-            @resetLayoutSizes()
+            @forceIframeRendering()
             @content.scrollTop 0
 
         if @currentView?
@@ -121,7 +121,7 @@ module.exports = class HomeView extends BaseView
             if view is @currentView
                 @frames.hide()
                 @content.show()
-                @resetLayoutSizes()
+                @forceIframeRendering()
                 return
 
             @currentView.$el.hide()
@@ -225,7 +225,6 @@ module.exports = class HomeView extends BaseView
             name = '' if not name?
             window.document.title = "Cozy - #{name}"
             $("#current-application").html name
-            #@resetLayoutSizes()
 
             @$("#app-btn-#{slug} .spinner").hide()
             @$("#app-btn-#{slug} .icon").show()
@@ -267,7 +266,7 @@ module.exports = class HomeView extends BaseView
             newhash  = location.hash.replace '#', ''
             @onAppHashChanged slug, newhash
 
-        @resetLayoutSizes()
+        @forceIframeRendering()
         # declare the iframe to the intent manager.
         # TODO : when each iFrame will
         # have its own domain, then precise it
@@ -280,15 +279,15 @@ module.exports = class HomeView extends BaseView
         if slug is @selectedApp
             app?.routers.main.navigate "/apps/#{slug}/#{newhash}", false
 
-            # Ugly trick required because some app state changes requires
-            # to redraw the iframe.
-            @resetLayoutSizes()
+            # Ugly trick required because app state changes sometime
+            # breaks the iframe layout.
+            @forceIframeRendering()
 
     ### Configuration ###
 
-    # Small trick to size properly iframe.
-    resetLayoutSizes: =>
-        # Ugly trick to for redrawing of iframes.
+    # Ugly trick for redrawing iframes. It's required because sometimes the
+    # browser breaks the Iframe layout (I didn't find any reason for that).
+    forceIframeRendering: =>
         @frames.find('iframe').height "99%"
         setTimeout =>
             @frames.find('iframe').height "100%"

--- a/client/app/views/market.coffee
+++ b/client/app/views/market.coffee
@@ -55,13 +55,12 @@ module.exports = class MarketView extends BaseView
             app.get('state') in ['installed', 'stopped', 'broken']
         installeds = installedApps.pluck 'slug'
 
+        @$('.cozy-app').remove()
         @marketApps.each (app) =>
             slug = app.get 'slug'
             if installeds.indexOf(slug) is -1
                 if @$("#market-app-#{app.get 'slug'}").length is 0
                     @addApplication app
-            else
-                @$("#market-app-#{app.get 'slug'}").remove()
 
         if @$('.cozy-app').length is 0
             @noAppMessage.show()
@@ -73,7 +72,6 @@ module.exports = class MarketView extends BaseView
         @noAppMessage.hide()
         @appList.append row.el
         appButton = @$(row.el)
-        appButton.hide().fadeIn()
 
     onEnterPressed: (event) =>
         if event.which is 13 and not @popover?.$el.is(':visible')


### PR DESCRIPTION
Here are the changes I did. There is not much code change but everything is tricky and related to some browser rendering edge cases.

* Use flexbox to manage the layout of iframes (no more height calculated via Javascript).
* Use a dirty hack to avoid the 2px height bug. It looks to be a browser bug, because forcing the rendering again simply fix the thing.
* Change the way iframe are hidden on rendering (relies on css positioning instead of display attribute).

Edit: I added another fix put the apps in the right order after an uninstall.

@aenario could you review it?