### PR TITLE
fix: Empty service list wording

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -396,7 +396,7 @@
     "noAccount": "No account",
     "add": "Add a service",
     "update": "Update available",
-    "no-connectors-connected": "You have not yet connected connectors",
+    "no-connectors-connected": "You have no account connected yet",
     "get-info": "Get automatically all your informations in your Cozy",
     "connect-account": "Connect my accounts",
     "logo": {


### PR DESCRIPTION
Better use the *accounts* word in title, less confusing than *connectors*.
Also better matches the french locale.

#### Checklist

Before merging this PR, the following things must have been done:

- [x] Faithful integration of the mockups at all screen sizes (message should be almost the same length)
- [ ] Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari)
- [x] Localized in english and french (french locale was already good)
- [ ] All changes have test coverage (not relevant)
- [ ] Updated README, if necessary (not necessary)
