### PR TITLE
fix: Reinstate hiding error through flag

### DIFF
--- a/src/components/KonnectorTile.jsx
+++ b/src/components/KonnectorTile.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux'
 import { NavLink, withRouter } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import get from 'lodash/get'
+import flag from 'cozy-flags'
 
 import AppIcon from 'cozy-ui/react/AppIcon'
 import { translate } from 'cozy-ui/react/I18n'
@@ -76,14 +77,17 @@ export class KonnectorTile extends Component {
         color: palette.pomegranate
       }
     }
+    const hideKonnectorErrors = flag('hide_konnector_errors') // flag used for some demo instances where we want to ignore all konnector errors
 
-    const status = getKonnectorStatus({
-      konnector,
-      isInMaintenance,
-      error,
-      userError,
-      accountsCount
-    })
+    const status = hideKonnectorErrors
+      ? STATUS.OK
+      : getKonnectorStatus({
+          konnector,
+          isInMaintenance,
+          error,
+          userError,
+          accountsCount
+        })
     const { className: statusClassName, icon, color } = get(
       statusThemes,
       status,


### PR DESCRIPTION
I removed the use of this flag [here](https://github.com/cozy/cozy-home/pull/1369/files#diff-c49bd336f6dba66952b99f88389304e9R61), thinking it wasn't used anymore… but it was. So here it is back again ! 