### PR TITLE
Handling folders from manifest

### DIFF
--- a/src/components/services/CreateAccountService.jsx
+++ b/src/components/services/CreateAccountService.jsx
@@ -16,6 +16,8 @@ import {
   getTriggerByKonnectorAndAccount
 } from '../../reducers'
 
+import { getCompleteFolderPath } from 'lib/helpers'
+
 class CreateAccountService extends React.Component {
   constructor(props, context) {
     super(props, context)
@@ -31,6 +33,15 @@ class CreateAccountService extends React.Component {
       values.folderPath = t('account.config.default_folder', {
         name: konnector.name
       })
+    } else if (Array.isArray(konnector.folders) && konnector.folders.length) {
+      const folder = konnector.folders[0] // we only handle the first one for now
+      if (folder.defaultDir) {
+        values.folderPath = getCompleteFolderPath(
+          folder.defaultDir,
+          konnector.name,
+          t
+        )
+      }
     }
 
     this.setState({ values: values })

--- a/src/containers/ConnectionManagement.jsx
+++ b/src/containers/ConnectionManagement.jsx
@@ -28,12 +28,14 @@ import KonnectorHeaderIcon from '../components/KonnectorHeaderIcon'
 import Notifier from '../components/Notifier'
 
 import backIcon from '../assets/sprites/icon-arrow-left.svg'
+import { getCompleteFolderPath } from 'lib/helpers'
 
 class ConnectionManagement extends Component {
   constructor(props, context) {
     super(props, context)
     this.store = this.context.store
     const { existingAccount, createdAccount, konnector } = props
+    const { t } = this.context
 
     const account = existingAccount || createdAccount
 
@@ -54,9 +56,23 @@ class ConnectionManagement extends Component {
         konnector.fields.advancedFields.folderPath) ||
       (!account && konnector && konnector.fields && konnector.folderPath)
     ) {
-      values.folderPath = this.context.t('account.config.default_folder', {
+      values.folderPath = t('account.config.default_folder', {
         name: konnector.name
       })
+    } else if (
+      !account &&
+      konnector &&
+      Array.isArray(konnector.folders) &&
+      konnector.folders.length
+    ) {
+      const folder = konnector.folders[0] // we only handle the first one for now
+      if (folder.defaultDir) {
+        values.folderPath = getCompleteFolderPath(
+          folder.defaultDir,
+          konnector.name,
+          t
+        )
+      }
     }
 
     this.state = {

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -23,3 +23,15 @@ export const getRandomKeyString = () =>
   Math.random()
     .toString(36)
     .substring(2, 15)
+
+export const getCompleteFolderPath = (defaultDir, konnectorName, t) => {
+  let folderPath = `/${defaultDir}/$konnector`
+  return folderPath
+    .replace(/\/\//g, '/')
+    .replace(/\$konnector/gi, konnectorName)
+    .replace(
+      /\$administrative/gi,
+      t('account.folder.placeholder.administrative')
+    )
+    .replace(/\$photos/gi, t('account.folder.placeholder.photos'))
+}

--- a/src/lib/statefulForm.jsx
+++ b/src/lib/statefulForm.jsx
@@ -115,6 +115,7 @@ export default function statefulForm(mapPropsToFormConfig) {
       configureFields(config = {}, defaultAccountNamePlaceholder, dateFormat) {
         // it will at least have an accountName field
         const configFields = (config.konnector && config.konnector.fields) || {}
+        const configFolders = config.konnector && config.konnector.folders
 
         // account name field added by the application
         const accountNamePlaceholder =
@@ -140,6 +141,16 @@ export default function statefulForm(mapPropsToFormConfig) {
             )
           }
           delete fieldsFromConfig.advancedFields
+        }
+
+        // FIXME Does not handle folders as form field at all
+        if (Array.isArray(configFolders) && configFolders.length) {
+          const folder = configFolders[0] // we only handle the first one for now
+          if (folder.defaultDir) {
+            fieldsFromConfig.folderPath = {
+              advanded: true
+            }
+          }
         }
 
         let fields = {}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -101,7 +101,11 @@
       "warning": "You're changing your folder path",
       "oldFiles": "All your olds bills will be moved in your new path.",
       "newFiles": "Your news bills will be downloaded in your new path.",
-      "newPath": "Everything went well, the new path for your %{name} account is:"
+      "newPath": "Everything went well, the new path for your %{name} account is:",
+      "placeholder": {
+        "administrative": "Administrative",
+        "photos": "Photos"
+      }
     },
     "success": {
       "title": {


### PR DESCRIPTION
Get `defaultDir` from the konnector manifest to replace the old way to add define a folder need.