### PR TITLE
fix: Set maintenance hook dependencies to avoid re-renders and re-que…

### DIFF
--- a/src/hooks/withAppsInMaintenance.jsx
+++ b/src/hooks/withAppsInMaintenance.jsx
@@ -10,11 +10,10 @@ const useAppsInMaintenance = client => {
   useEffect(() => {
     const fetchData = async () => {
       const newAppsInMaintenance = await registry.fetchAppsInMaintenance()
-      if (newAppsInMaintenance.length !== appsInMaintenance.length)
-        setAppsInMaintenance(newAppsInMaintenance)
+      setAppsInMaintenance(newAppsInMaintenance)
     }
     fetchData()
-  })
+  }, [])
 
   return appsInMaintenance
 }


### PR DESCRIPTION
The conditional setState prevented re-renders, but not concurrent fetches — specifying the dependencies does both!