### PR TITLE
fix: use time_interval in connector manifest

### DIFF
--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -172,7 +172,7 @@ export default class CollectStore {
                 // then use it if it needs.
                 startDate: new Date(),
                 ...randomDayTime(
-                  konnector.timeInterval ||
+                  konnector.time_interval ||
                     this.options.defaultTriggerTimeInterval
                 )
               }


### PR DESCRIPTION
According to documentation : /docs/konnector-manifest.md@c09f79a#L102

And no connector uses timeInterval anymore (neither orange or linxo)