### PR TITLE
fix: Subdomain type variable

### DIFF
--- a/src/components/AddServiceTile.jsx
+++ b/src/components/AddServiceTile.jsx
@@ -11,7 +11,6 @@ const AddServiceTile = ({ label, client }) => {
   const slug = 'store'
   const cozyURL = new URL(client.getStackClient().uri)
   const { cozySubdomainType } = useAppDataset()
-  const subDomainType = cozySubdomainType === '1' ? 'flat' : 'nested'
 
   return (
     <AppLinker
@@ -21,7 +20,7 @@ const AddServiceTile = ({ label, client }) => {
         cozyUrl: cozyURL.origin,
         slug,
         nativePath,
-        subDomainType
+        cozySubdomainType
       })}
     >
       {({ onClick, href }) => (


### PR DESCRIPTION
I must have checked out an earlier version of the stack, since I received a `1` or `2` value. But now we receive `nested` or `flat`, so it's a bit easier !