### PR TITLE
enabling gettoken to work when a browser app is opening

### DIFF
--- a/client/app/routers/main_router.coffee
+++ b/client/app/routers/main_router.coffee
@@ -28,7 +28,8 @@ module.exports = class MainRouter extends Backbone.Router
             intent = event.data
             switch intent.action
                 when 'getToken'
-                    iframeName = document.activeElement.id
+                    elements = document.getElementsByTagName 'iframe'
+                    iframeName = elements[0].getAttribute 'id'
                     appName = iframeName.substring 0, iframeName.indexOf '-'
                     token = new Token appName
                     token.getToken

--- a/client/app/routers/main_router.coffee
+++ b/client/app/routers/main_router.coffee
@@ -29,12 +29,12 @@ module.exports = class MainRouter extends Backbone.Router
             switch intent.action
                 when 'getToken'
                     path = event.source.location.pathname
-                    appName = path.replace '/apps/', ''
-                    appName = appName.replace '/', '' if appName.slice -1 is '/'
-                    token = new Token appName
+                    slug = path.replace '/apps/', ''
+                    slug = slug.replace '/', '' if slug.slice -1 is '/'
+                    token = new Token slug
                     token.getToken
                         success: (data) ->
-                            app.mainView.displayToken data, appName
+                            app.mainView.displayToken data, slug
                         error: ->
                             alert 'Server error occured, get token failed.'
                 when 'goto'

--- a/client/app/routers/main_router.coffee
+++ b/client/app/routers/main_router.coffee
@@ -28,9 +28,9 @@ module.exports = class MainRouter extends Backbone.Router
             intent = event.data
             switch intent.action
                 when 'getToken'
-                    elements = document.getElementsByTagName 'iframe'
-                    iframeName = elements[0].getAttribute 'id'
-                    appName = iframeName.substring 0, iframeName.indexOf '-'
+                    path = event.source.location.pathname
+                    appName = path.replace '/apps/', ''
+                    appName = appName.replace '/', '' if appName.slice -1 is '/'
                     token = new Token appName
                     token.getToken
                         success: (data) ->


### PR DESCRIPTION
Before the gettoken only worked when an event was activated in a browser app. The activeElement was'nt able to retrieve the name of the app. 