### PR TITLE
Fix display of update button

### DIFF
--- a/client/app/views/config_application.coffee
+++ b/client/app/views/config_application.coffee
@@ -133,7 +133,7 @@ module.exports = class ApplicationRow extends BaseView
         @setIconSrc()
 
         @updateIcon.toggle @model.get 'needsUpdate'
-        if (not @model.get("branch")? or @model.get 'branch' is 'master') and
+        if (not @model.get("branch")? or (@model.get('branch') is 'master')) and
             not(@model.get('needsUpdate'))
                 @$(".update-app").hide()
 


### PR DESCRIPTION
Update button was always displayed when branch explicitely set to
`master`