### PR TITLE
Downgrade bcrypt to 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "americano": "0.3.11",
     "americano-cozy": "0.2.11",
     "async": "0.2.10",
-    "bcrypt": "0.8.5",
+    "bcrypt": "0.8.1",
     "cozy-clearance": "0.1.19",
     "cozy-clients": "1.0.3",
     "cozy-notifications-helper": "1.0.2",


### PR DESCRIPTION
The 0.8.5 version can't be installed with the nodejs and npm from debian packages.