### PR TITLE
Allow Home to get manifest from NPM

### DIFF
--- a/server/lib/manifest.coffee
+++ b/server/lib/manifest.coffee
@@ -67,7 +67,7 @@ class exports.Manifest
     downloadFromNpm: (packageName, callback) ->
         client = request.createClient "https://registry.npmjs.org/"
         client.get packageName, (err, res, data) ->
-            if res.statusCode is 404
+            if res?.statusCode is 404
                 callback localizationManager.t 'manifest not found'
             else if err
                 callback err

--- a/server/lib/manifest.coffee
+++ b/server/lib/manifest.coffee
@@ -62,7 +62,7 @@ class exports.Manifest
 
 
     # Download the manifest from the NPM registry. This manifest has many
-    # information (it includes history). So we extract the lastest version
+    # information (it includes history). So we extract the latest version
     # of the application manifest.
     downloadFromNpm: (packageName, callback) ->
         client = request.createClient "https://registry.npmjs.org/"

--- a/server/lib/manifest.coffee
+++ b/server/lib/manifest.coffee
@@ -67,11 +67,14 @@ class exports.Manifest
     downloadFromNpm: (packageName, callback) ->
         client = request.createClient "https://registry.npmjs.org/"
         client.get packageName, (err, res, data) ->
-            manifest = data.versions[data['dist-tags'].latest]
-            if err? and res.statusCode is 404
-                err = localizationManager.t 'manifest not found'
-            @config = manifest
-            callback err, manifest
+            if res.statusCode is 404
+                callback localizationManager.t 'manifest not found'
+            else if err
+                callback err
+            else
+                manifest = data.versions[data['dist-tags'].latest]
+                @config = manifest
+                callback null, manifest
 
 
     getPermissions: =>

--- a/server/lib/manifest.coffee
+++ b/server/lib/manifest.coffee
@@ -8,6 +8,12 @@ logger = require('printit')
 class exports.Manifest
 
 
+    # Attempt to download application NPM manifest from three different
+    # location (location selection is based on manifest information):
+    #
+    # * NPM registry
+    # * Gitlab repository
+    # * Github repository
     download: (app, callback) ->
 
         if app.package?
@@ -27,6 +33,7 @@ class exports.Manifest
                 callback null, {}
 
         else if app.git?
+
             providerName = app.git.match /(github\.com|gitlab\.cozycloud\.cc)/
             if not providerName?
                 logger.error "Unknown provider '#{app.git}'"
@@ -35,10 +42,10 @@ class exports.Manifest
             else
                 providerName = providerName[0]
 
-                # This could be moved to a separate factory class...
                 if providerName is "gitlab.cozycloud.cc"
                     Provider = require('./git_providers').CozyGitlabProvider
-                else # fallback to github
+
+                else
                     Provider = require('./git_providers').GithubProvider
 
                 provider = new Provider app
@@ -54,6 +61,9 @@ class exports.Manifest
             callback null, {}
 
 
+    # Download the manifest from the NPM registry. This manifest has many
+    # information (it includes history). So we extract the lastest version
+    # of the application manifest.
     downloadFromNpm: (packageName, callback) ->
         client = request.createClient "https://registry.npmjs.org/"
         client.get packageName, (err, res, data) ->

--- a/server/models/application.coffee
+++ b/server/models/application.coffee
@@ -19,6 +19,7 @@ module.exports = Application = cozydb.getModel 'Application',
     path: String
     type: String
     color: {type: String, default: null}
+    package: String
     git: String
     errormsg: String
     errorcode: String
@@ -139,6 +140,7 @@ Application::getHaibuDescriptor = () ->
         name: @slug
         type: @type
         domain: "127.0.0.1"
+        package: @package
         repository:
             type: "git",
             url: @git
@@ -148,3 +150,4 @@ Application::getHaibuDescriptor = () ->
     if @branch? and @branch isnt "null"
         descriptor.repository.branch = @branch
     return descriptor
+

--- a/test/lib_manifest.coffee
+++ b/test/lib_manifest.coffee
@@ -1,0 +1,67 @@
+should = require 'should'
+
+{Manifest} = require '../server/lib/manifest'
+
+describe 'Manifest', ->
+
+    manifest = new Manifest()
+
+    it 'download (npm app)', (done) ->
+        app =
+            name: 'contacts'
+            package: 'cozy-contacts'
+
+        manifest.download app, (err, appManifest) ->
+            appManifest.name.should.equal 'cozy-contacts'
+            should.not.exist err
+            should.exist appManifest.version
+            should.exist appManifest.scripts.start
+
+            app =
+                name: 'contacts'
+                package:
+                    type: 'npm'
+                    name: 'cozy-contacts'
+
+            manifest.download app, (err, appManifest) ->
+                appManifest.name.should.equal 'cozy-contacts'
+                should.not.exist err
+                should.exist appManifest.version
+                should.exist appManifest.scripts.start
+
+                app =
+                    name: 'contacts'
+                    package:
+                        type: 'python'
+                        name: 'cozy-contacts'
+
+                manifest.download app, (err, appManifest) ->
+                    should.not.exist err
+                    Object.keys(appManifest).length.should.be.equal 0
+                    Object.keys(manifest.config).length.should.be.equal 0
+                    done()
+
+
+    it 'download (git app)', (done) ->
+        app =
+            name: 'contacts'
+            git: 'https://github.com/cozy/cozy-contacts.git'
+
+        manifest.download app, (err, appManifest) ->
+            should.not.exist err
+            appManifest.name.should.equal 'cozy-contacts'
+            should.exist appManifest.version
+            should.exist appManifest.scripts.start
+            done()
+
+
+    it 'download (wrong type)', (done) ->
+        app =
+            name: 'contacts'
+
+        manifest.download app, (err, appManifest) ->
+            Object.keys(appManifest).length.should.be.equal 0
+            Object.keys(manifest.config).length.should.be.equal 0
+            done()
+
+


### PR DESCRIPTION
If there is a package field in the app descriptor (from Cozy registry), it fetches additional metadata from NPM registry instead of the app git repository.