### PR TITLE
fix: Take banks url from store inside context

### DIFF
--- a/src/components/KonnectorSuccess.jsx
+++ b/src/components/KonnectorSuccess.jsx
@@ -3,7 +3,6 @@ import has from 'lodash/has'
 import sortBy from 'lodash/sortBy'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
 
 import Button from 'cozy-ui/react/Button'
 import { translate } from 'cozy-ui/react/I18n'
@@ -48,7 +47,6 @@ export class KonnectorSuccess extends Component {
 
   render() {
     const { account, error, title, messages } = this.props
-
     const relatedApps = sortBy(
       Object.values(KonnectorSuccess.apps).filter(app =>
         app.predicate(this.props)
@@ -128,10 +126,14 @@ KonnectorSuccess.apps = {
     },
     // eslint-disable-next-line react/display-name
     successLink: (props, context, i) => {
-      return <BanksLink key={i} banksUrl={props.store.banksUrl} />
+      return <BanksLink key={i} banksUrl={context.store.banksUrl} />
     },
     footerLink: () => null
   }
+}
+
+KonnectorSuccess.contextTypes = {
+  store: PropTypes.object
 }
 
 KonnectorSuccess.propTypes = {
@@ -146,9 +148,4 @@ KonnectorSuccess.propTypes = {
 
 export { SuccessImage, SuccessLinks, BanksLink, DriveLink }
 
-const provideStoreAsProp = connect(
-  null,
-  (dispatch, store) => ({ store })
-)
-
-export default translate()(provideStoreAsProp(KonnectorSuccess))
+export default translate()(KonnectorSuccess)

--- a/src/components/KonnectorSuccess.spec.jsx
+++ b/src/components/KonnectorSuccess.spec.jsx
@@ -5,9 +5,15 @@ import AppLike from '../../test/AppLike'
 
 describe('KonnectorSuccess', () => {
   let trigger, connector, root
+  const fakeStore = {
+    banksUrl: 'https://example-banks.mycozy.cloud',
+    getState: () => ({}),
+    subscribe: () => ({}),
+    dispatch: () => ({})
+  }
   const setup = () => {
     root = mount(
-      <AppLike>
+      <AppLike store={fakeStore}>
         <KonnectorSuccess
           account={{}}
           title="Fake title"


### PR DESCRIPTION
A mistake from my end ended up costing many hours of my life.
The second parameter of mapDispatchToProps is *not* the store,
but the ownProps. The simple way to access CollectStore is
through this.context. The best way would be to access it with
a ContextProvider. This should be done when home does not use
pReact