### PR TITLE
Remove success callback passed to TriggerManager when editing

### DIFF
--- a/src/components/KonnectorEdit.jsx
+++ b/src/components/KonnectorEdit.jsx
@@ -40,9 +40,7 @@ export const KonnectorEdit = props => {
     lastSuccess,
     oAuthTerminated,
     onDelete,
-    onDone,
     onForceConnection,
-    onLoginSuccess,
     onSubmit,
     submitting,
     toggleAdvanced,
@@ -134,8 +132,6 @@ export const KonnectorEdit = props => {
                 konnector={connector}
                 showError={false}
                 trigger={trigger}
-                onDone={onDone}
-                onLoginSuccess={onLoginSuccess}
                 running={submitting}
               />
             ) : (

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -430,8 +430,6 @@ class AccountConnection extends Component {
             oAuthTerminated={oAuthTerminated}
             onDelete={() => this.deleteConnection()}
             onForceConnection={forceConnection}
-            onDone={onDone}
-            onLoginSuccess={this.onLoginSuccess}
             onSubmit={this.onSubmit}
             submitting={submitting || isRunning}
             toggleAdvanced={toggleAdvanced}


### PR DESCRIPTION
We don't need those callbacks here and it could cause side effects