### PR TITLE
Get app slug from stack

### DIFF
--- a/src/targets/browser/index.ejs
+++ b/src/targets/browser/index.ejs
@@ -30,6 +30,7 @@
   data-cozy-app-editor="{{.AppEditor}}"
   data-cozy-app-name="{{.AppName}}"
   data-cozy-app-name-prefix="{{.AppNamePrefix}}"
+  data-cozy-app-slug="{{.AppSlug}}"
   data-cozy-tracking="{{.Tracking}}"
   data-cozy-icon-path="{{.IconPath}}"
 >

--- a/src/targets/intents/index.ejs
+++ b/src/targets/intents/index.ejs
@@ -28,5 +28,6 @@
   data-cozy-app-editor="{{.AppEditor}}"
   data-cozy-app-name="{{.AppName}}"
   data-cozy-app-name-prefix="{{.AppNamePrefix}}"
+  data-cozy-app-slug="{{.AppSlug}}"
   data-cozy-icon-path="{{.IconPath}}"
 >


### PR DESCRIPTION
Necessary to use the new cozy-bar navigation and the home app detection