### PR TITLE
fix: Load the cozy font

### DIFF
--- a/src/targets/browser/index.ejs
+++ b/src/targets/browser/index.ejs
@@ -12,11 +12,9 @@
   <link rel="stylesheet" href="<%- file %>">
 <% }); %>
 {{.ThemeCSS}}
+<link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css">
 <% if (__STACK_ASSETS__) { %>
 {{.CozyClientJS}}
-<% } else { %>
-  <%/* Perf: we don't load the font twice as it is already provided by the CozyBar */%>
-  <link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css">
 <% } %>
 </head>
 <body>


### PR DESCRIPTION
Since we don't have a cozy-bar on the page anymore, we need to load the Lato font explicitly.