### PR TITLE
Realtime for triggers

### DIFF
--- a/src/ducks/connections/index.js
+++ b/src/ducks/connections/index.js
@@ -6,7 +6,7 @@ import { buildKonnectorError, isKonnectorUserError } from '../../lib/konnectors'
 
 import { getTriggerLastJob } from '../jobs'
 
-import { deleteTrigger, launchTrigger } from '../triggers'
+import { launchTrigger } from '../triggers'
 import { getAccount } from '../accounts'
 
 // constant
@@ -336,12 +336,6 @@ export const deleteConnection = trigger => {
     })
     const account = getTriggerAccount(getState(), trigger)
     return deleteAccount(account)
-      .then(() => {
-        // Stack now deletes the trigger associated with an account, but keep
-        // this call to maintain local state and to ensure that the trigger
-        // is deleted.
-        dispatch(deleteTrigger(trigger))
-      })
       .then(() =>
         dispatch({
           type: CONNECTION_DELETED,

--- a/src/ducks/triggers/index.js
+++ b/src/ducks/triggers/index.js
@@ -33,11 +33,6 @@ export const createKonnectorTrigger = (
     }
   )
 
-export const deleteTrigger = trigger =>
-  fromCozyClient.deleteTrigger(trigger, {
-    updateCollections: [triggersCollectionKey]
-  })
-
 export const launchTrigger = trigger => fromCozyClient.launchTrigger(trigger)
 
 // Helpers

--- a/src/lib/triggers.js
+++ b/src/lib/triggers.js
@@ -1,0 +1,8 @@
+/* triggers lib ready to be added to cozy-client-js */
+import * as realtime from './realtime'
+
+const TRIGGERS_DOCTYPE = 'io.cozy.triggers'
+
+export function subscribeAll(cozy) {
+  return realtime.subscribeAll(cozy, TRIGGERS_DOCTYPE)
+}


### PR DESCRIPTION
### Target: patch 2.4.4
Also fix the remanent checkbox issue, after a 404 from the stack on trigger deletion, the redux store was not up to date and a checkmark was still visible on konnector tile.