### PR TITLE
feat: Redux logger behind a flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "cozy-client": "7.5.0",
     "cozy-device-helper": "1.7.5",
     "cozy-doctypes": "1.67.0",
-    "cozy-flags": "1.9.3",
+    "cozy-flags": "1.10.0",
     "cozy-harvest-lib": "1.10.1",
     "cozy-realtime": "3.1.4",
     "cozy-scripts": "1.13.2",

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 import PropTypes from 'react-proptypes'
 import { Route, Switch, Redirect, withRouter } from 'react-router-dom'
 
-import { enable as enableFlags } from 'cozy-flags'
+import flag, { enable as enableFlags } from 'cozy-flags'
 import Alerter from 'cozy-ui/react/Alerter'
 import { Sprite as IconSprite } from 'cozy-ui/react/Icon'
 import { Layout, Main, Content } from 'cozy-ui/react/Layout'
@@ -18,6 +18,8 @@ import ConnectionsQueue from 'ducks/connections/components/queue/index'
 
 const IDLE = 'idle'
 const FETCHING_CONTEXT = 'FETCHING_CONTEXT'
+
+window.flag = window.flag || flag
 
 class App extends Component {
   state = {

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -5,6 +5,7 @@ import konnectorsI18nMiddleware from 'lib/middlewares/konnectorsI18n'
 import thunkMiddleware from 'redux-thunk'
 
 import CollectStore from 'lib/CollectStore'
+import flag from 'cozy-flags'
 import getReducers from 'reducers'
 
 const configureStore = (legacyClient, cozyClient, context, options = {}) => {
@@ -14,12 +15,15 @@ const configureStore = (legacyClient, cozyClient, context, options = {}) => {
   const reduxStore = createStore(
     getReducers(),
     composeEnhancers(
-      applyMiddleware.apply(this, [
-        cozyMiddleware(legacyClient),
-        konnectorsI18nMiddleware(options.lang),
-        thunkMiddleware,
-        createLogger()
-      ])
+      applyMiddleware.apply(
+        this,
+        [
+          cozyMiddleware(legacyClient),
+          konnectorsI18nMiddleware(options.lang),
+          thunkMiddleware,
+          flag('redux-logger') ? createLogger() : null
+        ].filter(Boolean)
+      )
     )
   )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3471,10 +3471,10 @@ cozy-doctypes@1.67.0, cozy-doctypes@^1.67.0:
     lodash "4.17.15"
     prop-types "^15.7.2"
 
-cozy-flags@1.9.3:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-1.9.3.tgz#654569eb1db6454417725d8509ad3d14d3b5c2e4"
-  integrity sha512-3FaqsfvaVRZjIvra3TgS6s/nR2ylXxUl3VabquguaZD3uVcnj3znlm6B7nRPG9KP7bzzgZTdw7tqF8MX88hbMg==
+cozy-flags@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-1.10.0.tgz#5aa41684eade9c445a4807608ec3152e0e198f16"
+  integrity sha512-Pv6qHpfSIrBBE2m5Bdt3LQLLg2blH1uMwsW8pnueL1+r27dVQNcRJKwLRo3dfDTaxFHN+ZIjl+5Oos8FiH3CgQ==
   dependencies:
     microee "^0.0.6"
 


### PR DESCRIPTION
Redux logger pollutes the console with everything that is happening.
It trains us to ignore what is in the console. With cozy-flags, we
can put it back if we want `flag('redux-logger', true)` in the console.