### PR TITLE
chore: Remove the onboarding from the hidden apps

### DIFF
--- a/src/components/Applications.jsx
+++ b/src/components/Applications.jsx
@@ -31,7 +31,7 @@ const LoadingAppTiles = ({ num }) => {
 }
 
 export const Applications = () => {
-  const ignoredAppSlugs = ['home', 'onboarding', 'settings']
+  const ignoredAppSlugs = ['home', 'settings']
   return (
     <div className="app-list-wrapper">
       <Query


### PR DESCRIPTION
The onboarding app was deprecated, and the step of choosing a password was integrated in the stack. The onboarding app is no longer installed (and have been removed from existing instances), so we can stop filtering it in home.