### PR TITLE
Better Account Form width

### DIFF
--- a/src/styles/accountConnection.styl
+++ b/src/styles/accountConnection.styl
@@ -19,6 +19,7 @@
         display flex
         flex-direction column
         justify-content center
+        width 100%
 
     @media (max-width: rem(400))
         h4


### PR DESCRIPTION
With cozy-harvest-lib, the form was not wide enough on interapp.

Before

![capture d ecran 2019-02-07 a 12 53 09](https://user-images.githubusercontent.com/776764/52410514-d8327a00-2ad8-11e9-85c9-3488cc36bfc9.png)

After

![capture d ecran 2019-02-07 a 13 02 26](https://user-images.githubusercontent.com/776764/52410524-dec0f180-2ad8-11e9-83db-6ebf07db2ee3.png)
