### PR TITLE
Prevent undefined locale 'format.date'

### DIFF
--- a/src/components/AccountLoginForm.jsx
+++ b/src/components/AccountLoginForm.jsx
@@ -13,6 +13,7 @@ import Field, {
 } from './Field'
 import ReactMarkdownWrapper from './ReactMarkdownWrapper'
 import { map, groupBy } from 'lodash'
+import collectConfig from 'config/collect'
 
 const probableLoginFieldNames = [
   'email',
@@ -23,7 +24,12 @@ const probableLoginFieldNames = [
 
 const renderers = {
   password: ({ t }) => <PasswordField noAutoFill />,
-  date: ({ t }) => <Field type="date" placeholder={t('format.date')} />,
+  date: ({ t }) => (
+    <Field
+      type="date"
+      placeholder={t('format.date', { _: collectConfig.defaultDateFormat })}
+    />
+  ),
   checkbox: () => <CheckboxField />,
   dropdown: () => <DropdownField />,
   text: () => <Field />,

--- a/src/config/collect.json
+++ b/src/config/collect.json
@@ -1,4 +1,5 @@
 {
+  "defaultDateFormat": "MM/DD/YYYY",
   "ignoreJobsAfterInSeconds": "7200",
   "defaultTriggerTimeInterval": [0, 5]
 }

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -4,7 +4,7 @@ import styles from '../styles/accountConnection'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
-
+import collectConfig from 'config/collect'
 import {
   deleteConnection,
   getConnectionError,
@@ -259,7 +259,11 @@ class AccountConnection extends Component {
       }`
     }
 
-    valuesToSubmit = sanitizeDates(valuesToSubmit, fields, t('format.date'))
+    valuesToSubmit = sanitizeDates(
+      valuesToSubmit,
+      fields,
+      t('format.date', { _: collectConfig.defaultDateFormat })
+    )
 
     // Update the path if the name path is the account name
     const folderId =

--- a/src/lib/statefulForm.jsx
+++ b/src/lib/statefulForm.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import collectConfig from 'config/collect'
 import moment from 'moment'
 
 // From https://stackoverflow.com/questions/10193294/how-can-i-tell-if-a-browser-supports-input-type-date
@@ -23,7 +24,7 @@ export default function statefulForm(mapPropsToFormConfig) {
           fields: this.configureFields(
             config,
             t('account.form.placeholder.accountName'),
-            t('format.date')
+            t('format.date', { _: collectConfig.defaultDateFormat })
           ),
           dirty: false,
           oauth: props.onOAuth,


### PR DESCRIPTION
### Patch 2.4.1		
In the case of a regression removing the locale `format.date`, this PR provides a default date format from config.