### PR TITLE
fix: Pass exact root route to harvest

### DIFF
--- a/src/components/Konnector.jsx
+++ b/src/components/Konnector.jsx
@@ -16,7 +16,7 @@ class Konnector extends Component {
 
     return (
       <HarvestRoutes
-        konnectorRoot="/connected/:konnectorSlug"
+        konnectorRoot={`/connected/${konnector.slug}`}
         konnector={konnectorWithtriggers}
         onDismiss={() => history.push('/connected')}
       />


### PR DESCRIPTION
This goes with https://github.com/cozy/cozy-libs/pull/828. We were passing the root with a variable in it — it works, but we couldn't use the root to redirect to it because we would literally end up on `#/connected/:konnectorSlug`.

Now we're passing the actual slug, eg. `/connected/edf`. Works a bit better!