### PR TITLE
Ignore empty password

### DIFF
--- a/src/components/AccountLoginForm.jsx
+++ b/src/components/AccountLoginForm.jsx
@@ -13,14 +13,8 @@ import Field, {
 } from './Field'
 import ReactMarkdownWrapper from './ReactMarkdownWrapper'
 import { map, groupBy } from 'lodash'
+import { probableLoginFieldNames } from '../lib/accounts'
 import collectConfig from 'config/collect'
-
-const probableLoginFieldNames = [
-  'email',
-  'identifier',
-  'login',
-  'new_identifier'
-]
 
 const renderers = {
   password: ({ t }) => <PasswordField noAutoFill />,

--- a/test/lib/__snapshots__/accounts.spec.js.snap
+++ b/test/lib/__snapshots__/accounts.spec.js.snap
@@ -1,0 +1,19 @@
+exports[`accounts library should handle account updating 1`] = `
+Object {
+  "auth": Object {
+    "folderPath": "/Administrative/Mock2",
+    "frequency": "week",
+    "login": "test@mock2.cc",
+    "password": "khf79dzeNEBDX",
+  },
+}
+`;
+
+exports[`accounts library should not update empty password 1`] = `
+Object {
+  "auth": Object {
+    "folderPath": "/Administrative/Mock2",
+    "frequency": "week",
+  },
+}
+`;

--- a/test/lib/accounts.spec.js
+++ b/test/lib/accounts.spec.js
@@ -73,9 +73,32 @@ describe('accounts library', () => {
         expect(cozyMock.data.updateAttributes.mock.calls[0][1]).toEqual(
           accountMock._id
         )
-        expect(cozyMock.data.updateAttributes.mock.calls[0][2]).toEqual({
-          auth: accountMock2.auth
-        })
+        expect(
+          cozyMock.data.updateAttributes.mock.calls[0][2]
+        ).toMatchSnapshot()
+      })
+  })
+
+  it('should not update empty password', () => {
+    const accountMockWithEmptyPassword = {
+      _id: '4d1039c9a419779f70d1dee5f200992a',
+      account_type: 'mock3',
+      auth: {
+        folderPath: '/Administrative/Mock2',
+        frequency: 'week',
+        login: 'test@mock2.cc',
+        password: ''
+      },
+      folderId: '4d1039c9a419779f70d1dee5f2009b8f',
+      name: ''
+    }
+
+    return accounts
+      .update(cozyMock, accountMock, accountMockWithEmptyPassword)
+      .then(account => {
+        expect(
+          cozyMock.data.updateAttributes.mock.calls[0][2]
+        ).toMatchSnapshot()
       })
   })
 


### PR DESCRIPTION
### Target: patch 2.4.4

When updating account name, an empty password was erasing authentication data and making the konnector connection fail.

This PR fix this issue.

I have not been able to understand from where and when this bug was coming.

It was apparently older than the recent changes.