### PR TITLE
Filter hidden apps

### DIFF
--- a/src/components/Applications.jsx
+++ b/src/components/Applications.jsx
@@ -45,7 +45,11 @@ export const Applications = props => {
           ) : (
             <div className="list app-list" data-tutorial="home-apps">
               {data
-                .filter(app => !ignoredAppSlugs.includes(app.slug))
+                .filter(
+                  app =>
+                    app.state !== 'hidden' &&
+                    !ignoredAppSlugs.includes(app.slug)
+                )
                 .map(app => <AppTile app={app} />)}
               {fillWithGhostItems(6)}
             </div>

--- a/src/components/Applications.jsx
+++ b/src/components/Applications.jsx
@@ -30,7 +30,7 @@ const LoadingAppTiles = ({ num }) => {
   )
 }
 
-export const Applications = props => {
+export const Applications = () => {
   const ignoredAppSlugs = ['home', 'onboarding', 'settings']
   return (
     <div className="app-list-wrapper">
@@ -50,7 +50,7 @@ export const Applications = props => {
                     app.state !== 'hidden' &&
                     !ignoredAppSlugs.includes(app.slug)
                 )
-                .map(app => <AppTile app={app} />)}
+                .map((app, index) => <AppTile key={index} app={app} />)}
               {fillWithGhostItems(6)}
             </div>
           )

--- a/src/lib/tutorial.js
+++ b/src/lib/tutorial.js
@@ -11,8 +11,6 @@ export function display(t) {
     '[data-tutorial=home-services]'
   )[0]
 
-  console.debug(appsPanel, servicesPanel)
-
   for (const element in [appsPanel, servicesPanel]) {
     if (!element) throw new Error('Missing tutorial element.')
   }


### PR DESCRIPTION
Hidden apps are applications configured in database to not be show,
for example in a demo context.

The best solution should be to add a `hidden` attribute directly
to the app, but it should imply to update informations returned
by the stack.

So for now I used the `state` attribute, already returned by the
stack, to bring the information.

The switch to hidden app is for now manual.