### PR TITLE
fix: Add /assets prefix for logos

### DIFF
--- a/src/components/FooterLogo.jsx
+++ b/src/components/FooterLogo.jsx
@@ -12,7 +12,7 @@ const fetchHomeLogos = async client => {
     const logos = get(context, 'data.attributes.home_logos', {})
 
     return Object.keys(logos).reduce((acc, logoSrc) => {
-      acc[`${rootURL}${logoSrc}`] = logos[logoSrc]
+      acc[`${rootURL}/assets${logoSrc}`] = logos[logoSrc]
       return acc
     }, {})
   } catch (error) {

--- a/src/components/__snapshots__/FooterLogo.spec.jsx.snap
+++ b/src/components/__snapshots__/FooterLogo.spec.jsx.snap
@@ -7,12 +7,12 @@ exports[`FooterLogo should render multiple logos 1`] = `
   <img
     alt="alt text 1"
     className="u-ph-1 u-pv-half"
-    src="http://cozy.example.com/path1/cozy.svg"
+    src="http://cozy.example.com/assets/path1/cozy.svg"
   />
   <img
     alt="alt text 2"
     className="u-ph-1 u-pv-half"
-    src="http://cozy.example.com/path/2/cozy-with_complex-name.svg"
+    src="http://cozy.example.com/assets/path/2/cozy-with_complex-name.svg"
   />
 </div>
 `;


### PR DESCRIPTION
When we add a dynamic asset in a stack, we provide a URL, like `/logos/1.svg`. However, when using it from a webpage, the actual path to use is `/assets/logos/1.svg`.

This is a detail that the front-end should know about, not the context configuration file. With this PR the context data can reference the exact path used in the stack, and not worry about the `/assets` prefix.