### PR TITLE
fix: Better redirect after closing modal

### DIFF
--- a/src/components/AccountPicker.jsx
+++ b/src/components/AccountPicker.jsx
@@ -20,7 +20,7 @@ class AccountPicker extends Component {
       <KonnectorModal
         konnector={konnectorWithtriggers}
         dismissAction={() => {
-          history.push('/')
+          history.push('/connected')
         }}
         createAction={() => {
           history.push(`/connected/${konnector.slug}/new`)


### PR DESCRIPTION
Redirecting to `/` triggers a re-render of all components, including fetching the apps. The base route is actually `/connected` in this context.