### PR TITLE
fix(intents): Make harvest vault unlocker work

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cozy-doctypes": "1.67.0",
     "cozy-flags": "1.9.3",
     "cozy-harvest-lib": "1.10.1",
-    "cozy-keys-lib": "1.9.6",
+    "cozy-keys-lib": "1.10.0",
     "cozy-logger": "1.6.0",
     "cozy-realtime": "3.1.4",
     "cozy-scripts": "1.13.2",

--- a/src/components/KonnectorInstall.jsx
+++ b/src/components/KonnectorInstall.jsx
@@ -42,6 +42,7 @@ export class KonnectorInstall extends Component {
       account,
       konnector,
       legacySuccess,
+      onCancel,
       onDone,
       successMessage,
       successMessages,
@@ -77,6 +78,8 @@ export class KonnectorInstall extends Component {
             konnector={konnector}
             onLoginSuccess={this.handleLoginSuccess}
             onSuccess={this.handleSuccess}
+            vaultClosable={false}
+            onVaultDismiss={onCancel}
           />
         </div>
       </div>

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -98,6 +98,7 @@ class AccountConnection extends Component {
       handleConnectionSuccess,
       konnector,
       error,
+      onCancel,
       onDone,
       queued,
       t,
@@ -128,6 +129,7 @@ class AccountConnection extends Component {
           <KonnectorInstall
             account={createdAccount}
             connector={konnector}
+            onCancel={onCancel}
             onDone={onDone}
             onLoginSuccess={this.handleLoginSuccess}
             onSuccess={handleConnectionSuccess}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3620,10 +3620,10 @@ cozy-interapp@0.4.9:
   resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.4.9.tgz#5ef68d54755cc99c3e154e5a4646b68cbe5f16fd"
   integrity sha512-skyjrewnMu5zMfST7vTNGl3jsuWae1Iwfdev6pW9RLgb58M7oBSpsIa3ofRANv5tx0XVQDVSEzWvbFQ84WJPSg==
 
-cozy-keys-lib@1.9.6:
-  version "1.9.6"
-  resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-1.9.6.tgz#9e286667aae2c7fc3b672130cc035d54537625eb"
-  integrity sha512-m09pfyntYET7Ii4OaA4FjAjnIZq0RaIkWtUOGAKdGsETsIKieF8uNLdd/TRy26RG5TvUiO6mBP0o+bS23A9S7A==
+cozy-keys-lib@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-1.10.0.tgz#1fadf7df78fe4a1d5a77a4741b7b24ac1e0fb2e4"
+  integrity sha512-wn0xYDRqNaBOR86sqdqgcLLCRUxSa7312qx9uJSTARA0aKhYPUBfGm5MfIkKzHUyxnArId2nm/VLVq7HWd5drg==
   dependencies:
     "@aspnet/signalr" "^1.1.4"
     "@aspnet/signalr-protocol-msgpack" "^1.1.0"


### PR DESCRIPTION
Make the vault unlocker not closable by a modal cross but only by the « quit » button