### PR TITLE
Make gitlab provider the default

### DIFF
--- a/server/lib/git_providers.coffee
+++ b/server/lib/git_providers.coffee
@@ -12,6 +12,10 @@ class GitProvider
         @repoUrl = repoDescriptor.git
         @repoBranch = repoDescriptor.branch
 
+
+    getManifest: (callback) ->
+        throw new Error('getManifest must be defined.')
+
 # Github provider
 module.exports.GithubProvider = class GithubProvider extends GitProvider
 

--- a/server/lib/manifest.coffee
+++ b/server/lib/manifest.coffee
@@ -54,25 +54,21 @@ class exports.Manifest
 
         else if app.git?
 
-            providerName = app.git.match /(github\.com|gitlab\.cozycloud\.cc)/
+            providerName = app.git.match /(github\.com|gitlab\.cozycloud\.cc|framagit\.org)/
             if not providerName?
-                logger.error "Unknown provider '#{app.git}'"
-                callback "unknown provider"
+                logger.warn "Unknown provider '#{app.git}'"
 
+            # By default, the provider will be Gitlab
+            if providerName?[0] is "github.com"
+                Provider = require('./git_providers').GithubProvider
             else
-                providerName = providerName[0]
+                Provider = require('./git_providers').CozyGitlabProvider
 
-                if providerName is "gitlab.cozycloud.cc"
-                    Provider = require('./git_providers').CozyGitlabProvider
-
-                else
-                    Provider = require('./git_providers').GithubProvider
-
-                provider = new Provider app
-                provider.getManifest (err, data) =>
-                    @config = {}
-                    @config = data unless err?
-                    callback err, data
+            provider = new Provider app
+            provider.getManifest (err, data) =>
+                @config = {}
+                @config = data unless err?
+                callback err, data
 
         else
             @config = {}


### PR DESCRIPTION
Since many providers use gitlab, it's seems an easy win to make it the default provider for anything that is not Github.

It is required in order to make Kresus work (see https://github.com/cozy/cozy-home/issues/789) and also others (e.g. someone willing to try on a local Gitlab instance).