### PR TITLE
Fix bug about iframe hash change when intent

### DIFF
--- a/client/app/views/main.coffee
+++ b/client/app/views/main.coffee
@@ -267,11 +267,9 @@ module.exports = class HomeView extends BaseView
             # if the app was already open, we want to change its hash
             # only if there is a hash in the home given url.
             else if hash
-                contentWindow = frame.prop('contentWindow')
-
                 # Same origin policy may prevent to access location hash
                 try
-                    currentHash = contentWindow.location.hash.substring 1
+                    frame.prop('contentWindow').location.hash = hash
                 catch err
                     console.err err
                 onLoad()
@@ -356,4 +354,3 @@ module.exports = class HomeView extends BaseView
     displayToken: (token, slug) ->
         iframeWin = document.getElementById("#{slug}-frame").contentWindow
         iframeWin.postMessage token: token, appName:slug, '*'
-


### PR DESCRIPTION
When an intent is used and the application iframe is already displayed, the hash wasn't changed correctly. Fixed.

Probably due to this change: https://github.com/cozy/cozy-home/commit/ad5163bea95583023fcc4bddcd9bdb8e0d1c3dc0#diff-f7bf5c0ccbfe9c8277c9f901402aa840L250

__To merge in the development branch as well.__