### PR TITLE
chore: Bump dev version

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -14,7 +14,7 @@
     "name": "Cozy Cloud",
     "url": "https://cozy.io"
   },
-  "version": "1.18.0",
+  "version": "1.19.0",
   "licence": "AGPL-3.0",
   "permissions": {
     "apps": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-home",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "main": "src/index.jsx",
   "scripts": {
     "tx": "tx pull --all || true",


### PR DESCRIPTION
We're publishing 1.18.0 version. So we need to bump our dev version