### PR TITLE
fix: Use target top since BanksLink is used in an Intent

### DIFF
--- a/src/components/BanksLink.jsx
+++ b/src/components/BanksLink.jsx
@@ -15,7 +15,7 @@ const BanksLink = translate()(
           <a
             className={styles['col-account-success-link']}
             href={href}
-            target="_parent"
+            target="_top"
             onClick={onClick}
           >
             <Icon className="u-mr-half" icon="openwith" />


### PR DESCRIPTION
target=_top: Opens the linked document in the full body of the window

Since BanksLink is used in an intent (inside an iframe) we have
to tell the link to open the page in the full body of the window.
