### PR TITLE
fix: Upgrade cozy harvest lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cozy-device-helper": "1.7.1",
     "cozy-doctypes": "1.39.0",
     "cozy-flags": "1.9.3",
-    "cozy-harvest-lib": "0.57.2",
+    "cozy-harvest-lib": "0.67.6",
     "cozy-realtime": "3.1.3",
     "cozy-scripts": "1.13.0",
     "cozy-ui": "20.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -986,6 +986,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.5.2":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
+  integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -3410,13 +3417,15 @@ cozy-flags@1.9.3:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@0.57.2:
-  version "0.57.2"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-0.57.2.tgz#2b6d390d5c49c3b0e43c212c03becfe99f887443"
-  integrity sha512-zo8XlRCW/lpnr3aFU/kgovucCWaHPsG7op7fUgCRmIwJCf2e8pKnjdcH0QNGJgXtORzXPjkv7naCXygnYwLKjQ==
+cozy-harvest-lib@0.67.6:
+  version "0.67.6"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-0.67.6.tgz#8ce39c9ab2845ed23d32a5cfaef4aa4fd5debbac"
+  integrity sha512-9vDOR6Dpd+sgGMdAy4RE0AHwHzfkvbDHsVnMq6lXm/YL+rG9r99z83kiPprESS/X4cw9Rg9uFCD+Dw49irFOew==
   dependencies:
+    "@babel/runtime" "^7.5.2"
+    date-fns "^1.30.1"
     final-form "4.11.1"
-    lodash "4.17.11"
+    lodash "4.17.15"
     microee "^0.0.6"
     preact-portal "^1.1.3"
     react-final-form "3.7.0"
@@ -3895,7 +3904,7 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@1.30.1:
+date-fns@1.30.1, date-fns@^1.30.1:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
@@ -8017,6 +8026,11 @@ lodash@4.17.14:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
+
+lodash@4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR upgrade cozy-harvest-lib in order to support `defaultDir ` in the konnector manifest 