### PR TITLE
Ignore hook jobs on account deletion

### DIFF
--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -101,9 +101,12 @@ export default class CollectStore {
     const normalizedJob = normalize(job, 'io.cozy.jobs')
     // TODO Filter by worker on the WebSocket when it will be available in the
     // stack
-    if (normalizedJob.worker !== 'konnector') {
+    const isKonnectorJob = normalizedJob.worker === 'konnector'
+    const isDeletedAccountHookJob = !!normalizedJob.account_deleted
+    if (!isKonnectorJob || isDeletedAccountHookJob) {
       return
     }
+
     this.dispatch({
       type: 'RECEIVE_NEW_DOCUMENT',
       response: { data: [normalizedJob] },

--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -101,7 +101,7 @@ export default class CollectStore {
     const normlalizedJob = normalize(job, 'io.cozy.jobs')
     // TODO Filter by worker on the WebSocket when it will be available in the
     // stack
-    if (normlalizedJob.worker === 'thumbnail') {
+    if (normlalizedJob.worker !== 'konnector') {
       return
     }
     this.dispatch({

--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -98,18 +98,18 @@ export default class CollectStore {
   }
 
   async updateUnfinishedJob(job) {
-    const normlalizedJob = normalize(job, 'io.cozy.jobs')
+    const normalizedJob = normalize(job, 'io.cozy.jobs')
     // TODO Filter by worker on the WebSocket when it will be available in the
     // stack
-    if (normlalizedJob.worker !== 'konnector') {
+    if (normalizedJob.worker !== 'konnector') {
       return
     }
     this.dispatch({
       type: 'RECEIVE_NEW_DOCUMENT',
-      response: { data: [normlalizedJob] },
+      response: { data: [normalizedJob] },
       updateCollections: ['jobs']
     })
-    const trigger = await triggers.fetch(cozy.client, normlalizedJob.trigger_id)
+    const trigger = await triggers.fetch(cozy.client, normalizedJob.trigger_id)
     this.onTriggerUpdated(trigger)
   }
 


### PR DESCRIPTION
As Realtime is watching jobs with konnector worker, we are also triggering logic for hook jobs triggered when an account is deleted.

See https://github.com/cozy/cozy-stack/blob/master/model/account/accounts.go#L83