### PR TITLE
chore: Unbump version

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -11,7 +11,7 @@
     "name": "Cozy Cloud",
     "url": "https://cozy.io"
   },
-  "version": "1.21.0",
+  "version": "1.20.0",
   "licence": "AGPL-3.0",
   "permissions": {
     "apps": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-home",
-  "version": "1.21.0",
+  "version": "1.20.0",
   "main": "src/index.jsx",
   "scripts": {
     "tx": "tx pull --all || true",


### PR DESCRIPTION
Earlier, i bumped the version number to 1.21.0, but we haven't release v1.20.0 yet.