### PR TITLE
Aggregator account

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/cozy/cozy-home#readme",
   "dependencies": {
-    "cozy-client": "5.0.2",
+    "cozy-client": "5.2.0",
     "cozy-doctypes": "^1.18.0",
     "cozy-scripts": "1.3.0",
     "date-fns": "1.29.0",

--- a/src/connections/accounts.js
+++ b/src/connections/accounts.js
@@ -1,0 +1,87 @@
+const ACCOUNTS_DOCTYPE = 'io.cozy.accounts'
+const PERMISSIONS_DOCTYPE = 'io.cozy.permissions'
+
+export const accountsMutations = client => {
+  const createAccount = async attributes => {
+    const { data } = await client.create(ACCOUNTS_DOCTYPE, attributes)
+    return data
+  }
+
+  const findParentAccount = async id => {
+    const { data } = await client.query(
+      client.find(ACCOUNTS_DOCTYPE).where({ _id: id })
+    )
+    return data[0]
+  }
+
+  const createParentAccount = id => {
+    return createAccount({
+      _id: id
+    })
+  }
+
+  const createChildAccount = async (konnector, attributes) => {
+    const { aggregator } = konnector
+
+    if (!aggregator || !aggregator.accountId)
+      throw new Error('Konnector does not provide aggregator account id')
+
+    const parentAccountId = aggregator.accountId
+
+    let parentAccount
+    try {
+      parentAccount = await findParentAccount(parentAccountId)
+    } catch (error) {
+      throw new Error(
+        `An error occurred when finding parent account ${parentAccountId} (${
+          error.message
+        })`
+      )
+    }
+
+    if (!parentAccount) {
+      try {
+        parentAccount = await createParentAccount(parentAccountId)
+      } catch (error) {
+        throw new Error(
+          `Cannot create parent account ${parentAccountId} (${error.message})`
+        )
+      }
+    }
+
+    try {
+      await client.collection(PERMISSIONS_DOCTYPE).add(konnector, {
+        aggregatorAccount: {
+          type: ACCOUNTS_DOCTYPE,
+          verbs: ['GET', 'PUT'],
+          values: [`${ACCOUNTS_DOCTYPE}.${parentAccountId}`]
+        }
+      })
+    } catch (error) {
+      throw new Error(
+        `Cannot set permission for account ${parentAccountId} (${
+          error.message
+        })`
+      )
+    }
+
+    return await createAccount({
+      ...attributes,
+      relationships: {
+        parent: {
+          data: {
+            _id: parentAccountId,
+            _type: ACCOUNTS_DOCTYPE
+          }
+        }
+      }
+    })
+  }
+
+  return {
+    createAccount,
+    createChildAccount
+  }
+}
+
+export default accountsMutations

--- a/src/connections/accounts.spec.js
+++ b/src/connections/accounts.spec.js
@@ -1,0 +1,302 @@
+/* eslint-env jest */
+
+import client from 'cozy-client'
+
+jest.mock('cozy-client', () => ({
+  collection: jest.fn().mockReturnValue({
+    add: jest.fn()
+  }),
+  create: jest.fn(),
+  find: jest.fn().mockReturnValue({
+    where: jest.fn()
+  }),
+  get: jest.fn(),
+  query: jest.fn()
+}))
+
+const fixtures = {
+  accountPermissions: {
+    source_id: `io.cozy.konnectors/kaggregated`,
+    permissions: {
+      aggregatorAccount: {
+        type: 'io.cozy.accounts',
+        verbs: ['GET', 'PUT'],
+        values: ['io.cozy.accounts.kaggregated-aggregator']
+      }
+    }
+  },
+  konnectorWithAggregator: {
+    slug: 'kaggregated',
+    aggregator: {
+      accountId: 'kaggregated-aggregator'
+    }
+  },
+  simpleAccount: {
+    account_type: 'test',
+    auth: {
+      login: 'login',
+      password: 'pass'
+    }
+  },
+  parentAccount: {
+    _id: 'kaggregated-aggregator'
+  }
+}
+
+import { accountsMutations } from './accounts'
+const { createAccount, createChildAccount } = accountsMutations(client)
+
+describe('Account mutations', () => {
+  beforeEach(() => {
+    client.create.mockReset()
+    client.create.mockResolvedValue({ data: fixtures.simpleAccount })
+  })
+
+  describe('createAccount', () => {
+    it('calls Cozy Client and return account', async () => {
+      const account = await createAccount(fixtures.simpleAccount)
+
+      expect(client.create).toHaveBeenCalledWith(
+        'io.cozy.accounts',
+        fixtures.simpleAccount
+      )
+      expect(account).toEqual(fixtures.simpleAccount)
+    })
+  })
+
+  describe('createChildAccount', () => {
+    const simpleAccountFixtureWithMasterRelation = {
+      ...fixtures.simpleAccount,
+      relationships: {
+        parent: {
+          data: {
+            _id: 'kaggregated-aggregator',
+            _type: 'io.cozy.accounts'
+          }
+        }
+      }
+    }
+
+    beforeEach(() => {
+      client.query.mockReset()
+    })
+
+    it('throws an error when konnector have no aggregator attribute', async () => {
+      const konnector = {}
+      expect(
+        createChildAccount(konnector, fixtures.simpleAccount)
+      ).rejects.toEqual(
+        new Error('Konnector does not provide aggregator account id')
+      )
+    })
+
+    it('throws an error when konnector have no aggregator.accountId attribute', async () => {
+      const konnector = { aggregator: {} }
+      expect(
+        createChildAccount(konnector, fixtures.simpleAccount)
+      ).rejects.toEqual(
+        new Error('Konnector does not provide aggregator account id')
+      )
+    })
+
+    describe('if parent account does not exists', () => {
+      beforeEach(() => {
+        client.query.mockReset()
+        client.query = jest.fn().mockResolvedValue({ data: [] })
+        client.create.mockResolvedValue({
+          data: simpleAccountFixtureWithMasterRelation
+        })
+        client.create.mockResolvedValueOnce({ data: fixtures.parentAccount })
+      })
+
+      it('creates parent account', async () => {
+        await createChildAccount(
+          fixtures.konnectorWithAggregator,
+          fixtures.simpleAccount
+        )
+
+        expect(client.create).toHaveBeenCalledWith('io.cozy.accounts', {
+          _id: fixtures.konnectorWithAggregator.aggregator.accountId
+        })
+      })
+
+      it('adds permissions to parent account', async () => {
+        await createChildAccount(
+          fixtures.konnectorWithAggregator,
+          fixtures.simpleAccount
+        )
+
+        expect(client.collection().add).toHaveBeenCalledWith(
+          fixtures.konnectorWithAggregator,
+          fixtures.accountPermissions.permissions
+        )
+      })
+
+      it('creates child account', async () => {
+        await createChildAccount(
+          fixtures.konnectorWithAggregator,
+          fixtures.simpleAccount
+        )
+
+        expect(client.create).toHaveBeenCalledWith(
+          'io.cozy.accounts',
+          simpleAccountFixtureWithMasterRelation
+        )
+      })
+
+      it('throws error if find fails', async () => {
+        client.query.mockReset()
+        client.query.mockRejectedValue(new Error('Mocked error'))
+
+        await expect(
+          createChildAccount(
+            fixtures.konnectorWithAggregator,
+            fixtures.simpleAccount
+          )
+        ).rejects.toEqual(
+          new Error(
+            'An error occurred when finding parent account kaggregated-aggregator (Mocked error)'
+          )
+        )
+      })
+
+      it('throws error if permission add fails', async () => {
+        client
+          .collection()
+          .add.mockRejectedValueOnce(new Error('Mocked add Error'))
+        await expect(
+          createChildAccount(
+            fixtures.konnectorWithAggregator,
+            fixtures.simpleAccount
+          )
+        ).rejects.toEqual(
+          new Error(
+            'Cannot set permission for account kaggregated-aggregator (Mocked add Error)'
+          )
+        )
+      })
+
+      it('returns child account', async () => {
+        const account = await createChildAccount(
+          fixtures.konnectorWithAggregator,
+          fixtures.simpleAccount
+        )
+
+        expect(account).toEqual(simpleAccountFixtureWithMasterRelation)
+      })
+
+      it('throws error if parent account creation fails', async () => {
+        client.create.mockReset()
+        client.create.mockRejectedValue(new Error('Mocked error'))
+
+        await expect(
+          createChildAccount(
+            fixtures.konnectorWithAggregator,
+            fixtures.simpleAccount
+          )
+        ).rejects.toEqual(
+          new Error(
+            'Cannot create parent account kaggregated-aggregator (Mocked error)'
+          )
+        )
+      })
+
+      it('throws error if child account creation fails', async () => {
+        client.create.mockReset()
+        client.create.mockResolvedValueOnce({ data: fixtures.parentAccount })
+        client.create.mockRejectedValue(new Error('Mocked error'))
+
+        await expect(
+          createChildAccount(
+            fixtures.konnectorWithAggregator,
+            fixtures.simpleAccount
+          )
+        ).rejects.toEqual(new Error('Mocked error'))
+      })
+    })
+
+    describe('if parent account exists', () => {
+      beforeEach(() => {
+        client.query.mockReset()
+        client.query = jest
+          .fn()
+          .mockResolvedValue({ data: [fixtures.parentAccount] })
+        client.create.mockResolvedValue({
+          data: simpleAccountFixtureWithMasterRelation
+        })
+      })
+
+      it('does not create parent account', async () => {
+        await createChildAccount(
+          fixtures.konnectorWithAggregator,
+          fixtures.simpleAccount
+        )
+
+        expect(client.create).not.toHaveBeenCalledWith('io.cozy.accounts', {
+          _id: fixtures.konnectorWithAggregator.aggregator.accountId
+        })
+      })
+
+      it('adds permissions to parent account', async () => {
+        await createChildAccount(
+          fixtures.konnectorWithAggregator,
+          fixtures.simpleAccount
+        )
+
+        expect(client.collection().add).toHaveBeenCalledWith(
+          fixtures.konnectorWithAggregator,
+          fixtures.accountPermissions.permissions
+        )
+      })
+
+      it('creates child account', async () => {
+        await createChildAccount(
+          fixtures.konnectorWithAggregator,
+          fixtures.simpleAccount
+        )
+
+        expect(client.create).toHaveBeenCalledWith(
+          'io.cozy.accounts',
+          simpleAccountFixtureWithMasterRelation
+        )
+      })
+
+      it('returns child account', async () => {
+        const account = await createChildAccount(
+          fixtures.konnectorWithAggregator,
+          fixtures.simpleAccount
+        )
+
+        expect(account).toEqual(simpleAccountFixtureWithMasterRelation)
+      })
+
+      it('throws error if find fails', async () => {
+        client.query.mockReset()
+        client.query.mockRejectedValue(new Error('Mocked error'))
+
+        await expect(
+          createChildAccount(
+            fixtures.konnectorWithAggregator,
+            fixtures.simpleAccount
+          )
+        ).rejects.toEqual(
+          new Error(
+            'An error occurred when finding parent account kaggregated-aggregator (Mocked error)'
+          )
+        )
+      })
+
+      it('throws error if child account creation fails', async () => {
+        client.create.mockReset()
+        client.create.mockRejectedValueOnce(new Error('Mocked error'))
+
+        await expect(
+          createChildAccount(
+            fixtures.konnectorWithAggregator,
+            fixtures.simpleAccount
+          )
+        ).rejects.toEqual(new Error('Mocked error'))
+      })
+    })
+  })
+})

--- a/src/lib/accounts.js
+++ b/src/lib/accounts.js
@@ -1,4 +1,6 @@
 /* accounts lib ready to be added to cozy-client-js */
+import * as realtime from './realtime'
+
 export const ACCOUNTS_DOCTYPE = 'io.cozy.accounts'
 
 export const ACCOUNT_ERRORS = {
@@ -44,4 +46,8 @@ export function update(cozy, account, newAccount) {
 
 export function _delete(cozy, account) {
   return cozy.data.delete(ACCOUNTS_DOCTYPE, account)
+}
+
+export function subscribeAll(cozy) {
+  return realtime.subscribeAll(cozy, ACCOUNTS_DOCTYPE)
 }

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -20,6 +20,8 @@ import 'styles/index.styl'
 const lang = document.documentElement.getAttribute('lang') || 'en'
 const context = window.context || 'cozy'
 
+const ACCOUNTS_DOCTYPE = 'io.cozy.accounts'
+
 const handleOAuthResponse = () => {
   /* global URLSearchParams */
   const queryParams = new URLSearchParams(window.location.search)
@@ -58,7 +60,21 @@ document.addEventListener('DOMContentLoaded', () => {
   const cozyClient = new MostRecentCozyClient({
     uri: `//${data.cozyDomain}`,
     schema: {
-      app: Application.schema
+      app: Application.schema,
+      accounts: {
+        doctype: ACCOUNTS_DOCTYPE,
+        attributes: {},
+        relationships: {
+          master: {
+            type: 'has-one',
+            doctype: ACCOUNTS_DOCTYPE
+          }
+        }
+      },
+      permissions: {
+        doctype: 'io.cozy.permissions',
+        attributes: {}
+      }
     },
     token: data.cozyToken
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -752,10 +752,17 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
-"@babel/runtime@7.1.2", "@babel/runtime@^7.1.2":
+"@babel/runtime@7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.2.tgz#81c89935f4647706fc54541145e6b4ecfef4b8e3"
   integrity sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
+"@babel/runtime@^7.1.2":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
+  integrity sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==
   dependencies:
     regenerator-runtime "^0.12.0"
 
@@ -2725,7 +2732,7 @@ core-js@2.6.0:
 
 core-js@^1.0.0:
   version "1.2.7"
-  resolved "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
 core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.3:
@@ -8920,7 +8927,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@*, prop-types@15.6.2, prop-types@^15.6.0, prop-types@^15.6.2:
+prop-types@*, prop-types@15.6.2, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
@@ -8928,7 +8935,7 @@ prop-types@*, prop-types@15.6.2, prop-types@^15.6.0, prop-types@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.5.1, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.1:
+prop-types@^15.5.1, prop-types@^15.5.10, prop-types@^15.5.8:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   integrity sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==
@@ -9193,9 +9200,9 @@ react-input-autosize@^2.2.1:
     prop-types "^15.5.8"
 
 react-is@^16.3.2, react-is@^16.6.0:
-  version "16.6.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.0.tgz#456645144581a6e99f6816ae2bd24ee94bdd0c01"
-  integrity sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g==
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
+  integrity sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==
 
 react-is@^16.6.1:
   version "16.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2814,13 +2814,13 @@ cozy-client-js@0.13.0:
     pouchdb-adapter-cordova-sqlite "https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
     pouchdb-find "6.4.3"
 
-cozy-client@5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-5.0.2.tgz#5033fe2cd2ae0c749bdf9b3917ac8b489cdfd76c"
-  integrity sha512-WglKk1EasAjgRBVcVU6J7364iB015ArjbHF4p96aA+ZWbIwWBp91qkdqYDd1an6yUe32kn4jdYpG2q1UyXI6VQ==
+cozy-client@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-5.2.0.tgz#c56a5ba7e09d170cf34264a629fba2a7aee90cc7"
+  integrity sha512-CKLTBEItEVe3iVJBFVdGM7DXK9ZgeDsx+UDIFQrxLENMligZ4xoJWCF3u8/8C3hhXPGQ9zAIqCc6kOBvP9S7fQ==
   dependencies:
     cozy-device-helper "1.4.14"
-    cozy-stack-client "^5.0.2"
+    cozy-stack-client "^5.2.0"
     lodash "4.17.11"
     prop-types "15.6.2"
     react "16.4.2"
@@ -2916,10 +2916,10 @@ cozy-scripts@1.3.0:
     webpack-dev-server "3.1.10"
     webpack-merge "4.1.4"
 
-cozy-stack-client@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-5.0.2.tgz#3b8d6f1a726c0bd2ea92536545933ddc247ef903"
-  integrity sha512-ugEZbVeD0Rrn1Yd3k1dQHawP+rO2y1i5DZZuBJ1Fj3Qeh5gKX8qjzRtqk71/dsHZ2ImqcRTI3lS5azFSaA/L+A==
+cozy-stack-client@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-5.2.0.tgz#dd576b3dba802b4f4709d6ecde14294224f68b28"
+  integrity sha512-DXsgtkLedXarYOF4lLbiXRtnfg3hoAohESLGMsuMTvqj/9rrsCHCouLvHx8hFQwnjXrsagOLRMD1evoibKLkTA==
   dependencies:
     mime-types "2.1.20"
 


### PR DESCRIPTION
This PR handles konnector declaring `agregator` field in their manifest.

An aggregator is a main service used by several konnectors (for example:
Budget Insight for Banking konnectors).

When an account is created, we check if the konnector declares an aggregator.
If so, we create a _master account_, which will be later filled by the konnector.

Then we relate every account of the given konnector to this master account.

This PR use CozyClient but still mix some old logic from redux-cozy-client
to keep the existant behaviour working. It also adds realtime for accounts
to keep the whole state synchronized.