### PR TITLE
Fix notification icon and layout

### DIFF
--- a/src/styles/notifier.styl
+++ b/src/styles/notifier.styl
@@ -24,8 +24,9 @@ notification-width = rem(546)
     min-height          rem(96)
     padding-left        rem(96)
     background-image    embedurl('../assets/icons/icon-check.svg')
+    background-size     rem(32) rem(32)
     background-repeat   no-repeat
-    background-position rem(24) center
+    background-position rem(32) center
 
     transition                 top .5s
     transition-timing-function ease-out

--- a/src/styles/notifier.styl
+++ b/src/styles/notifier.styl
@@ -8,7 +8,7 @@ notification-width = rem(546)
     z-index 100
 
 .coz-notification
-    display          block
+    display          flex
     position         absolute
     top              rem(16)
     left             0
@@ -17,6 +17,8 @@ notification-width = rem(546)
     background-color emerald
     box-shadow       0 rem(6) rem(18) 0 rgba(50, 54, 63, .23)
     box-sizing       border-box
+    flex-direction   column
+    justify-content  center
     padding          1em
     color            white
 


### PR DESCRIPTION
Icon was too big following https://github.com/cozy/cozy-home/pull/1121

Vertical alignement was wrong.

Before:

![capture d ecran 2019-03-04 a 20 57 45](https://user-images.githubusercontent.com/776764/53759281-35470300-3ec0-11e9-8acc-56f151ee6fd9.png)

After:

![capture d ecran 2019-03-04 a 20 58 58](https://user-images.githubusercontent.com/776764/53759328-5c9dd000-3ec0-11e9-95b6-5ea45879c429.png)
