### PR TITLE
fix: Use cached version of the default wallpaper

### DIFF
--- a/src/components/HeroHeader.jsx
+++ b/src/components/HeroHeader.jsx
@@ -7,7 +7,7 @@ import { withBreakpoints } from 'cozy-ui/transpiled/react'
 import { translate } from 'cozy-ui/react/I18n'
 import useInstanceSettings from 'hooks/useInstanceSettings'
 import useCustomWallpaper from 'hooks/useCustomWallpaper'
-import homeConfig from 'config/collect'
+import useAppDataset from 'hooks/useAppDataset'
 
 const HeroHeader = ({ t, client, breakpoints: { isMobile } }) => {
   const {
@@ -16,10 +16,11 @@ const HeroHeader = ({ t, client, breakpoints: { isMobile } }) => {
   } = useCustomWallpaper(client)
   const rootURL = client.getStackClient().uri
   const { host } = new URL(rootURL)
+  const { cozyDefaultWallpaper } = useAppDataset()
+
   let backgroundURL = null
   if (fetchStatus !== 'loading')
-    backgroundURL =
-      wallpaperLink || `${rootURL}${homeConfig.defaultWallpaperPath}`
+    backgroundURL = wallpaperLink || cozyDefaultWallpaper
 
   const { data: instanceSettings } = useInstanceSettings(client)
   const publicName = get(instanceSettings, 'public_name', '')

--- a/src/config/collect.json
+++ b/src/config/collect.json
@@ -2,6 +2,5 @@
   "defaultDateFormat": "MM/DD/YYYY",
   "defaultTriggerTimeInterval": [0, 5],
   "filteredApps": ["home"],
-  "defaultWallpaperPath": "/assets/images/default-wallpaper.jpg",
   "customWallpaperPath": "/Photos/Settings/Wallpaper.jpg"
 }

--- a/src/targets/browser/index.ejs
+++ b/src/targets/browser/index.ejs
@@ -30,6 +30,7 @@
   data-cozy-tracking="{{.Tracking}}"
   data-cozy-icon-path="{{.IconPath}}"
   data-cozy-subdomain-type="{{.SubDomain}}"
+  data-cozy-default-wallpaper="{{.DefaultWallpaper}}"
   >
 <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
   <script src="<%- file %>"></script>


### PR DESCRIPTION
Using the [new DefaultWallpaper](https://github.com/cozy/cozy-stack/pull/2191) variable gives a wallpaper URL that has cache control on it.