### PR TITLE
Prioritise update for tile if in maintenance

### DIFF
--- a/src/components/KonnectorTile.jsx
+++ b/src/components/KonnectorTile.jsx
@@ -35,6 +35,7 @@ const getErrorClass = ({
   if (hide) return ''
 
   if (inMaintenance) {
+    if (hasUpdate) return 'konnector-error--with-badge'
     return 'konnector-error--minor-breaking'
   }
 

--- a/test/components/KonnectorTile.spec.jsx
+++ b/test/components/KonnectorTile.spec.jsx
@@ -1,0 +1,27 @@
+'use strict'
+
+/* eslint-env jest */
+
+import React from 'react'
+import { configure, shallow } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-15'
+
+import KonnectorTile from '../../src/components/KonnectorTile'
+
+configure({ adapter: new Adapter() })
+
+describe('KonnectorTile component', () => {
+  it('should render updated mark if it is updated, even if it is in maintenance', () => {
+    const mockProps = {
+      konnector: { available_version: true },
+      inMaintenance: true
+    }
+    const component = shallow(<KonnectorTile {...mockProps} />).getElement()
+    expect(component).toMatchSnapshot()
+  })
+  it('should render maintenance if it is in maintenance without update', () => {
+    const mockProps = { inMaintenance: true }
+    const component = shallow(<KonnectorTile {...mockProps} />).getElement()
+    expect(component).toMatchSnapshot()
+  })
+})

--- a/test/components/__snapshots__/KonnectorTile.spec.jsx.snap
+++ b/test/components/__snapshots__/KonnectorTile.spec.jsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KonnectorTile component should render maintenance if it is in maintenance without update 1`] = `
+<Connect(withRouter(KonnectorTile))
+  inMaintenance={true}
+/>
+`;
+
+exports[`KonnectorTile component should render updated mark if it is updated, even if it is in maintenance 1`] = `
+<Connect(withRouter(KonnectorTile))
+  inMaintenance={true}
+  konnector={
+    Object {
+      "available_version": true,
+    }
+  }
+/>
+`;


### PR DESCRIPTION
Before, if an application was in maintenance and has an update available:
<img width="94" alt="screenshot 2019-01-24 at 12 27 36" src="https://user-images.githubusercontent.com/10224453/51675250-70a60600-1fd3-11e9-932c-021cb8a49c2c.png">

Now
<img width="115" alt="screenshot 2019-01-24 at 12 27 49" src="https://user-images.githubusercontent.com/10224453/51675256-77347d80-1fd3-11e9-86e7-d59b06059b12.png">
