### PR TITLE
Fix/issue 519

### DIFF
--- a/client/app/helpers/client.coffee
+++ b/client/app/helpers/client.coffee
@@ -38,4 +38,4 @@ exports.head = (url, callbacks) ->
 # Invalid hash could be iframe source
 # Force refresh to root application
 exports.getSAMEORIGINError = (hash) ->
-    return hash.match /^(\w*:\/\/\w+\.)/)
+    return hash.match /^(\w*:\/\/\w+\.)/

--- a/client/app/helpers/client.coffee
+++ b/client/app/helpers/client.coffee
@@ -33,3 +33,9 @@ exports.del = (url, callbacks) ->
 # Expected callbacks: success and error
 exports.head = (url, callbacks) ->
     exports.request "HEAD", url, null, callbacks
+
+# Handle SAMEORIGIN error
+# Invalid hash could be iframe source
+# Force refresh to root application
+exports.getSAMEORIGINError = (hash) ->
+    return hash.match /^(\w*:\/\/\w+\.)/)

--- a/client/app/routers/main_router.coffee
+++ b/client/app/routers/main_router.coffee
@@ -1,5 +1,6 @@
 ObjectPickerCroper = require '../views/object_picker'
 Token = require "../models/token"
+client = require '../helpers/client'
 
 module.exports = class MainRouter extends Backbone.Router
 
@@ -15,12 +16,11 @@ module.exports = class MainRouter extends Backbone.Router
         "update-stack"        : "updateStack"
         "apps/:slug"          : "application"
         "apps/:slug/*hash"    : "application"
-        "*path"               : "applicationList"
-        '*notFound'           : 'applicationList'
+        "*path"               : "default"
+        '*notFound'           : 'default'
 
 
     initialize: ->
-
         # Wait for applications to send intents. Intents are sent trough
         # messages. Messages between app and home are possible only when the
         # app is displayed with the home top bar.
@@ -60,8 +60,22 @@ module.exports = class MainRouter extends Backbone.Router
                 else
                     console.log "Weird intent, cannot handle it.", intent
 
+    # Always goto Home
+    # when hash is unkwnow
+    default: (hash) ->
+        @navigate 'home', true
 
-    ## Route behaviors
+
+    navigate: (hash, trigger) ->
+        # Handle SAMEORIGIN error
+        # Invalid hash could be iframe source
+        # Force refresh to root application
+        if (client.getSAMEORIGINError hash)
+            hash = ''
+            trigger = true
+
+        super hash, trigger
+
 
     applicationList: ->
         app.mainView.displayApplicationsList()
@@ -87,7 +101,7 @@ module.exports = class MainRouter extends Backbone.Router
         app.mainView.displayAccount()
 
 
-    application: (slug, hash) ->
+    application: (slug, hash='') ->
         app.mainView.displayApplication slug, hash
 
 

--- a/client/app/templates/application_iframe.jade
+++ b/client/app/templates/application_iframe.jade
@@ -1,1 +1,1 @@
-iframe(src="#{src}", id="#{id}")
+iframe(src="#{source}", id="#{id}")

--- a/client/app/templates/application_iframe.jade
+++ b/client/app/templates/application_iframe.jade
@@ -1,1 +1,1 @@
-iframe(src="apps/#{id}/#{hash}", id="#{id}-frame")
+iframe(src="#{src}", id="#{id}")

--- a/client/app/views/main.coffee
+++ b/client/app/views/main.coffee
@@ -226,9 +226,8 @@ module.exports = class HomeView extends BaseView
             @$("#app-btn-#{slug} .spinner").show()
             @$("#app-btn-#{slug} .icon").hide()
 
-
             iframeID = @getAppFrameID slug
-            frame = $("##{iframeID}")
+            frame = @$("##{iframeID}")
 
             onLoad = =>
                 # We display back the iframes
@@ -238,10 +237,15 @@ module.exports = class HomeView extends BaseView
                 @frames.show()
 
                 @content.hide()
+
+                # Display global navigation
                 @backButton.show()
 
+                # Hide other applications
+                # and show current one
                 @$('#app-frames').find('iframe').hide()
-                frame.show()
+                @$("##{iframeID}").show()
+
                 @selectedApp = slug
                 app = @apps.get slug
                 name = app.get('displayName') or app.get('name') or ''

--- a/client/app/views/main.coffee
+++ b/client/app/views/main.coffee
@@ -293,17 +293,11 @@ module.exports = class HomeView extends BaseView
         iframeHTML = appIframeTemplate {id, source}
         iframe$    = $(iframeHTML).appendTo @frames
 
-        # Use Element added to the DOM
-        # not Element to add to the DOM
-        iframe$    = $("##{id}")
-
-        console.log source, iframeHTML
-
-        # # Listen to Iframe added to DOM
-        # iframe$.prop('contentWindow').onhashchange = ->
-        #     location = iframe$.prop('contentWindow').location
-        #     newhash  = location.hash.replace '#', ''
-        #     @onAppHashChanged slug, newhash
+        # Listen to Iframe added to DOM
+        $("##{id}").prop('contentWindow').onhashchange = ->
+            location = $("##{id}").prop('contentWindow').location
+            newhash  = location.hash.replace '#', ''
+            @onAppHashChanged slug, newhash
 
         @forceIframeRendering()
 
@@ -381,4 +375,4 @@ module.exports = class HomeView extends BaseView
     redirectIframe: (hash) ->
         iframeHash = @getIframeLocation hash
         unless (client.getSAMEORIGINError iframeHash)
-            @navigate iframeHash, false
+            window?.app?.routers?.main?.navigate iframeHash, false


### PR DESCRIPTION
See last comment of https://github.com/cozy/cozy-home/issues/519
 

- [x] Do not allow malicious `iframe.source` propagate into App such as: `http://www.toto.fr`,
- [x] Update `location.hash` when redirection to home.

Note: we can't avoid somebody to update iframe source from the DOM, but we can avoid to propagate it.
