### PR TITLE
Fix connections reducer

### DIFF
--- a/src/ducks/connections/index.js
+++ b/src/ducks/connections/index.js
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux'
 import moment from 'moment'
 import omit from 'lodash/omit'
+import get from 'lodash/get'
 
 import { buildKonnectorError, isKonnectorUserError } from 'lib/konnectors'
 
@@ -97,26 +98,21 @@ const reducer = (state = {}, action) => {
           ...newState,
           [konnectorSlug]: {
             triggers: {
-              ...((newState[konnectorSlug] &&
-                newState[konnectorSlug].triggers) ||
-                {}),
+              ...get(newState, [konnectorSlug, 'triggers'], []),
               data: [
-                ...((newState[konnectorSlug] &&
-                  newState[konnectorSlug].triggers.data) ||
-                  []),
+                ...get(newState, [konnectorSlug, 'triggers', 'data'], []),
                 doc
               ],
               [triggerId]: {
-                ...((newState[konnectorSlug] &&
-                  newState[konnectorSlug].triggers &&
-                  newState[konnectorSlug].triggers[triggerId]) ||
-                  {}),
+                ...get(newState, [konnectorSlug, 'triggers', triggerId], {}),
                 account:
                   account ||
-                  (newState[konnectorSlug] &&
-                    newState[konnectorSlug].triggers &&
-                    newState[konnectorSlug].triggers[triggerId] &&
-                    newState[konnectorSlug].triggers[triggerId].account),
+                  get(newState, [
+                    konnectorSlug,
+                    'triggers',
+                    triggerId,
+                    'account'
+                  ]),
                 error,
                 hasError: !!error || currentStatus === 'errored',
                 isRunning: ['queued', 'running'].includes(currentStatus),

--- a/src/ducks/connections/index.js
+++ b/src/ducks/connections/index.js
@@ -94,19 +94,24 @@ const reducer = (state = {}, action) => {
             doc.current_state.last_execution) ||
           (isJob && doc.queued_at)
 
+        const existingTriggers = get(
+          newState,
+          [konnectorSlug, 'triggers', 'data'],
+          []
+        )
+        let rawTriggers = existingTriggers
+
+        if (isTrigger) {
+          rawTriggers = existingTriggers.filter(({ _id }) => _id !== doc._id)
+          rawTriggers.push(doc)
+        }
+
         return {
           ...newState,
           [konnectorSlug]: {
             triggers: {
               ...get(newState, [konnectorSlug, 'triggers'], []),
-              data: [
-                ...get(
-                  newState,
-                  [konnectorSlug, 'triggers', 'data'],
-                  []
-                ).filter(({ _id }) => _id !== doc._id),
-                doc
-              ],
+              data: rawTriggers,
               [triggerId]: {
                 ...get(newState, [konnectorSlug, 'triggers', triggerId], {}),
                 account:

--- a/src/ducks/connections/index.js
+++ b/src/ducks/connections/index.js
@@ -100,7 +100,11 @@ const reducer = (state = {}, action) => {
             triggers: {
               ...get(newState, [konnectorSlug, 'triggers'], []),
               data: [
-                ...get(newState, [konnectorSlug, 'triggers', 'data'], []),
+                ...get(
+                  newState,
+                  [konnectorSlug, 'triggers', 'data'],
+                  []
+                ).filter(({ _id }) => _id !== doc._id),
                 doc
               ],
               [triggerId]: {

--- a/src/ducks/connections/test/connections.spec.js
+++ b/src/ducks/connections/test/connections.spec.js
@@ -189,6 +189,57 @@ describe('Connections Duck', () => {
         expect(triggerState.length).toEqual(1)
         expect(triggerState[0]).toEqual(newConnectorData)
       })
+
+      it('should not add jobs to the list', () => {
+        const initialState = {
+          creation: null,
+          konnectors: {
+            'my-kon': {
+              triggers: {
+                data: [
+                  {
+                    _id: 'trigger-id',
+                    _type: 'io.cozy.triggers',
+                    message: {
+                      konnector: 'my-kon',
+                      account: 'account 1'
+                    },
+                    current_state: {
+                      status: 'done',
+                      last_error: null,
+                      last_execution: '2019-01-01'
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+
+        const newConnectorData = {
+          _id: 'job-id',
+          _type: 'io.cozy.jobs',
+          worker: 'konnector',
+          trigger_id: 'trigger-id',
+          state: 'done',
+          error: null,
+          queued_at: '2019-02-01',
+          message: {
+            konnector: 'my-kon'
+          }
+        }
+
+        const newState = connections(initialState, {
+          type: RECEIVE_DATA,
+          response: {
+            data: [newConnectorData]
+          }
+        })
+
+        const triggerState = get(newState, 'konnectors.my-kon.triggers.data')
+        expect(triggerState.length).toEqual(1)
+        expect(triggerState[0].current_state).toBeDefined()
+      })
     })
   })
 


### PR DESCRIPTION
We added a new bit in the redux store to store trigger informations, but the same reducer also receives job informations that accidentally ended up in the same part of the store, causing problems.

I think it would be best to isolate this new part in a separate slice of the store, but I'm not familiar enough with the code base to make such a change at the moment. Instead I patched the issue and started adding tests to this big reducer.