### PR TITLE
fix: avoid malformed manifest message from stack

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -72,8 +72,6 @@
     "contacts": {
       "description": "Required for the service to update the myself contact",
       "type": "io.cozy.contacts",
-      "selector": "me",
-      "values": [true],
       "verbs": [
         "ALL"
       ]
@@ -134,7 +132,7 @@
     "myselfFromIdentities": {
       "type": "node",
       "file": "services/myselfFromIdenties/home.js",
-      "trigger": "@event io.cozy.identities:CREATED @event io.cozy.identities:UPDATED"
+      "trigger": "@event io.cozy.identities:CREATED,UPDATED"
     }
   }
 }


### PR DESCRIPTION
Two issues are fixed :
     - permission selector values with boolean does not seem to be correctly accepted
     - bad syntax for triggers with multiple events

This will allow the app to be installed

