### PR TITLE
get token with name and not with id

### DIFF
--- a/client/app/models/token.coffee
+++ b/client/app/models/token.coffee
@@ -3,8 +3,8 @@ client = require 'helpers/client'
 # Describes an application installed in mycloud.
 module.exports = class Token
 
-    constructor: (id) ->
-        @id = id
+    constructor: (name) ->
+        @name = name
    
     getToken: (callbacks) ->
-        client.get "api/getToken/#{@id}", callbacks
+        client.get "api/getToken/#{@name}", callbacks

--- a/client/app/routers/main_router.coffee
+++ b/client/app/routers/main_router.coffee
@@ -28,10 +28,12 @@ module.exports = class MainRouter extends Backbone.Router
             intent = event.data
             switch intent.action
                 when 'getToken'
-                    token = new Token intent.name
+                    iframeName = document.activeElement.id
+                    appName = iframeName.substring 0, iframeName.indexOf '-'
+                    token = new Token appName
                     token.getToken
                         success: (data) ->
-                            app.mainView.displayToken data, intent.name
+                            app.mainView.displayToken data, iframeName
                         error: ->
                             alert 'Server error occured, get token failed.'
                 when 'goto'

--- a/client/app/routers/main_router.coffee
+++ b/client/app/routers/main_router.coffee
@@ -1,7 +1,6 @@
 ObjectPickerCroper = require '../views/object_picker'
 Token = require "../models/token"
 
-
 module.exports = class MainRouter extends Backbone.Router
 
     routes :
@@ -29,7 +28,7 @@ module.exports = class MainRouter extends Backbone.Router
             intent = event.data
             switch intent.action
                 when 'getToken'
-                    token = new Token intent.id
+                    token = new Token intent.name
                     token.getToken
                         success: (data) ->
                             app.mainView.displayToken data, intent.name

--- a/client/app/views/main.coffee
+++ b/client/app/views/main.coffee
@@ -333,6 +333,6 @@ module.exports = class HomeView extends BaseView
 
     # Returns app iframe corresponding for given app slug.
     displayToken: (token, slug) ->
-        iframeWin = document.getElementById("#{slug}-frame").contentWindow
+        iframeWin = document.getElementById("#{slug}").contentWindow
         iframeWin.postMessage token: token, '*'
         

--- a/server/controllers/applications.coffee
+++ b/server/controllers/applications.coffee
@@ -51,7 +51,6 @@ sendErrorSocket = (err) ->
 markBroken = (res, app, err) ->
     console.log "Marking app #{app.name} as broken because"
     console.log err.stack
-
     data =
         state: 'broken'
         password: null
@@ -598,15 +597,17 @@ module.exports =
             else
                 res.send 200, data
 
-
+    # get token for static application access
     getToken: (req, res, next) ->
-        Application.getToken req.params.id, (err, access) ->
-            if err?
-                res.send
-                    error: true
-                    success: false
-                    message: err
-                , 500
-            else
-                res.send 200, access.token
-    
+        Application.all key: req.params.name, (err, apps) ->
+            return sendError res, err if err
+            Application.getToken apps[0]._id, (err, access) ->
+                if err?
+                    res.send
+                        error: true
+                        success: false
+                        message: err
+                    , 500
+                else
+                    res.send 200, access.token
+

--- a/server/controllers/routes.coffee
+++ b/server/controllers/routes.coffee
@@ -50,7 +50,8 @@ module.exports =
     'api/applications/update/stack'   : put: stackApplications.update
     'api/applications/reboot/stack'   : put: stackApplications.reboot
 
-    'api/getToken/:id'                : get: applications.getToken
+    'api/getToken/:name'                :
+        get: applications.getToken
 
     # Devices routes
     'api/devices'    : get: devices.devices

--- a/server/models/application.coffee
+++ b/server/models/application.coffee
@@ -77,6 +77,7 @@ Application::getAccess = (callback) ->
 
 # get token for static app
 Application.getToken = (id, callback) ->
+    dataClient.setBasicAuth 'home', getToken()
     dataClient.post "request/access/byApp/", key: id, (err, res, body) ->
         if err
             callback err


### PR DESCRIPTION
This PR proposes to get the token with the name of the app and not the id. I think that when the app wants to get ask token for permission it's simpler to fill the name of the app than the id IMHO