### PR TITLE
fix: remove edf specific "temporary" error message

### DIFF
--- a/src/components/Banners/ErrorMessage.jsx
+++ b/src/components/Banners/ErrorMessage.jsx
@@ -77,20 +77,6 @@ export class ErrorMessage extends Component {
       )
     }
 
-    // FIXME temporarily, only for EDF
-    if (konnector.slug === 'edf') {
-      return (
-        <Infos
-          className="u-maw-none"
-          text={t('status.edf.maintenance', {
-            supportLink: t('status.edf.support_link')
-          })}
-          title={t('status.interrupted')}
-          isImportant
-        />
-      )
-    }
-
     return (
       <Infos
         actionButton={this.renderButton(error)}


### PR DESCRIPTION
This was from a time where we did not have a registry yet.
And this error message is displayed for EDF on any error.