### PR TITLE
Handle account parameter in redirects

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -116,6 +116,7 @@
       ],
       "href": "/#/redirect",
       "data": [
+        "account",
         "konnector"
       ]
     }

--- a/src/components/IntentRedirect.jsx
+++ b/src/components/IntentRedirect.jsx
@@ -30,7 +30,13 @@ const IntentRedirect = ({ installedKonnectors, location }) => {
     })
   }
 
-  return <Redirect to={`/connected/${query.konnector}`} />
+  let redirectRoute = `/connected/${query.konnector}`
+
+  if (query.account) {
+    redirectRoute = `${redirectRoute}/accounts/${query.account}`
+  }
+
+  return <Redirect to={redirectRoute} />
 }
 
 const mapStateToProps = state => ({

--- a/src/components/IntentRedirect.jsx
+++ b/src/components/IntentRedirect.jsx
@@ -18,17 +18,19 @@ const IntentRedirect = ({ installedKonnectors, location }) => {
         return accumulator
       }, {})
 
-  if (query.konnector) {
-    if (
-      installedKonnectors.find(konnector => konnector.slug === query.konnector)
-    ) {
-      return <Redirect to={`/connected/${query.konnector}`} />
-    } else {
-      cozy.client.intents.redirect('io.cozy.apps', { slug: query.konnector })
-    }
+  if (!query.konnector) {
+    return <Redirect to={`/connected`} />
   }
 
-  return <Redirect to={`/connected`} />
+  if (
+    !installedKonnectors.find(konnector => konnector.slug === query.konnector)
+  ) {
+    return cozy.client.intents.redirect('io.cozy.apps', {
+      slug: query.konnector
+    })
+  }
+
+  return <Redirect to={`/connected/${query.konnector}`} />
 }
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
Handle `account` parameter from query string on redirects.

`/#/redirect?konnector=foo&account=abcdef123456` will redirect to `/#/connected/foo/accounts/abcdef123456`