### PR TITLE
[FIX] updateButton button issues

### DIFF
--- a/client/app/views/config_applications.coffee
+++ b/client/app/views/config_applications.coffee
@@ -128,15 +128,20 @@ module.exports = class ConfigApplicationsView extends BaseView
         setTimeout @fetch, 10000
 
 
-    # When update stack button is clicked, the update stack dialog is
-    # displayed.
-    onUpdateClicked: ->
-        @showUpdateStackDialog()
+    # When update stack button is clicked,
+    # the update stack dialog is displayed.
+    # Disabled button while updating
+    # not to launch several time the same request
+    onUpdateClicked: (event) ->
+        unless !!(isDisabled = @updateBtn.attr 'disable')
+            @updateBtn.attr 'disable', true
+            @showUpdateStackDialog()
 
 
     # Show the dialog to allow the user to update his stack.
     showUpdateStackDialog: ->
         @popover.hide() if @popover?
+
         @popover = new UpdateStackModal
             confirm: (application) =>
                 @runFullUpdate (err, permissionChanges) =>
@@ -144,9 +149,12 @@ module.exports = class ConfigApplicationsView extends BaseView
                         @popover.onError err, permissionChanges
                     else
                         @popover.onSuccess permissionChanges
+
             cancel: (application) =>
                 @popover.hide()
                 @popover.remove()
+                @updateBtn.removeAttr 'disable'
+
             end: (success) ->
                 location.reload() if success
 
@@ -182,4 +190,3 @@ module.exports = class ConfigApplicationsView extends BaseView
                 @rebootStackBtn.spin false
             else
                 location.reload()
-

--- a/client/app/views/update_stack_modal.coffee
+++ b/client/app/views/update_stack_modal.coffee
@@ -59,24 +59,26 @@ module.exports = class UpdateStackModal extends BaseView
     # Display success message on modal.
     # Add information about application that requires a dedicated update
     # because of permission changes.
-    onSuccess: (permissionChanges) ->
+    onSuccess: (changes) ->
         @$('.step2').hide()
         @$('.success').show()
-        @showPermissionsChanged permissionChanges
+        @showPermissionsChanged changes
         @$('#ok').show()
         @$('#confirmbtn').hide()
+
+        @endCallback changes
 
 
     # Inform the user that an error occured during the update.
     # Add information about application that requires a dedicated update
     # because of permission changes.
-    onError: (err, permissionChanges) ->
+    onError: (err, changes) ->
         @blocked = false
         @$('.step2').hide()
         @$('.error').show()
         @$('#ok').show()
         @$('#confirmbtn').hide()
-        @showPermissionsChanged permissionChanges
+        @showPermissionsChanged changes
 
         if err.data?.message? and typeof(err.data.message) is 'object'
             infos = err.data.message
@@ -97,10 +99,10 @@ module.exports = class UpdateStackModal extends BaseView
 
     # Show the list of application that requires a dedicated update because
     # of application changes.
-    showPermissionsChanged: (permissionChanges) ->
-        if permissionChanges? and Object.keys(permissionChanges).length > 0
+    showPermissionsChanged: (changes) ->
+        if changes? and Object.keys(changes).length > 0
             html = "<ul>"
-            for app of permissionChanges
+            for app of changes
                 html += """
                 <li class='app-changed'>#{app}</li>
                 """
@@ -133,4 +135,3 @@ module.exports = class UpdateStackModal extends BaseView
         @$('.step1').hide()
         @$('.step2').show()
         @$('#confirmbtn').spin true
-


### PR DESCRIPTION
 - [x] disable button while updating,
 - [x] button should be visible if update have failed.

For this 2nd point: there is a part server side and another on client; this PR fixes the last one.
We have to check why application are saved as updated when they are not.
