### PR TITLE
Remove spinner from "add service" button

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cozy-harvest-lib": "1.14.2",
     "cozy-realtime": "3.1.4",
     "cozy-scripts": "1.13.2",
-    "cozy-ui": "25.13.0",
+    "cozy-ui": "26.7.0",
     "date-fns": "1.30.1",
     "husky": "1.3.1",
     "intro.js-fix-cozy": "2.9.5",

--- a/src/components/AddServiceTile.jsx
+++ b/src/components/AddServiceTile.jsx
@@ -4,10 +4,14 @@ import Icon from 'cozy-ui/react/Icon'
 import AppLinker, { generateWebLink } from 'cozy-ui/react/AppLinker'
 import palette from 'cozy-ui/stylus/settings/palette.json'
 
+import useAppDataset from 'hooks/useAppDataset'
+
 const AddServiceTile = ({ label, client }) => {
   const nativePath = '/discover/?type=konnector'
   const slug = 'store'
   const cozyURL = new URL(client.getStackClient().uri)
+  const { cozySubdomainType } = useAppDataset()
+  const subDomainType = cozySubdomainType === '1' ? 'flat' : 'nested'
 
   return (
     <AppLinker
@@ -15,8 +19,9 @@ const AddServiceTile = ({ label, client }) => {
       nativePath={nativePath}
       href={generateWebLink({
         cozyUrl: cozyURL.origin,
-        slug: slug,
-        nativePath: nativePath
+        slug,
+        nativePath,
+        subDomainType
       })}
     >
       {({ onClick, href }) => (

--- a/src/components/AddServiceTile.jsx
+++ b/src/components/AddServiceTile.jsx
@@ -1,38 +1,34 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { withClient } from 'cozy-client'
-
 import Icon from 'cozy-ui/react/Icon'
 import AppLinker, { generateWebLink } from 'cozy-ui/react/AppLinker'
 import palette from 'cozy-ui/stylus/settings/palette.json'
 
-export class AddServiceTile extends Component {
-  render() {
-    const { label, client } = this.props
-    const nativePath = '/discover/?type=konnector'
-    const slug = 'store'
-    const cozyURL = new URL(client.getStackClient().uri)
+const AddServiceTile = ({ label, client }) => {
+  const nativePath = '/discover/?type=konnector'
+  const slug = 'store'
+  const cozyURL = new URL(client.getStackClient().uri)
 
-    return (
-      <AppLinker
-        slug={'store'}
-        nativePath={nativePath}
-        href={generateWebLink({
-          cozyUrl: cozyURL.origin,
-          slug: slug,
-          nativePath: nativePath
-        })}
-      >
-        {({ onClick, href }) => (
-          <a onClick={onClick} href={href} className="item item--add-service">
-            <div className="item-icon">
-              <Icon icon="plus" size={16} color={palette['dodgerBlue']} />
-            </div>
-            <span className="item-title">{label}</span>
-          </a>
-        )}
-      </AppLinker>
-    )
-  }
+  return (
+    <AppLinker
+      slug={'store'}
+      nativePath={nativePath}
+      href={generateWebLink({
+        cozyUrl: cozyURL.origin,
+        slug: slug,
+        nativePath: nativePath
+      })}
+    >
+      {({ onClick, href }) => (
+        <a onClick={onClick} href={href} className="item item--add-service">
+          <div className="item-icon">
+            <Icon icon="plus" size={16} color={palette['dodgerBlue']} />
+          </div>
+          <span className="item-title">{label}</span>
+        </a>
+      )}
+    </AppLinker>
+  )
 }
 
 export default withClient(AddServiceTile)

--- a/src/components/AddServiceTile.jsx
+++ b/src/components/AddServiceTile.jsx
@@ -1,53 +1,38 @@
-/* global cozy */
 import React, { Component } from 'react'
+import { withClient } from 'cozy-client'
 
 import Icon from 'cozy-ui/react/Icon'
+import AppLinker, { generateWebLink } from 'cozy-ui/react/AppLinker'
 import palette from 'cozy-ui/stylus/settings/palette.json'
 
 export class AddServiceTile extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      redirecting: false
-    }
-
-    this.toggleRedirect = this.toggleRedirect.bind(this)
-  }
-
-  async toggleRedirect() {
-    if (this.state.redirecting) return // don't toggle twice
-    this.setState(() => ({ redirecting: true }))
-    try {
-      await cozy.client.intents.redirect('io.cozy.apps', { type: 'konnector' })
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error(error)
-      this.setState({
-        redirecting: false
-      })
-    }
-  }
-
   render() {
-    const { label } = this.props
-    const { redirecting } = this.state
+    const { label, client } = this.props
+    const nativePath = '/discover/?type=konnector'
+    const slug = 'store'
+    const cozyURL = new URL(client.getStackClient().uri)
+
     return (
-      <div
-        aria-busy={redirecting}
-        className="item item--add-service"
-        onClick={this.toggleRedirect}
+      <AppLinker
+        slug={'store'}
+        nativePath={nativePath}
+        href={generateWebLink({
+          cozyUrl: cozyURL.origin,
+          slug: slug,
+          nativePath: nativePath
+        })}
       >
-        {redirecting ? (
-          <Icon icon="spinner" className="item-icon" color="grey" spin />
-        ) : (
-          <div className="item-icon">
-            <Icon icon="plus" size={16} color={palette['dodgerBlue']} />
-          </div>
+        {({ onClick, href }) => (
+          <a onClick={onClick} href={href} className="item item--add-service">
+            <div className="item-icon">
+              <Icon icon="plus" size={16} color={palette['dodgerBlue']} />
+            </div>
+            <span className="item-title">{label}</span>
+          </a>
         )}
-        <span className="item-title">{label}</span>
-      </div>
+      </AppLinker>
     )
   }
 }
 
-export default AddServiceTile
+export default withClient(AddServiceTile)

--- a/src/hooks/useAppDataset.jsx
+++ b/src/hooks/useAppDataset.jsx
@@ -1,0 +1,14 @@
+import { useState, useEffect } from 'react'
+
+const useAppDataset = () => {
+  const [data, setData] = useState({})
+
+  useEffect(() => {
+    const root = document.querySelector('[role=application]')
+    setData(root.dataset)
+  }, [])
+
+  return data
+}
+
+export default useAppDataset

--- a/src/targets/browser/index.ejs
+++ b/src/targets/browser/index.ejs
@@ -31,6 +31,7 @@
   data-cozy-app-slug="{{.AppSlug}}"
   data-cozy-tracking="{{.Tracking}}"
   data-cozy-icon-path="{{.IconPath}}"
+  data-cozy-subdomain-type="{{.SubDomain}}"
   >
 <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
   <script src="<%- file %>"></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3200,10 +3200,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@25.13.0:
-  version "25.13.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-25.13.0.tgz#92d2211feb64d8855feb0b1f795d06e2477bb943"
-  integrity sha512-/CBCBM/ANfmSfL9rBp4A8hyX9oZpSRuZ+YYrhLQodwblQHOz7wcnjFocJUO0TyhROp7fdDL9QiWZrCKC7cSvhQ==
+cozy-ui@26.7.0:
+  version "26.7.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-26.7.0.tgz#1a497d595c522b4e1068ab124cd57f79012c33d2"
+  integrity sha512-yxlODK1uKFuiebpsW5XOc18oIF9vujc6d60UpE3RFjtvZ8zqL3xvsu+3lPZHPzbP/6l3LivFK+g/RkRAQfYQbg==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"


### PR DESCRIPTION
The "add service" button was making an interapp request to find the URL of the store, and displayed a spinner while the request was being made. Instead it's now a normal link, without spinner, like the other tiles.