### PR TITLE
Better account name

### DIFF
--- a/src/lib/accounts.js
+++ b/src/lib/accounts.js
@@ -11,11 +11,12 @@ export const ACCOUNT_ERRORS = {
   USER_ACTION_NEEDED: 'USER_ACTION_NEEDED'
 }
 
+// Order matters
 export const probableLoginFieldNames = [
-  'email',
-  'identifier',
   'login',
-  'new_identifier'
+  'identifier',
+  'new_identifier',
+  'email'
 ]
 
 function ignorePassword(auth) {

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -1,4 +1,5 @@
 import uuid from 'uuid/v4'
+import { probableLoginFieldNames } from './accounts'
 
 export const getAccountName = account => {
   if (!account) return null
@@ -11,7 +12,9 @@ export const getAccountName = account => {
 
 export const getAccountLogin = account => {
   if (account && account.auth) {
-    return account.auth.login || account.auth.identifier || account.auth.email
+    for (const fieldName of probableLoginFieldNames) {
+      if (account.auth[fieldName]) return account.auth[fieldName]
+    }
   }
 }
 


### PR DESCRIPTION
Quickfix:

Determines account name based on probableLoginFieldNames from lib/accounts.

`new_identifier` was not taken into account.