### PR TITLE
Add triggerId as key for AppIcon ✨

### DIFF
--- a/src/ducks/connections/components/queue/__snapshots__/queue.spec.js.snap
+++ b/src/ducks/connections/components/queue/__snapshots__/queue.spec.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Queue component should render 1`] = `
+<div
+  className="queue"
+>
+  <h4
+    className="queue-header"
+    onDoubleClick={[Function]}
+  >
+    <div
+      className="queue-header-inner"
+    >
+      <span
+        className="coz-desktop"
+      >
+        Syncing accounts:
+      </span>
+      <span
+        className="coz-mobile"
+      >
+        1 of 2
+      </span>
+    </div>
+  </h4>
+  <progress
+    className="queue-progress"
+    max={2}
+    value={1}
+  />
+  <div
+    className="queue-content"
+  >
+    <div
+      className="queue-list"
+    >
+      <Item
+        konnector={
+          Object {
+            "slug": "testk",
+          }
+        }
+        label="Test"
+        status="done"
+        t={[Function]}
+      />
+      <Item
+        konnector={
+          Object {
+            "slug": "testk2",
+          }
+        }
+        label="Test 2"
+        status="ongoing"
+        t={[Function]}
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/ducks/connections/components/queue/queue.jsx
+++ b/src/ducks/connections/components/queue/queue.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { translate } from 'cozy-ui/react/I18n'
 
@@ -79,7 +80,7 @@ class Item extends Component {
   }
 }
 
-class Queue extends Component {
+export class Queue extends Component {
   state = {
     collapsed: false
   }
@@ -157,6 +158,11 @@ class Queue extends Component {
       </div>
     )
   }
+}
+
+Queue.contextTypes = {
+  domain: PropTypes.string,
+  secure: PropTypes.bool
 }
 
 export default translate()(Queue)

--- a/src/ducks/connections/components/queue/queue.jsx
+++ b/src/ducks/connections/components/queue/queue.jsx
@@ -46,7 +46,7 @@ class ProgressBar extends Component {
 
 class Item extends Component {
   render() {
-    const { konnector, label, status, t, triggerId } = this.props
+    const { konnector, label, status, t } = this.props
     const { domain, secure } = this.context
     const isOngoing = status === 'ongoing'
     return (
@@ -143,9 +143,9 @@ class Queue extends Component {
         />
         <div className={styles['queue-content']}>
           <div className={styles['queue-list']}>
-            {queue.map((item, index) => (
+            {queue.map(item => (
               <Item
-                key={index}
+                key={item.triggerId}
                 konnector={item.konnector}
                 label={item.label}
                 status={item.status}

--- a/src/ducks/connections/components/queue/queue.spec.js
+++ b/src/ducks/connections/components/queue/queue.spec.js
@@ -1,0 +1,37 @@
+'use strict'
+
+/* eslint-env jest */
+
+import React from 'react'
+import { configure, shallow } from 'enzyme'
+import { tMock } from '../../../../../test/jestLib/I18n'
+
+import { Queue } from './queue'
+
+import Adapter from 'enzyme-adapter-react-15'
+
+configure({ adapter: new Adapter() })
+
+describe('Queue component', () => {
+  const queue = [
+    {
+      konnector: { slug: 'testk' },
+      label: 'Test',
+      status: 'done',
+      triggerId: '0412d5795e464ead99f5cea2611bbf21'
+    },
+    {
+      konnector: { slug: 'testk2' },
+      label: 'Test 2',
+      status: 'ongoing',
+      triggerId: 'f042dd05b97842c3acfed33253009659'
+    }
+  ]
+
+  it('should render', () => {
+    const component = shallow(
+      <Queue queue={queue} visible={false} t={tMock} />
+    ).getElement()
+    expect(component).toMatchSnapshot()
+  })
+})

--- a/src/ducks/connections/index.js
+++ b/src/ducks/connections/index.js
@@ -451,7 +451,12 @@ export const getQueue = (state, konnectors) =>
               if (triggers[triggerId].isEnqueued) {
                 const label = konnector.name
                 const status = getTriggerQueueStatus(triggers[triggerId])
-                return queuedTriggers.concat({ konnector, label, status })
+                return queuedTriggers.concat({
+                  konnector,
+                  label,
+                  status,
+                  triggerId
+                })
               }
 
               return queuedTriggers


### PR DESCRIPTION
Use trigger Id as key to force rerendering of AppIcon,
to avoid the behaviour seen in the following screen capture:

![capture_du_2018-11-30_12-10-45](https://user-images.githubusercontent.com/776764/49453583-bae4e500-f7e3-11e8-9d2f-f8a23c3d350a.png)