### PR TITLE
Update intent call to avoid configuration in store

### DIFF
--- a/src/containers/IntentService.jsx
+++ b/src/containers/IntentService.jsx
@@ -15,7 +15,7 @@ class IntentService extends Component {
       const installedKonnector = await service.compose(
         'INSTALL',
         'io.cozy.apps',
-        data
+        { data, configure: false }
       )
 
       // if installedKonnector is null, it means the installation have been


### PR DESCRIPTION
As the store now perform an intent composition to cozy-home to configure a installed konnector, we need to avoid a loop and tell the store to not compose.