### PR TITLE
fix: Interapp window init

### DIFF
--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const root = document.querySelector('[role=application]')
   const appData = root.dataset
 
-  const client = new CozyClient({
+  const legacyClient = new CozyClient({
     cozyURL: `//${appData.cozyDomain}`,
     token: appData.cozyToken
   })
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', () => {
   })
 
   // store
-  const store = configureStore(client, context, {
+  const store = configureStore(legacyClient, cozyClient, context, {
     lang
   })
 


### PR DESCRIPTION
In b082ab60a6714f6d2fc2df1f37e3be464fe7b72b we changed the signature of `configureStore`, but didn't update the calling code in the intents.