### PR TITLE
Handling correctly konnector type from OAuth response

### DIFF
--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -20,6 +20,7 @@ import { translate } from 'cozy-ui/react/I18n'
 import KonnectorInstall from '../components/KonnectorInstall'
 import KonnectorEdit from '../components/KonnectorEdit'
 import { popupCenter, waitForClosedPopup } from '../lib/popup'
+import { getRandomKeyString } from '../lib/helpers'
 import statefulForm from '../lib/statefulForm'
 
 import moment from 'moment'
@@ -91,13 +92,18 @@ class AccountConnection extends Component {
     const cozyUrl = `${window.location.protocol}//${
       document.querySelector('[role=application]').dataset.cozyDomain
     }`
+
+    // We use localStorage to store the account related data
+    const OAuthState = { accountType }
+    const OAuthStateKey = getRandomKeyString()
+    localStorage.setItem(OAuthStateKey, JSON.stringify(OAuthState))
     const newTab = popupCenter(
-      `${cozyUrl}/accounts/${accountType}/start?scope=${scope}&state=xxx&nonce=${Date.now()}`,
+      `${cozyUrl}/accounts/${accountType}/start?scope=${scope}&state=${OAuthStateKey}&nonce=${Date.now()}`,
       `${accountType}_oauth`,
       800,
       800
     )
-    return waitForClosedPopup(newTab, `${accountType}_oauth`)
+    return waitForClosedPopup(newTab, accountType)
       .then(accountID => {
         return this.terminateOAuth(accountID, values)
       })

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -12,3 +12,14 @@ export const getAccountLogin = account => {
     return account.auth.login || account.auth.identifier || account.auth.email
   }
 }
+
+export const getRandomKeyString = () =>
+  Math.random()
+    .toString(36)
+    .substring(2, 15) +
+  Math.random()
+    .toString(36)
+    .substring(2, 15) +
+  Math.random()
+    .toString(36)
+    .substring(2, 15)

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -26,6 +26,7 @@ const handleOAuthResponse = () => {
   if (queryParams.get('account')) {
     const opener = window.opener
     const accountKey = queryParams.get('account')
+    const OAuthStateKey = queryParams.get('state')
     const targetOrigin =
       window.location.origin ||
       `${window.location.protocol}//${window.location.hostname}${
@@ -34,7 +35,7 @@ const handleOAuthResponse = () => {
     opener.postMessage(
       {
         key: accountKey,
-        origin: window.name
+        OAuthStateKey
       },
       targetOrigin
     )


### PR DESCRIPTION
Now we use the OAuth state parameter as a key and store the account type related to the key in the local storage.