### PR TITLE
Correction of a misbehaviour due to the free command

### DIFF
--- a/server/lib/memory.coffee
+++ b/server/lib/memory.coffee
@@ -67,8 +67,8 @@ class exports.MemoryManager
                     else
                         lines = resp.split('\n')
                         line = lines[0]
-                        # This is to prevent a misbehaviour which happens if the
-                        # syntax of free command is different than expected
+                        # This is to prevent a misbehaviour which happens if
+                        # the syntax of free command is different than expected
                         if isNaN parseInt(line)
                             data.freeMem = Math.floor os.freemem() / 1000
                         else

--- a/server/lib/memory.coffee
+++ b/server/lib/memory.coffee
@@ -67,7 +67,12 @@ class exports.MemoryManager
                     else
                         lines = resp.split('\n')
                         line = lines[0]
-                        data.freeMem = line
+                        # This is to prevent a misbehaviour which happens if the
+                        # syntax of free command is different than expected
+                        if isNaN parseInt(line)
+                            data.freeMem = Math.floor os.freemem() / 1000
+                        else
+                            data.freeMem = line
                         callback null, data
 
     # Try to get disk infos from the Cozy controller (it can access to the

--- a/server/lib/memory.coffee
+++ b/server/lib/memory.coffee
@@ -68,7 +68,8 @@ class exports.MemoryManager
                         lines = resp.split('\n')
                         line = lines[0]
                         # This is to prevent a misbehaviour which happens if
-                        # the syntax of free command is different than expected
+                        # the syntax of free command is different than
+                        # expected
                         if isNaN parseInt(line)
                             data.freeMem = Math.floor os.freemem() / 1000
                         else


### PR DESCRIPTION
Since there wasn't any check on the output of the `free` command, the function was misbehaving and considering there wasn't enough memory on the machine whenever the output was a bit different than expected.