### PR TITLE
Fix connecting icon

### DIFF
--- a/src/styles/konnectorSuccess.styl
+++ b/src/styles/konnectorSuccess.styl
@@ -17,3 +17,7 @@
     padding-left 1.3em
     margin-top 1rem
     cursor pointer
+
+.col-account-success-illu
+    height rem(112)
+    width rem(120)


### PR DESCRIPTION
Icon was too big following https://github.com/cozy/cozy-home/pull/1121

Before:

![capture d ecran 2019-03-05 a 07 59 16](https://user-images.githubusercontent.com/776764/53786646-9c92a080-3f1c-11e9-8443-af5f1beba222.png)


After:

![capture d ecran 2019-03-05 a 07 58 35](https://user-images.githubusercontent.com/776764/53786654-a2888180-3f1c-11e9-9c3c-d1cb83560ee6.png)
