### PR TITLE
config_applications: Handle megabytes and smaller units for disk usage.

### DIFF
--- a/client/app/views/config_applications.coffee
+++ b/client/app/views/config_applications.coffee
@@ -101,18 +101,17 @@ module.exports = class ConfigApplicationsView extends BaseView
                 alert t 'Server error occured, infos cannot be displayed.'
 
             else
-                if data.usedUnit is 'T'
-                    data.usedUnit = 'G'
-                    data.usedDiskSpace *= 1000
-
-                if data.totalUnit is 'T'
-                    data.totalUnit = 'G'
-                    data.totalDiskSpace *= 1000
-
-                diskUsed  = "#{data.usedDiskSpace} "
-                diskTotal = "#{data.totalDiskSpace} "
+                diskUsed  = @toGigabytes data.usedDiskSpace, data.usedUnit
+                diskTotal = @toGigabytes data.totalDiskSpace, data.totalUnit
                 @displayMemory data.freeMem, data.totalMem
                 @displayDiskSpace diskUsed, diskTotal
+
+    toGigabytes: (value, unit) ->
+        switch unit
+            when 'T' then value * 1000;
+            when 'G' then value;
+            when 'M' then value / 1000;
+            else 0
 
 
     displayMemory: (amount, total) ->
@@ -121,8 +120,8 @@ module.exports = class ConfigApplicationsView extends BaseView
 
 
     displayDiskSpace: (amount, total) ->
-        @diskSpace.find('.amount').html amount
-        @diskSpace.find('.total').html total
+        @diskSpace.find('.amount').html "#{amount} "
+        @diskSpace.find('.total').html "#{total} "
 
 
     onAppStateChanged: ->


### PR DESCRIPTION
Else, they will be displayed as if they were gigabytes.  This can cause
some confusing "123.4 / 50 GB" text to be displayed if only 123.4 MB are
used.  This patch make it display "0.1234 / 50 GB", which is a bit
better.  For smaller size units, 0 is displayed.

Also, this pull request does not address it, but the code currently mixes SI prefixes with 1024-based prefixes.  df -h use 1024 prefixes, but they may be divided by 1000 in the client, and they are always displayed as "GB".