### PR TITLE
Bump cozy-clients version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "americano": "0.4.5",
     "async": "0.2.10",
     "cozy-clearance": "0.1.22",
-    "cozy-clients": "1.0.5",
+    "cozy-clients": "1.0.6",
     "cozy-notifications-helper": "1.1.0",
     "cozy-realtime-adapter": "1.0.2",
     "cozy-slug": "0.2.2",


### PR DESCRIPTION
This allows to use a non-standard cozy-controller port.

As discussed in https://github.com/cozy/cozy-monitor/pull/155#issuecomment-249879984.