### PR TITLE
fix: Remove blanket redirect

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import classNames from 'classnames'
-import { Route, withRouter, Redirect } from 'react-router'
+import { Route, withRouter } from 'react-router'
 
 import { translate } from 'cozy-ui/react/I18n'
 import { Main, Content } from 'cozy-ui/react/Layout'
@@ -51,7 +51,6 @@ class Home extends Component {
           <FooterLogo />
         </Content>
         <Route path="/connected/:konnectorSlug" component={Konnector} />
-        <Redirect from="/connected/*" to="/connected" />
       </Main>
     )
   }


### PR DESCRIPTION
There are links in other apps that open on a konnector modal, but because of the redirect the user always ends up at the root fo the home. Removing the redirect fixes the problem.

The redirect was there to prevent loading non-existing pages, I will create a PR in harvest to prevent this more finely.