### PR TITLE
fix: Better footer logo alignment

### DIFF
--- a/src/components/FooterLogo.jsx
+++ b/src/components/FooterLogo.jsx
@@ -35,13 +35,13 @@ export class FooterLogo extends React.Component {
     return Object.keys(logos).length === 0 ? (
       false
     ) : (
-      <div className="u-maw-7 u-m-auto u-pv-1 u-mt-1 u-ta-center">
+      <div className="u-maw-7 u-mh-auto u-mt-1 u-pv-1 u-flex u-flex-row u-flex-items-center u-flex-justify-center u-flex-wrap">
         {Object.entries(logos).map(([logoSrc, logoAlt]) => (
           <img
             key={logoSrc}
             src={logoSrc}
             alt={logoAlt}
-            className="u-ph-1 u-pv-half"
+            className="u-ph-1 u-pv-half u-mah-5"
           />
         ))}
       </div>

--- a/src/components/__snapshots__/FooterLogo.spec.jsx.snap
+++ b/src/components/__snapshots__/FooterLogo.spec.jsx.snap
@@ -2,16 +2,16 @@
 
 exports[`FooterLogo should render multiple logos 1`] = `
 <div
-  className="u-maw-7 u-m-auto u-pv-1 u-mt-1 u-ta-center"
+  className="u-maw-7 u-mh-auto u-mt-1 u-pv-1 u-flex u-flex-row u-flex-items-center u-flex-justify-center u-flex-wrap"
 >
   <img
     alt="alt text 1"
-    className="u-ph-1 u-pv-half"
+    className="u-ph-1 u-pv-half u-mah-5"
     src="http://cozy.example.com/assets/path1/cozy.svg"
   />
   <img
     alt="alt text 2"
-    className="u-ph-1 u-pv-half"
+    className="u-ph-1 u-pv-half u-mah-5"
     src="http://cozy.example.com/assets/path/2/cozy-with_complex-name.svg"
   />
 </div>


### PR DESCRIPTION
Slightly changing the layout of the footer logos — our only use case now involves logos with very different ratios, so flexbox should do the work a bit better.

<img width="1012" alt="Capture d'écran 2019-11-13 09 42 17" src="https://user-images.githubusercontent.com/2261445/68747651-46254800-05fb-11ea-9693-919d9fce2ace.png">
