### PR TITLE
Fix ejs comment

### DIFF
--- a/src/targets/browser/index.ejs
+++ b/src/targets/browser/index.ejs
@@ -16,7 +16,7 @@
 {{.CozyClientJS}}
 {{.CozyBar}}
 <% } else { %>
-  <%# Perf: we don't load the font twice as it is already provided by the CozyBar %>
+  <%/* Perf: we don't load the font twice as it is already provided by the CozyBar */%>
   <link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css">
 <% } %>
 </head>


### PR DESCRIPTION
Apparently ejs provides two comment syntaxes, which only one is valid.

Fixing 2489baed397a2367a488118eb50ec6c077c683b7