### PR TITLE
Make compatible recent success handlers with legacy

### DIFF
--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -70,6 +70,17 @@ class AccountConnection extends Component {
     this.handleLoginSuccess = this.handleLoginSuccess.bind(this)
   }
 
+  componentDidUpdate(prevProps) {
+    const { success, queued } = this.props
+
+    const succeed = !prevProps.success && success
+    const loginSucceed = !prevProps.queued && queued
+
+    if (succeed || loginSucceed) {
+      this.props.handleConnectionSuccess()
+    }
+  }
+
   componentWillReceiveProps(props) {
     this.UNSAFE_componentWillReceiveProps(props)
   }


### PR DESCRIPTION
Following https://github.com/cozy/cozy-home/pull/1140/files and https://github.com/cozy/cozy-home/pull/1149/files, it seems that we need a last little adjustement.

For legacy konnector jobs, konnector icon was still present on regular job success (before login success).

![capture d ecran 2019-03-07 a 17 18 18](https://user-images.githubusercontent.com/776764/53971374-1a150700-40fd-11e9-8c94-43755ca333d5.png)


This PR fixes this by updating the `ConnectionManagement`'s `isSuccess` state variable in case of `legacy` success.