### PR TITLE
Fix CozyClient initialisation in Intents

### DIFF
--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -33,7 +33,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // New improvements must be done with CozyClient
   const cozyClient = new MostRecentCozyClient({
-    uri: `//${appData.cozyDomain}`,
+    uri: `${window.location.protocol}//${appData.cozyDomain}`,
     schema: {
       app: Application.schema,
       accounts: {


### PR DESCRIPTION
URL are embeding two informations : protocol (secure or not ?) and domain (url host).

I think a variable should always bring one information. But this point of view is not shared unfortunately.