### PR TITLE
feat: Refactor for easier override

### DIFF
--- a/src/components/KonnectorSuccess.jsx
+++ b/src/components/KonnectorSuccess.jsx
@@ -22,6 +22,43 @@ const SuccessImage = () => (
   </div>
 )
 
+const BanksLink = translate()(
+  ({ banksUrl, t }) =>
+    banksUrl ? (
+      <AppLinker slug="banks" href={banksUrl}>
+        {({ href, onClick, name }) => (
+          <a
+            className={styles['col-account-success-link']}
+            href={href}
+            target="_parent"
+            onClick={onClick}
+          >
+            <Icon className="u-mr-half" icon="openwith" />
+            {t('account.success.banksLinkText', {
+              appName: name
+            })}
+          </a>
+        )}
+      </AppLinker>
+    ) : (
+      <a
+        className={styles['col-account-success-link']}
+        onClick={() =>
+          cozy.client.intents.redirect(
+            'io.cozy.apps',
+            { slug: 'banks' },
+            url => {
+              window.top.location.href = url
+            }
+          )
+        }
+      >
+        <Icon className="u-mr-half" icon="openwith" />
+        {t('account.success.banksLinkText')}
+      </a>
+    )
+)
+
 export class KonnectorSuccess extends Component {
   constructor(props, context) {
     super(props, context)
@@ -73,41 +110,8 @@ export class KonnectorSuccess extends Component {
                     label={t('account.success.driveLinkText')}
                   />
                 )}
-                {displayBanksUrl &&
-                  (banksUrl ? (
-                    <AppLinker slug="banks" href={banksUrl}>
-                      {({ href, onClick, name }) => (
-                        <a
-                          className={styles['col-account-success-link']}
-                          href={href}
-                          target="_parent"
-                          onClick={onClick}
-                        >
-                          <Icon className="u-mr-half" icon="openwith" />
-                          {t('account.success.banksLinkText', {
-                            appName: name
-                          })}
-                        </a>
-                      )}
-                    </AppLinker>
-                  ) : (
-                    <a
-                      className={styles['col-account-success-link']}
-                      onClick={() =>
-                        cozy.client.intents.redirect(
-                          'io.cozy.apps',
-                          { slug: 'banks' },
-                          url => {
-                            window.top.location.href = url
-                          }
-                        )
-                      }
-                    >
-                      <Icon className="u-mr-half" icon="openwith" />
-                      {t('account.success.banksLinkText')}
-                    </a>
-                  ))}
               </p>
+                {displayBanksUrl && <BanksLink banksUrl={banksUrl} />}
             )}
           </DescriptionContent>
 

--- a/src/components/KonnectorSuccess.jsx
+++ b/src/components/KonnectorSuccess.jsx
@@ -16,6 +16,12 @@ import DescriptionContent from 'components/DescriptionContent'
 import TriggerFolderLink from 'components/TriggerFolderLink'
 import connectingIllu from 'assets/images/connecting-data-in-progress.svg'
 
