### PR TITLE
Update Modal is closed when changes are applied

### DIFF
--- a/client/app/views/config_applications.coffee
+++ b/client/app/views/config_applications.coffee
@@ -152,7 +152,7 @@ module.exports = class ConfigApplicationsView extends BaseView
 
     # Show the dialog to allow the user to update his stack.
     showUpdateStackDialog: ->
-        @popover.hide() if @popover?
+        @popover.remove() if @popover?
 
         @popover = new UpdateStackModal
             confirm: (model) =>
@@ -163,10 +163,8 @@ module.exports = class ConfigApplicationsView extends BaseView
                         @popover.onSuccess changes
 
             cancel: (model) =>
+                @popover.remove()
                 @render()
-
-            end: (success) =>
-                @render() if success
 
         $("#config-applications-view").append @popover.$el
         @popover.show()

--- a/client/app/views/update_stack_modal.coffee
+++ b/client/app/views/update_stack_modal.coffee
@@ -19,7 +19,6 @@ module.exports = class UpdateStackModal extends BaseView
         super
         @confirmCallback = options.confirm
         @cancelCallback = options.cancel
-        @endCallback = options.end
 
 
     afterRender: ->
@@ -56,17 +55,19 @@ module.exports = class UpdateStackModal extends BaseView
         $('#home-content').removeClass 'md-open'
 
 
+    displaySuccessChanges: (changes) ->
+        @$('.step2').hide()
+        @$('.success').show()
+        @$('#ok').show()
+        @$('#confirmbtn').hide()
+        @showPermissionsChanged changes
+
+
     # Display success message on modal.
     # Add information about application that requires a dedicated update
     # because of permission changes.
     onSuccess: (changes) ->
-        @$('.step2').hide()
-        @$('.success').show()
-        @showPermissionsChanged changes
-        @$('#ok').show()
-        @$('#confirmbtn').hide()
-
-        @endCallback changes
+        @displaySuccessChanges changes
 
 
     # Inform the user that an error occured during the update.
@@ -74,11 +75,8 @@ module.exports = class UpdateStackModal extends BaseView
     # because of permission changes.
     onError: (err, changes) ->
         @blocked = false
-        @$('.step2').hide()
-        @$('.error').show()
-        @$('#ok').show()
-        @$('#confirmbtn').hide()
-        @showPermissionsChanged changes
+
+        @displaySuccessChanges changes
 
         if err.data?.message? and typeof(err.data.message) is 'object'
             infos = err.data.message
@@ -93,8 +91,6 @@ module.exports = class UpdateStackModal extends BaseView
                 @body.append html
         else
             @$('.apps-error').hide()
-
-        @endCallback false
 
 
     # Show the list of application that requires a dedicated update because
@@ -115,7 +111,7 @@ module.exports = class UpdateStackModal extends BaseView
     # hidden and the ending callback is fired.
     onClose: =>
         @hide()
-        @endCallback true
+        @cancelCallback()
 
 
     # When the update is running, the modal cannot be closed. The user should


### PR DESCRIPTION
## behavior
### Expected behavior
UpdateApplicationModal should display a `ok` button when changes are applied.

### Buggy behavior
UpdateApplicationModal disappear when changes are applied.

## FIX
`endCallback` was closing modal after success; so 
 - I have replaced it by `cancelCallback`,
 - I removed `cancelCallback` from `onSuccessCallback`.