### PR TITLE
feat: Check fr locales ✨

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "src/index.jsx",
   "scripts": {
     "tx": "tx pull --all || true",
+    "posttx": "./scripts/check-locales.sh",
     "lint": "yarn lint:js && yarn lint:styles",
     "lint:js": "cozy-scripts lint '{src,test}/**/*.{js,jsx}'",
     "lint:styles": "stylint src/styles --config ./.stylintrc",

--- a/scripts/check-locales.sh
+++ b/scripts/check-locales.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+cmp <(jq 'path(..)|[.[]|tostring]|join(".")' src/locales/en.json) <(jq 'path(..)|[[.[]| select(length > 0)]  |tostring]|join(".")' src/locales/fr.json)


### PR DESCRIPTION
Compares en.json and fr.json keys

The command `yarn posttx` compares keys in `en.json` et `fr.json` and fails if keys are missing in `fr.json`.

It prevent to deploy an app version with en locales not pushed on Transifex.