### PR TITLE
feat: Remove unsupported locales from the bundled JS

### DIFF
--- a/config/webpack.config.cozy-home.js
+++ b/config/webpack.config.cozy-home.js
@@ -1,9 +1,13 @@
 'use strict'
 
 const path = require('path')
-const { DefinePlugin } = require('webpack')
+const { DefinePlugin, ContextReplacementPlugin } = require('webpack')
 
 const SRC_DIR = path.resolve(__dirname, '../src')
+
+// See https://github.com/date-fns/date-fns/blob/master/docs/webpack.md
+const supportedLocales = ['en', 'fr', 'es']
+const regexpLocales = new RegExp(`/(${supportedLocales.join('|')})`)
 
 module.exports = {
   resolve: {
@@ -17,6 +21,9 @@ module.exports = {
       __PIWIK_SITEID__: 8,
       __PIWIK_DIMENSION_ID_APP__: 1,
       __PIWIK_TRACKER_URL__: JSON.stringify('https://piwik.cozycloud.cc')
-    })
+    }),
+    new ContextReplacementPlugin(/moment[\/\\]locale$/, regexpLocales),
+    new ContextReplacementPlugin(/date-fns[\/\\]locale$/, regexpLocales),
+    new ContextReplacementPlugin(/src[\/\\]locales/, regexpLocales),
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2992,20 +2992,6 @@ cozy-stack-client@^6.3.0, cozy-stack-client@^6.3.3:
     detect-node "2.0.4"
     mime-types "2.1.20"
 
-cozy-ui@19.1.1:
-  version "19.1.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-19.1.1.tgz#20c61f163003ede853ce1634103ed611a4805579"
-  integrity sha512-aK4ERwT9lTJy9sGhymLVumXhJcNUD2nO6M74vloz/xSin6apOJeJGToL19cOhlpvYsVDSfpZoDG0oRlj4kLj9g==
-  dependencies:
-    body-scroll-lock "^2.5.8"
-    classnames "^2.2.5"
-    date-fns "^1.28.5"
-    hammerjs "^2.0.8"
-    node-polyglot "^2.2.2"
-    normalize.css "^7.0.0"
-    react-hot-loader "^4.3.11"
-    react-select "2.2.0"
-
 cozy-ui@19.3.0:
   version "19.3.0"
   resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-19.3.0.tgz#8e215ae1d2d49d5a8a1503f731cbc7963d06ae21"


### PR DESCRIPTION
We had in the bundle a log of JSON and JS for locales that we don't support. It takes a lot of spaces (several hundreds of kb) and it is not used as it's not possible to select one of those locales currently. So, let's remove them to make the home loads faster.

Note: the change has been made on cozy-home, but if it works nicely, it should probably moved to cozy-scripts.