### PR TITLE
Retry account deletion on 409 error

### DIFF
--- a/src/ducks/accounts/index.js
+++ b/src/ducks/accounts/index.js
@@ -1,6 +1,5 @@
 import {
   createDocument,
-  deleteDocument,
   fetchCollection,
   fetchDocument
 } from 'redux-cozy-client'
@@ -16,8 +15,6 @@ export const createAccount = attributes =>
       updateCollections: [accountCollectionKey]
     }
   )
-
-export const deleteAccount = deleteDocument
 
 export const fetchAccounts = () =>
   fetchCollection(accountCollectionKey, DOCTYPE)

--- a/src/ducks/connections/index.js
+++ b/src/ducks/connections/index.js
@@ -337,6 +337,9 @@ export const deleteConnection = trigger => {
     const account = getTriggerAccount(getState(), trigger)
     return deleteAccount(account)
       .then(() => {
+        // Stack now deletes the trigger associated with an account, but keep
+        // this call to maintain local state and to ensure that the trigger
+        // is deleted.
         dispatch(deleteTrigger(trigger))
       })
       .then(() =>

--- a/src/ducks/connections/index.js
+++ b/src/ducks/connections/index.js
@@ -44,7 +44,19 @@ const isKonnectorJob = doc =>
   doc._type === JOBS_DOCTYPE && doc.worker === 'konnector'
 
 const deleteAccount = async account => {
-  await cozy.client.data.delete('io.cozy.accounts', account)
+  try {
+    await cozy.client.data.delete('io.cozy.accounts', account)
+  } catch (error) {
+    if (error.status === 409) {
+      const syncedAccount = await cozy.client.data.find(
+        'io.cozy.accounts',
+        account._id
+      )
+      await cozy.client.data.delete('io.cozy.accounts', syncedAccount)
+    } else {
+      throw error
+    }
+  }
 }
 
 // reducers


### PR DESCRIPTION
### patch 2.4.2
This PR:
* Improves error handling for account deletion, now every error is thrown
* Add a retry mechanism on 409 errors
* Add comment about trigger deletion performed by the stack