### PR TITLE
fix: Don't use color var in stylus func

### DIFF
--- a/src/styles/lists.styl
+++ b/src/styles/lists.styl
@@ -6,7 +6,7 @@ sundown = #ffb3b3
 .app-list-wrapper
     margin-top rem(32)
     border-radius rem(8)
-    background-color rgba(white, .85)
+    background-color rgba(255, 255, 255, .85)
     padding rem(16 24)
 
     @media (max-width: 60rem)


### PR DESCRIPTION
Some cleaning in preparation for a future [release of Cozy-UI](https://github.com/cozy/cozy-ui/pull/641) with color variables as CSS custom properties.