### PR TITLE
fix: Use componentDidMount instead of constructor for side-fx

### DIFF
--- a/src/components/KonnectorSuccess.jsx
+++ b/src/components/KonnectorSuccess.jsx
@@ -18,6 +18,9 @@ export class KonnectorSuccess extends Component {
   constructor(props, context) {
     super(props, context)
     this.store = this.context.store
+  }
+
+  componentDidMount() {
     if (typeof this.props.handleConnectionSuccess === 'function') {
       this.props.handleConnectionSuccess()
     }


### PR DESCRIPTION
It is possible to instantiate an instance of a component without
showing it. I believe the intent of the code was to call
handleSuccess when the component is displayed.

ex of an instantiated component that is not displayed:

```
render () {
  const success = <KonnectorSuccess />
  return hasSucceeded ? success : null
}
```