### PR TITLE
feat: Added an optional footer

### DIFF
--- a/src/components/FooterLogo.jsx
+++ b/src/components/FooterLogo.jsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import get from 'lodash/get'
+import { withClient } from 'cozy-client'
+
+const fetchHomeLogos = async client => {
+  try {
+    const rootURL = client.getStackClient().uri
+    const context = await client
+      .getStackClient()
+      .fetchJSON('GET', '/settings/context')
+    const logos = get(context, 'data.attributes.home_logos', {})
+
+    return Object.keys(logos).reduce((acc, logoSrc) => {
+      acc[`${rootURL}${logoSrc}`] = logos[logoSrc]
+      return acc
+    }, {})
+  } catch (error) {
+    return {}
+  }
+}
+
+export class FooterLogo extends React.Component {
+  state = {
+    logos: {}
+  }
+
+  async componentDidMount() {
+    const logos = await fetchHomeLogos(this.props.client)
+    this.setState({ logos })
+  }
+
+  render() {
+    const { logos } = this.state
+    return Object.keys(logos).length === 0 ? (
+      false
+    ) : (
+      <div className="u-maw-7 u-m-auto u-pv-1 u-mt-1 u-ta-center">
+        {Object.entries(logos).map(([logoSrc, logoAlt]) => (
+          <img
+            key={logoSrc}
+            src={logoSrc}
+            alt={logoAlt}
+            className="u-ph-1 u-pv-half"
+          />
+        ))}
+      </div>
+    )
+  }
+}
+
+PropTypes.propTypes = {
+  client: PropTypes.object
+}
+
+export default withClient(FooterLogo)

--- a/src/components/FooterLogo.spec.jsx
+++ b/src/components/FooterLogo.spec.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { FooterLogo } from './FooterLogo'
+
+describe('FooterLogo', () => {
+  const mockClient = {
+    getStackClient: () => mockClient,
+    uri: 'http://cozy.example.com',
+    fetchJSON: jest.fn()
+  }
+
+  it('should render nothing when there are no logos', () => {
+    mockClient.fetchJSON.mockResolvedValue({
+      data: {
+        attributes: {}
+      }
+    })
+    const component = shallow(<FooterLogo client={mockClient} />)
+    expect(component.getElement()).toEqual(null)
+  })
+
+  it('should render multiple logos', async () => {
+    mockClient.fetchJSON.mockResolvedValue({
+      data: {
+        attributes: {
+          home_logos: {
+            '/path1/cozy.svg': 'alt text 1',
+            '/path/2/cozy-with_complex-name.svg': 'alt text 2'
+          }
+        }
+      }
+    })
+    const component = shallow(<FooterLogo client={mockClient} />)
+    await new Promise(resolve => setImmediate(resolve)) // await the didMount
+    expect(component.getElement()).toMatchSnapshot()
+  })
+})

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -10,6 +10,7 @@ import Applications from 'components/Applications'
 import ScrollToTopOnMount from 'components/ScrollToTopOnMount'
 import Services from 'components/Services'
 import { isTutorial, display as displayTutorial } from 'lib/tutorial'
+import FooterLogo from 'components/FooterLogo'
 
 class Home extends Component {
   componentDidMount() {
@@ -38,15 +39,16 @@ class Home extends Component {
     return (
       <Main>
         <ScrollToTopOnMount target={wrapper} />
-        <Content>
+        <Content className="u-flex">
           <div
-            className={classNames('col-content', {
+            className={classNames('col-content', 'u-flex-grow-1', {
               'has-custom-background': false
             })}
           >
             <Applications />
             <Services />
           </div>
+          <FooterLogo />
         </Content>
         <Route path="/connected/:konnectorSlug" component={Konnector} />
         <Redirect from="/connected/*" to="/connected" />

--- a/src/components/__snapshots__/FooterLogo.spec.jsx.snap
+++ b/src/components/__snapshots__/FooterLogo.spec.jsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FooterLogo should render multiple logos 1`] = `
+<div
+  className="u-maw-7 u-m-auto u-pv-1 u-mt-1 u-ta-center"
+>
+  <img
+    alt="alt text 1"
+    className="u-ph-1 u-pv-half"
+    src="http://cozy.example.com/path1/cozy.svg"
+  />
+  <img
+    alt="alt text 2"
+    className="u-ph-1 u-pv-half"
+    src="http://cozy.example.com/path/2/cozy-with_complex-name.svg"
+  />
+</div>
+`;

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -75,6 +75,7 @@ class App extends Component {
     return (
       <Layout
         monoColumn
+        className="u-flex u-flex-column"
         ref={
           isReady
             ? div => {

--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -2,6 +2,16 @@
 @require 'settings/breakpoints.styl'
 @require 'settings/palette.styl'
 
+// overriding the general layout to allow a sticky footer
+html,
+body
+    height 100%
+    +medium-screen()
+        height 100%
+
+        main > [role=main].u-flex
+            display flex
+
 body
     // Allows horizontal swipe on mobile
     +mobile()


### PR DESCRIPTION
Adds a footer at the bottom of the home page with some logos. The logos are defined in the cozy's context, and refer to dynamic assets.

I had to change the general layout of the app in order to have a sticky footer, but it should be the same as before when there isn't a footer.