### PR TITLE
Add a postinstall script for node4 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "build:client": "cd client && brunch b",
     "build:server": "cake build",
     "build": "npm run build:clean && npm run build:client && npm run build:server",
-	"postinstall": "node postinstall.js"
+    "postinstall": "node postinstall.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "americano": "0.3.11",
     "americano-cozy": "0.2.11",
     "async": "0.2.10",
-    "bcrypt": "0.8.1",
     "cozy-clearance": "0.1.22",
     "cozy-clients": "1.0.4",
     "cozy-notifications-helper": "1.0.2",
@@ -61,6 +60,7 @@
     "build:clean": "rm -rf build",
     "build:client": "cd client && brunch b",
     "build:server": "cake build",
-    "build": "npm run build:clean && npm run build:client && npm run build:server"
+    "build": "npm run build:clean && npm run build:client && npm run build:server",
+	"postinstall": "node postinstall.js"
   }
 }

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+var spawn = require('child_process').spawn;
+var major = process.versions.node.split('.')[0];
+var bcrypt = 'bcrypt@0.8.5';
+
+if (major == '0') {
+  bcrypt = 'bcrypt@0.8.1';
+}
+spawn('npm', ['install', bcrypt], { stdio: 'inherit' });

--- a/postinstall.js
+++ b/postinstall.js
@@ -4,7 +4,7 @@ var spawn = require('child_process').spawn;
 var major = process.versions.node.split('.')[0];
 var bcrypt = 'bcrypt@0.8.5';
 
-if (major == '0') {
+if (major === '0') {
   bcrypt = 'bcrypt@0.8.1';
 }
 spawn('npm', ['install', bcrypt], { stdio: 'inherit' });


### PR DESCRIPTION
Bcrypt@0.8.1 is compatible with node 0.x.y
Bcrypt@0.8.5 is compatible with node 0.10.40+

We want cozy-proxy to works on:

- node 0.10.25 (the version installed by default on ubuntu)
- node 0.10.29 (the version installed by default on debian)
- the current stable release of node 0.10, 0.12, 4 and 5

So, we have to use the postinstall feature of npm to check the version
of node and install a version of bcrypt compatible with it.