### PR TITLE
chore: Remove Deezer of long term maintenance in home

### DIFF
--- a/src/config/maintenance.json
+++ b/src/config/maintenance.json
@@ -27,13 +27,6 @@
     "en": "Darty added a protection system that blocks your Cozy's access to your data. As a result the connector is not able to get your bills back from Darty.<br/>We are trying to clear the situation and you will be noticed when it is fixed."
     }
   },
-  "deezer" : {
-    "longTerm": true,
-    "message": {
-      "fr": "Deezer a ajouté un mécanisme bloquant l'accès à vos données par votre Cozy. Le connecteur n'est donc pas actuellement en mesure de récupérer votre historique de factures détenu par Deezer.<br/>Nous tentons de rétablir le service et vous informerons si la situation évolue.",
-      "en": "Deezer added a protection system that blocks your Cozy's access to your data. As a result the connector is not able to get your bill history back from Deezer.<br/>We are trying to clear the situation and you will be noticed when it is fixed."
-    }
-  },
   "deliveroo": {
     "longTerm": true,
     "message": {


### PR DESCRIPTION
Deezer connector is now ready to be remove from maintenance.

This PR does that in home. 
Publication has to be synchronised with registry maintenance removing, please warn me.