### PR TITLE
Fix horizontal scroll for apps

### DIFF
--- a/src/components/Applications.jsx
+++ b/src/components/Applications.jsx
@@ -39,8 +39,8 @@ export const Applications = props => {
           return fetchStatus !== 'loaded' ? (
             <LoadingAppTiles num="3" />
           ) : (
-            <div className="app-list">
-              <div data-tutorial="home-apps">
+            <div className="app-list-wrapper">
+              <div className="app-list" data-tutorial="home-apps">
                 {data
                   .filter(app => !ignoredAppSlugs.includes(app.slug))
                   .map(app => <AppTile app={app} />)}

--- a/src/styles/lists.styl
+++ b/src/styles/lists.styl
@@ -41,12 +41,30 @@ h2
     &.col-picture-for-empty-list
         background-color white
 
+// Tutorial-fit constraint:
+// -------------------
+// When the tutorial is active, (i.e. the route is /intro), we want the
+// tutorial mask to fit perfectly with the number of apps. It leads to two
+// things:
+// * The element .app-list, having also [data-tutorial=home-apps],
+//   cannot be 100hw like it is the case in the horizontal-scroll() mixin.
+// * It still needs to be horizontally scrollable on mobile, so we wrap it
+//   in a .app-list-wrapper element, which keeps the right CSS properties
+//   to have an horizontal scroll.
+
+// Tutorial-fit constraint, keep the properties to scroll horizontally
+// on mobile.
+.app-list-wrapper
+    width 100vw
+    overflow-x auto
+
 .app-list
     horizontal-scroll()
 
     // Negative margin ensure correct alignment with 6 items
     margin 0 -.75rem
-    display flex
+    width auto // Tutorial-fit constraint, override horizontal-scroll()
+    display inline-flex // Tutorial-fit constraint, override horizontal-scroll()
     flex-direction row
     justify-content flex-start
     flex-wrap wrap


### PR DESCRIPTION
A intermediate div `[data-tutorial=home-apps]` has been added in the last stages of Cozy-Home integration.

The role of this div was to wrap only the App icons, making the tutorial fit perfectly the number of icons.

The side effect is that it broke the horizontal scroll on mobile.

This PR fix this horizontal scroll and keeps the tutorial required behaviour.