### PR TITLE
Fix "late job error" behaviour

### DIFF
--- a/src/components/KonnectorInstall.jsx
+++ b/src/components/KonnectorInstall.jsx
@@ -39,6 +39,7 @@ export class KonnectorInstall extends PureComponent {
     const {
       account,
       konnector,
+      legacySuccess,
       onDone,
       successMessage,
       successMessages,
@@ -48,8 +49,8 @@ export class KonnectorInstall extends PureComponent {
 
     const { trigger, success } = this.state
 
-    if (flag('harvest')) {
-      return success ? (
+    if (success || legacySuccess) {
+      return (
         <KonnectorSuccess
           account={account}
           connector={konnector}
@@ -60,24 +61,26 @@ export class KonnectorInstall extends PureComponent {
           messages={successMessages}
           successButtonLabel={successButtonLabel}
         />
-      ) : (
-        <div className={styles['col-account-connection-content']}>
-          <div className={styles['col-account-connection-form']}>
-            <h4 className="u-ta-center">
-              {t('account.config.title', { name: konnector.name })}
-            </h4>
-            <TriggerManager
-              account={account}
-              konnector={konnector}
-              onLoginSuccess={this.handleLoginSuccess}
-              onSuccess={this.handleSuccess}
-            />
-          </div>
-        </div>
       )
     }
 
-    return <LegacyKonnectorInstall {...this.props} />
+    return flag('harvest') ? (
+      <div className={styles['col-account-connection-content']}>
+        <div className={styles['col-account-connection-form']}>
+          <h4 className="u-ta-center">
+            {t('account.config.title', { name: konnector.name })}
+          </h4>
+          <TriggerManager
+            account={account}
+            konnector={konnector}
+            onLoginSuccess={this.handleLoginSuccess}
+            onSuccess={this.handleSuccess}
+          />
+        </div>
+      </div>
+    ) : (
+      <LegacyKonnectorInstall {...this.props} />
+    )
   }
 }
 

--- a/src/components/LegacyKonnectorInstall.jsx
+++ b/src/components/LegacyKonnectorInstall.jsx
@@ -4,7 +4,6 @@ import styles from '../styles/konnectorInstall'
 
 import AccountLoginForm from './AccountLoginForm'
 import DescriptionContent from './DescriptionContent'
-import KonnectorSuccess from './KonnectorSuccess'
 
 import { getKonnectorMessage, isKonnectorLoginError } from '../lib/konnectors'
 import ErrorDescription from './ErrorDescriptions'
@@ -12,30 +11,22 @@ import ErrorDescription from './ErrorDescriptions'
 export const KonnectorInstall = props => {
   const {
     t,
-    account,
     connector,
     disableSuccessTimeout,
     error,
     fields,
-    handleConnectionSuccess,
     queued,
     isUnloading,
     oAuthTerminated,
-    onCancel,
-    onDone,
     onSubmit,
     submitting,
     success,
-    successMessage,
-    successMessages,
-    trigger,
     allRequiredFieldsAreFilled,
     displayAdvanced,
     toggleAdvanced,
     isFetching,
     isValid,
-    dirty,
-    successButtonLabel
+    dirty
   } = props
   const hasLoginError = isKonnectorLoginError(error)
   const hasErrorExceptLogin = !!error && !hasLoginError
@@ -54,43 +45,25 @@ export const KonnectorInstall = props => {
               centerTitle
             />
           )}
-        {!account || !success || hasLoginError ? (
-          <AccountLoginForm
-            connectorSlug={connector.slug}
-            konnectorName={connector.name}
-            disableSuccessTimeout={disableSuccessTimeout}
-            error={hasLoginError}
-            fields={fields}
-            isValid={isValid}
-            dirty={dirty}
-            isFetching={isFetching}
-            forceEnabled={!!error}
-            isOAuth={connector.oauth}
-            isUnloading={isUnloading}
-            oAuthTerminated={oAuthTerminated}
-            onSubmit={onSubmit}
-            submitting={submitting}
-            allRequiredFieldsAreFilled={allRequiredFieldsAreFilled}
-            displayAdvanced={displayAdvanced}
-            toggleAdvanced={toggleAdvanced}
-          />
-        ) : (
-          <KonnectorSuccess
-            connector={connector}
-            error={error}
-            account={account}
-            handleConnectionSuccess={handleConnectionSuccess}
-            isRunningInQueue={isRunningInQueue}
-            isUnloading={isUnloading}
-            onDone={onDone}
-            onCancel={onCancel}
-            success={success}
-            title={successMessage}
-            trigger={trigger}
-            messages={successMessages}
-            successButtonLabel={successButtonLabel}
-          />
-        )}
+        <AccountLoginForm
+          connectorSlug={connector.slug}
+          konnectorName={connector.name}
+          disableSuccessTimeout={disableSuccessTimeout}
+          error={hasLoginError}
+          fields={fields}
+          isValid={isValid}
+          dirty={dirty}
+          isFetching={isFetching}
+          forceEnabled={!!error}
+          isOAuth={connector.oauth}
+          isUnloading={isUnloading}
+          oAuthTerminated={oAuthTerminated}
+          onSubmit={onSubmit}
+          submitting={submitting}
+          allRequiredFieldsAreFilled={allRequiredFieldsAreFilled}
+          displayAdvanced={displayAdvanced}
+          toggleAdvanced={toggleAdvanced}
+        />
       </div>
     </div>
   )

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -460,7 +460,7 @@ class AccountConnection extends Component {
             onSubmit={() => this.onSubmit()}
             onSuccess={handleConnectionSuccess}
             submitting={submitting || isRunning}
-            success={success || queued}
+            legacySuccess={success || queued}
             successMessage={t('account.success.title.connect')}
             successButtonLabel={successButtonLabel}
             successMessages={successMessages}


### PR DESCRIPTION
We discovered that a konnector job may have been queued after a login success.

This event is intented to show the success message from component KonnectorSuccessMessage.

But if the job was failing after the the success message has been shown, the KonnectorSuccessMesssage could have been "mixed" with the job error.

![capture d ecran 2019-03-07 a 15 35 27](https://user-images.githubusercontent.com/776764/53963987-af5ccf00-40ee-11e9-9ccb-76eb63fd0609.png)


This PR fixes this behaviour by keeping the success message up even when the related queued job has failed.