### PR TITLE
Handle locale for field label

### DIFF
--- a/src/components/AccountLoginForm.jsx
+++ b/src/components/AccountLoginForm.jsx
@@ -117,7 +117,7 @@ export class AccountLoginForm extends React.Component {
       submitEnabled
     const onEnterKey = canHandleEnterKey && onSubmit
 
-    const renderField = field => {
+    const renderField = konnectorSlug => field => {
       const { name, label, type, value, placeholder } = field
       if (!renderers[type]) {
         console.warn && console.warn('Unknown field type ' + type)
@@ -142,7 +142,9 @@ export class AccountLoginForm extends React.Component {
         invalid: !!error,
         onEnterKey,
         giveFocus,
-        label: t(`account.form.label.${label || name}`),
+        label: t(`${konnectorSlug}.fields.${field.name}.label`, {
+          _: t(`account.form.label.${label || name}`)
+        }),
         readonly: readonly,
         value: isUnloading ? '' : hydrate(value),
         placeholder: placeholder
@@ -167,7 +169,7 @@ export class AccountLoginForm extends React.Component {
         {!!editableFields &&
           !!editableFields.length && (
             <fieldset className={styles['account-form-fieldset']}>
-              {editableFields.map(renderField)}
+              {editableFields.map(renderField(connectorSlug))}
             </fieldset>
           )}
         {editing &&
@@ -187,7 +189,7 @@ export class AccountLoginForm extends React.Component {
           !!advancedFields &&
           !!advancedFields.length && (
             <fieldset className={styles['account-form-fieldset']}>
-              {advancedFields.map(renderField)}
+              {advancedFields.map(renderField(connectorSlug))}
             </fieldset>
           )}
 


### PR DESCRIPTION
This PR handle locale for field label in manifest. The manifest should look like this:

```json
{
  "fields": {
    "myfield": {
      "label": "great.locale"
    }
  },
  "locales": {
    "en": {
      "great": {
        "locale": "My pretty field"
      }
    }
  }
}
```

### FINAL UPDATE:

> **Reminder**
> This PR use the fact that all fetched konnectors have their manifest locales merged into the whole app locales, see https://github.com/cozy/cozy-home/blob/master/src/lib/middlewares/konnectorsI18n.js

So the locale of any field should be stored under the `locales.${LANG}.fields` attribute.

For example:
```json
"fields": {
    "mySpecialField": {
      "type": "email"
    },
},
"locales": {
  "fr": {
    "fields": {
        "mySpecialField": {
            "label": "Mon champ spécial"
       }
  }
}
```