### PR TITLE
Remove cozy-harvest-lib flag

### DIFF
--- a/src/components/AccountLoginForm.jsx
+++ b/src/components/AccountLoginForm.jsx
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react'
 import { connect } from 'react-redux'
 
 import { TriggerManager } from 'cozy-harvest-lib'
-import flag from 'cozy-flags'
 
 import LegacyAccountLoginForm from './LegacyAccountLoginForm'
 import { getKonnector } from 'ducks/konnectors'
@@ -10,10 +9,10 @@ import { getKonnector } from 'ducks/konnectors'
 export class AccountLoginForm extends PureComponent {
   render() {
     const { account, konnector } = this.props
-    return flag('harvest') ? (
-      <TriggerManager account={account} konnector={konnector} />
-    ) : (
+    return konnector.oauth ? (
       <LegacyAccountLoginForm {...this.props} />
+    ) : (
+      <TriggerManager account={account} konnector={konnector} />
     )
   }
 }

--- a/src/components/KonnectorEdit.jsx
+++ b/src/components/KonnectorEdit.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import flag from 'cozy-flags'
 import { TriggerManager } from 'cozy-harvest-lib'
 import { translate } from 'cozy-ui/react/I18n'
 import has from 'lodash/has'
@@ -8,7 +7,7 @@ import styles from '../styles/konnectorEdit'
 import { Tab, Tabs, TabList, TabPanels, TabPanel } from 'cozy-ui/react/Tabs'
 
 import AccountConnectionData from './AccountConnectionData'
-import AccountLoginForm from './AccountLoginForm'
+import LegacyAccountLoginForm from './LegacyAccountLoginForm'
 import AccountLogout from './AccountLogout'
 import DescriptionContent from './DescriptionContent'
 import TriggerFolderLink from './TriggerFolderLink'
@@ -126,16 +125,8 @@ export const KonnectorEdit = props => {
               messages={[getKonnectorMessage(t, connector, 'terms')]}
             />
 
-            {flag('harvest') ? (
-              <TriggerManager
-                account={account}
-                konnector={connector}
-                showError={false}
-                trigger={trigger}
-                running={submitting}
-              />
-            ) : (
-              <AccountLoginForm
+            {connector.oauth ? (
+              <LegacyAccountLoginForm
                 account={account}
                 connectorSlug={connector.slug}
                 disableSuccessTimeout={disableSuccessTimeout}
@@ -155,6 +146,14 @@ export const KonnectorEdit = props => {
                 allRequiredFieldsAreFilled={allRequiredFieldsAreFilled}
                 isValidButPasswords={isValidButPasswords}
                 allRequiredFilledButPasswords={allRequiredFilledButPasswords}
+              />
+            ) : (
+              <TriggerManager
+                account={account}
+                konnector={connector}
+                showError={false}
+                trigger={trigger}
+                running={submitting}
               />
             )}
 

--- a/src/components/KonnectorInstall.jsx
+++ b/src/components/KonnectorInstall.jsx
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react'
 import { connect } from 'react-redux'
 
 import { TriggerManager } from 'cozy-harvest-lib'
-import flag from 'cozy-flags'
 
 import KonnectorSuccess from './KonnectorSuccess'
 import LegacyKonnectorInstall from './LegacyKonnectorInstall'
@@ -64,7 +63,9 @@ export class KonnectorInstall extends PureComponent {
       )
     }
 
-    return flag('harvest') ? (
+    return konnector.oauth ? (
+      <LegacyKonnectorInstall {...this.props} />
+    ) : (
       <div className={styles['col-account-connection-content']}>
         <div className={styles['col-account-connection-form']}>
           <h4 className="u-ta-center">
@@ -78,8 +79,6 @@ export class KonnectorInstall extends PureComponent {
           />
         </div>
       </div>
-    ) : (
-      <LegacyKonnectorInstall {...this.props} />
     )
   }
 }

--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -1,6 +1,4 @@
 /* global cozy */
-import flags from 'cozy-flags'
-
 import * as accounts from './accounts'
 import * as konnectors from './konnectors'
 import * as jobs from './jobs'
@@ -56,10 +54,8 @@ export default class CollectStore {
     const realtimeTriggers = await triggers.subscribeAll(cozy.client)
     realtimeTriggers.onDelete(trigger => this.deleteTrigger(trigger))
 
-    if (flags('harvest')) {
-      realtimeTriggers.onCreate(trigger => this.onTriggerCreated(trigger))
-      realtimeAccounts.onUpdate(account => this.onAccountUpdated(account))
-    }
+    realtimeTriggers.onCreate(trigger => this.onTriggerCreated(trigger))
+    realtimeAccounts.onUpdate(account => this.onAccountUpdated(account))
   }
 
   async onAccountCreated(account) {


### PR DESCRIPTION
Cozy-Home now rely on cozy-harvest-lib by default.

Only OAuth konnectors are managed the old fashion way.