### PR TITLE
fix(Konnector): Don't crash if there is no trigger

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -60,18 +60,16 @@ export const getTriggerByKonnectorAndAccount = (state, konnector, account) => {
 }
 
 export const getTriggersByKonnector = (state, konnectorSlug) => {
-  const triggers = Object.keys(state.cozy.documents['io.cozy.triggers']).reduce(
-    (acc, key) => {
-      const document = state.cozy.documents['io.cozy.triggers'][key]
-      if (
-        document.worker === 'konnector' &&
-        get(document, 'message.konnector') === konnectorSlug
-      ) {
-        acc.push(document)
-      }
-      return acc
-    },
-    []
-  )
+  const triggersInState = state.cozy.documents['io.cozy.triggers'] || {}
+  const triggers = Object.keys(triggersInState).reduce((acc, key) => {
+    const document = state.cozy.documents['io.cozy.triggers'][key]
+    if (
+      document.worker === 'konnector' &&
+      get(document, 'message.konnector') === konnectorSlug
+    ) {
+      acc.push(document)
+    }
+    return acc
+  }, [])
   return triggers
 }


### PR DESCRIPTION
When there is no trigger on the instance, clicking on a konnector was crashing because we tried to convert `undefined` to an object in `getTriggersByKonnector`.