### PR TITLE
Moving KonnectorMaintenance from KonnectorInstall to AccountConnection

### DIFF
--- a/src/components/KonnectorInstall.jsx
+++ b/src/components/KonnectorInstall.jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux'
 import { TriggerManager } from 'cozy-harvest-lib'
 import flag from 'cozy-flags'
 
-import KonnectorMaintenance from './KonnectorMaintenance'
 import KonnectorSuccess from './KonnectorSuccess'
 import LegacyKonnectorInstall from './LegacyKonnectorInstall'
 import { getKonnector } from 'ducks/konnectors'
@@ -40,8 +39,6 @@ export class KonnectorInstall extends PureComponent {
     const {
       account,
       konnector,
-      lang,
-      maintenance,
       onDone,
       successMessage,
       successMessages,
@@ -50,15 +47,6 @@ export class KonnectorInstall extends PureComponent {
     } = this.props
 
     const { trigger, success } = this.state
-
-    if (maintenance && maintenance.longTerm)
-      return (
-        <KonnectorMaintenance
-          maintenance={maintenance}
-          lang={lang}
-          konnectorName={konnector.name}
-        />
-      )
 
     if (flag('harvest')) {
       return success ? (

--- a/src/components/LegacyKonnectorInstall.jsx
+++ b/src/components/LegacyKonnectorInstall.jsx
@@ -4,7 +4,6 @@ import styles from '../styles/konnectorInstall'
 
 import AccountLoginForm from './AccountLoginForm'
 import DescriptionContent from './DescriptionContent'
-import KonnectorMaintenance from './KonnectorMaintenance'
 import KonnectorSuccess from './KonnectorSuccess'
 
 import { getKonnectorMessage, isKonnectorLoginError } from '../lib/konnectors'
@@ -36,9 +35,7 @@ export const KonnectorInstall = props => {
     isFetching,
     isValid,
     dirty,
-    successButtonLabel,
-    maintenance,
-    lang
+    successButtonLabel
   } = props
   const hasLoginError = isKonnectorLoginError(error)
   const hasErrorExceptLogin = !!error && !hasLoginError
@@ -50,21 +47,14 @@ export const KonnectorInstall = props => {
         {hasErrorExceptLogin && ErrorDescription({ t, error, connector })}
         {(!error || hasLoginError) &&
           !isRunningInQueue &&
-          !success &&
-          !maintenance && (
+          !success && (
             <DescriptionContent
               title={t('account.config.title', { name: connector.name })}
               messages={[getKonnectorMessage(t, connector, 'terms')]}
               centerTitle
             />
           )}
-        {maintenance && maintenance.longTerm ? (
-          <KonnectorMaintenance
-            maintenance={maintenance}
-            lang={lang}
-            konnectorName={connector.name}
-          />
-        ) : !account || !success || hasLoginError ? (
+        {!account || !success || hasLoginError ? (
           <AccountLoginForm
             connectorSlug={connector.slug}
             konnectorName={connector.name}

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -20,6 +20,7 @@ import { has } from 'lodash'
 import { translate } from 'cozy-ui/react/I18n'
 
 import KonnectorInstall from '../components/KonnectorInstall'
+import KonnectorMaintenance from '../components/KonnectorMaintenance'
 import UpdateMessage from '../components/UpdateMessage'
 import KonnectorEdit from '../components/KonnectorEdit'
 import accountsMutations from '../connections/accounts'
@@ -432,6 +433,12 @@ class AccountConnection extends Component {
             maintenance={maintenance}
             lang={lang}
           />
+        ) : maintenance ? (
+          <KonnectorMaintenance
+            maintenance={maintenance}
+            lang={lang}
+            konnectorName={konnector.name}
+          />
         ) : (
           <KonnectorInstall
             displayAccountsCount={displayAccountsCount}
@@ -461,8 +468,6 @@ class AccountConnection extends Component {
             allRequiredFieldsAreFilled={allRequiredFieldsAreFilled}
             displayAdvanced={displayAdvanced}
             toggleAdvanced={toggleAdvanced}
-            maintenance={maintenance}
-            lang={lang}
           />
         )}
       </div>


### PR DESCRIPTION
Simplifying Cozy-Home, one step at a time.

Here we follow https://github.com/cozy/cozy-home/pull/1140#discussion_r263044543

Here we are moving up KonnectorMaintenance component, which inform
user about konnector maintenance, from KonnectorInstall (very late)
to AccountConnection (earlier but could be better).

We also do not rely anymore on `maintenance.longTerm` as ALL
konnectors in maintenance are also in longTerm maintenance.