### PR TITLE
Fix description of applications not requesting permissions

### DIFF
--- a/client/app/views/popover_description.coffee
+++ b/client/app/views/popover_description.coffee
@@ -55,7 +55,8 @@ module.exports = class PopoverDescriptionView extends BaseView
         description = @model.get "description"
         @header.parent().append "<p class=\"line\"> #{description} </p>"
 
-        if Object.keys(@model.get("permissions")).length is 0
+        permissions = @model.get("permissions")
+        if not permissions? or Object.keys(permissions).length is 0
             permissionsDiv = $ """
                 <div class='permissionsLine'>
                     <h5>#{t('no specific permissions needed')} </h5>


### PR DESCRIPTION
If package has no permission field, an client JS exception is triggered and the description window is empty.