+const SuccessImage = () => (
+  <div className={styles['col-account-success-illu-wrapper']}>
+    <img src={connectingIllu} className={styles['col-account-success-illu']} />
+  </div>
+)
+
 export class KonnectorSuccess extends Component {
   constructor(props, context) {
     super(props, context)
@@ -49,14 +55,7 @@ export class KonnectorSuccess extends Component {
     return (
       account && (
         <div className={styles['col-account-success']}>
-          {!error && (
-            <div className={styles['col-account-success-illu-wrapper']}>
-              <img
-                src={connectingIllu}
-                className={styles['col-account-success-illu']}
-              />
-            </div>
-          )}
+          {!error && <SuccessImage />}
           <DescriptionContent
             title={!error && title}
             messages={!error && messages}

--- a/src/components/KonnectorSuccess.jsx
+++ b/src/components/KonnectorSuccess.jsx
@@ -72,6 +72,12 @@ const DriveLink = translate()(({ folderId, t }) => (
   />
 ))
 
+const SuccessFooter = translate()(({ children }) => (
+  <div className={styles['coz-form-controls-success']}>
+    <div className={styles['col-account-form-success-buttons']}>{children}</div>
+  </div>
+))
+
 export class KonnectorSuccess extends Component {
   constructor(props, context) {
     super(props, context)
@@ -118,17 +124,15 @@ export class KonnectorSuccess extends Component {
             )}
           </DescriptionContent>
 
-          <div className={styles['coz-form-controls-success']}>
-            <div className={styles['col-account-form-success-buttons']}>
-              <Button
-                label={successButtonLabel || t('account.success.button')}
-                onClick={event => {
-                  event.preventDefault()
-                  onDone(account)
-                }}
-              />
-            </div>
-          </div>
+          <SuccessFooter>
+            <Button
+              label={successButtonLabel || t('account.success.button')}
+              onClick={event => {
+                event.preventDefault()
+                onDone(account)
+              }}
+            />
+          </SuccessFooter>
         </div>
       )
     )

--- a/src/components/KonnectorSuccess.jsx
+++ b/src/components/KonnectorSuccess.jsx
@@ -22,6 +22,12 @@ const SuccessImage = () => (
   </div>
 )
 
+const SuccessLinks = ({ children }) => (
+  <p className={classNames(styles['col-account-success-links'], 'u-mv-half')}>
+    {children}
+  </p>
+)
+
 const BanksLink = translate()(
   ({ banksUrl, t }) =>
     banksUrl ? (
@@ -105,15 +111,10 @@ export class KonnectorSuccess extends Component {
             messages={!error && messages}
           >
             {hasLinks && (
-              <p
-                className={classNames(
-                  styles['col-account-success-links'],
-                  'u-mv-half'
-                )}
-              >
-              </p>
+              <SuccessLinks>
                 {displayDriveUrl && <DriveLink folderId={trigger.message.folder_to_save} />}
                 {displayBanksUrl && <BanksLink banksUrl={banksUrl} />}
+              </SuccessLinks>
             )}
           </DescriptionContent>
 

--- a/src/components/KonnectorSuccess.jsx
+++ b/src/components/KonnectorSuccess.jsx
@@ -59,6 +59,13 @@ const BanksLink = translate()(
     )
 )
 
+const DriveLink = translate()(({ folderId, t }) => (
+  <TriggerFolderLink
+    folderId={folderId}
+    label={t('account.success.driveLinkText')}
+  />
+))
+
 export class KonnectorSuccess extends Component {
   constructor(props, context) {
     super(props, context)
@@ -104,13 +111,8 @@ export class KonnectorSuccess extends Component {
                   'u-mv-half'
                 )}
               >
-                {displayDriveUrl && (
-                  <TriggerFolderLink
-                    folderId={trigger.message.folder_to_save}
-                    label={t('account.success.driveLinkText')}
-                  />
-                )}
               </p>
+                {displayDriveUrl && <DriveLink folderId={trigger.message.folder_to_save} />}
                 {displayBanksUrl && <BanksLink banksUrl={banksUrl} />}
             )}
           </DescriptionContent>

--- a/src/components/KonnectorSuccess.spec.jsx
+++ b/src/components/KonnectorSuccess.spec.jsx
@@ -1,0 +1,26 @@
+import { mount } from 'enzyme'
+import KonnectorSuccess, { BanksLink, DriveLink } from './KonnectorSuccess'
+
+describe('KonnectorSuccess', () => {
+  let trigger, connector, root
+  const setup = () => {
+    root = mount(<KonnectorSuccess connector={connector} trigger={trigger} />)
+  }
+
+  beforeEach(() => {
+    connector = {}
+    trigger = { message: {}}
+  })
+
+  it('should show drive if trigger has a folder_to_save', () => {
+    trigger.message.folder_to_save = 'deadbeef'
+    setup()
+    expect(root.find(DriveLink)).toBe(true)
+  })
+
+  it('should show banks if connector has datatypes with bankAccoutns', () => {
+    connector.datatypes = ['bankAccounts']
+    setup()
+    expect(root.find(BanksLink)).toBe(true)
+  })
+})

--- a/test/components/AccountPickerItem.spec.js
+++ b/test/components/AccountPickerItem.spec.js
@@ -3,13 +3,10 @@
 /* eslint-env jest */
 
 import React from 'react'
-import { configure, shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-15'
+import { shallow } from 'enzyme'
 
 import { tMock } from '../jestLib/I18n'
 import { AccountPickerItem } from '../../src/components/AccountPickerItem'
-
-configure({ adapter: new Adapter() })
 
 const mockAccount = {
   _id: '123456789',

--- a/test/components/DataItem.spec.js
+++ b/test/components/DataItem.spec.js
@@ -3,8 +3,7 @@
 /* eslint-env jest */
 
 import React from 'react'
-import { configure, shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-15'
+import { shallow } from 'enzyme'
 
 import { tMock } from '../jestLib/I18n'
 import { DataItem } from '../../src/components/DataItem'
@@ -12,8 +11,6 @@ import { DataItem } from '../../src/components/DataItem'
 import datatypesToTest from '../../src/config/datatypes'
 
 const hexColorMock = '#297EF2'
-
-configure({ adapter: new Adapter() })
 
 describe('DataItem component', () => {
   beforeEach(() => {

--- a/test/components/DescriptionContent.spec.js
+++ b/test/components/DescriptionContent.spec.js
@@ -3,13 +3,10 @@
 /* eslint-env jest */
 
 import React from 'react'
-import { configure, shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-15'
+import { shallow } from 'enzyme'
 
 import { tMock } from '../jestLib/I18n'
 import { DescriptionContent } from '../../src/components/DescriptionContent'
-
-configure({ adapter: new Adapter() })
 
 describe('DescriptionContent component', () => {
   beforeEach(() => {

--- a/test/components/Failure.spec.js
+++ b/test/components/Failure.spec.js
@@ -3,14 +3,10 @@
 /* eslint-env jest */
 
 import React from 'react'
-import { configure, shallow } from 'enzyme'
+import { shallow } from 'enzyme'
 
 import { tMock } from '../jestLib/I18n'
 import { Failure } from '../../src/components/Failure'
-
-import Adapter from 'enzyme-adapter-react-15'
-
-configure({ adapter: new Adapter() })
 
 describe('Failure component', () => {
   beforeEach(() => {

--- a/test/components/KonnectorTile.spec.js
+++ b/test/components/KonnectorTile.spec.js
@@ -3,13 +3,10 @@
 /* eslint-env jest */
 
 import React from 'react'
-import { configure, shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-15'
+import { shallow } from 'enzyme'
 
 import { tMock } from '../jestLib/I18n'
 import { KonnectorTile } from 'components/KonnectorTile'
-
-configure({ adapter: new Adapter() })
 
 const mockKonnector = {
   name: 'Mock',

--- a/test/components/LegacyAccountLoginForm.spec.js
+++ b/test/components/LegacyAccountLoginForm.spec.js
@@ -1,15 +1,12 @@
 /* eslint-env jest */
 
 import React from 'react'
-import { configure, shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-15'
+import { shallow } from 'enzyme'
 
 import { Button } from 'cozy-ui/react/Button'
 
 import { tMock } from '../jestLib/I18n'
 import { AccountLoginForm } from '../../src/components/LegacyAccountLoginForm'
-
-configure({ adapter: new Adapter() })
 
 describe('LegacyAccountLoginForm component', () => {
   beforeEach(() => {

--- a/test/components/Loading.test.js
+++ b/test/components/Loading.test.js
@@ -3,13 +3,10 @@
 /* eslint-env jest */
 
 import React from 'react'
-import { configure, shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-15'
+import { shallow } from 'enzyme'
 
 import { tMock } from '../jestLib/I18n'
 import { Loading } from '../../src/components/Loading'
-
-configure({ adapter: new Adapter() })
 
 describe('Loading component', () => {
   beforeEach(() => {

--- a/test/components/ReactMarkdownWrapper.test.js
+++ b/test/components/ReactMarkdownWrapper.test.js
@@ -3,15 +3,12 @@
 /* eslint-env jest */
 
 import React from 'react'
-import { configure, shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-15'
+import { shallow } from 'enzyme'
 
 import {
   ReactMarkdownWrapper,
   reactMarkdownRendererOptions
 } from '../../src/components/ReactMarkdownWrapper'
-
-configure({ adapter: new Adapter() })
 
 describe('ReactMarkdownWrapper component', () => {
   beforeEach(() => {

--- a/test/jestLib/setup.js
+++ b/test/jestLib/setup.js
@@ -1,3 +1,8 @@
+import { configure } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-15'
+
+configure({ adapter: new Adapter() })
+
 // installed by cozy-scripts
 require('babel-polyfill')
 


### PR DESCRIPTION
KonnectorSuccess had its logic inside the render() which made it hard to 
override hence it was copy/pasted in the customisation repository.

The first commits of ths PR
split the components down to presentational components which makes its
overall structure more obvious.

Next, the logic behind which links to which app are shown to the user
is refactored so that it is easier to see on which condition a link
to an app is shown. It is similar to what we do for bill actions in
banks.

It makes the addition/removal of an app easier, which is important
for customisation.



# Do not modify or remove the line above.
# Everything below it will be ignored.

Requesting a pull to cozy:master from cozy:refactor

Write a message for this pull request. The first block
of text is the title and the rest is the description.

Changes:

2dcf5a65 (Patrick Browne, 62 minutes ago)
   refactor: Jest setup to configure enzyme adapter

1ce003b1 (Patrick Browne, 85 minutes ago)
   feat: Declarative way for apps

da3e1745 (Patrick Browne, 2 hours ago)
   fixup: extract SuccessFooter

4e39aae8 (Patrick Browne, 2 hours ago)
   feat: Extract SuccessLinks

9ab87b1e (Patrick Browne, 2 hours ago)
   feat: Extract DriveLink

f303ab69 (Patrick Browne, 2 hours ago)
   feat: Extract BanksLink

64c68525 (Patrick Browne, 3 hours ago)
   feat: Extract SuccessIllu