### PR TITLE
Prevent 409 on account update

### DIFF
--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -58,12 +58,21 @@ export default class CollectStore {
 
     if (flags('harvest')) {
       realtimeTriggers.onCreate(trigger => this.onTriggerCreated(trigger))
+      realtimeAccounts.onUpdate(account => this.onAccountUpdated(account))
     }
   }
 
   async onAccountCreated(account) {
     this.dispatch({
       type: 'RECEIVE_NEW_DOCUMENT',
+      response: { data: [normalize(account, 'io.cozy.accounts')] },
+      updateCollections: ['accounts']
+    })
+  }
+
+  async onAccountUpdated(account) {
+    this.dispatch({
+      type: 'RECEIVE_UPDATED_DOCUMENT',
       response: { data: [normalize(account, 'io.cozy.accounts')] },
       updateCollections: ['accounts']
     })


### PR DESCRIPTION
With Harvest we need to subcribe to accounts update, otherwise we could face 409 errors.

By subscribing to realtime we are aware when Harvest update an account.