### PR TITLE
fix: Candidate konnector slugs

### DIFF
--- a/src/config/candidates.json
+++ b/src/config/candidates.json
@@ -1,11 +1,11 @@
 {
   "konnectors": [
     { "slug": "ameli", "name": "Ameli" },
-    { "slug": "impots", "name": "Impôts.gouv.fr" }
+    { "slug": "caf", "name": "CAF" }
   ],
   "categories": {
-    "banking": ["hsbc119", "caissedepargne1", "ing", "cic45"],
-    "isp": ["sfr", "free", "orange", "bouygues"],
+    "banking": ["hsbc119", "caissedepargne1", "ingdirect95", "cic45"],
+    "isp": ["sfr", "free", "orange", "bouyguestelecom"],
     "insurance": ["maifecheancier", "alan", "harmonie", "macif"],
     "energy": ["engie", "planeteoui", "veoliaeau", "ekwateur"]
   }

--- a/test/components/__snapshots__/NoServicesList.spec.jsx.snap
+++ b/test/components/__snapshots__/NoServicesList.spec.jsx.snap
@@ -10,8 +10,8 @@ exports[`NoServicesList component should render service suggestions 1`] = `
       slug="ameli"
     />
     <Wrapper
-      name="Impôts.gouv.fr"
-      slug="impots"
+      name="CAF"
+      slug="caf"
     />
     <Wrapper
       category="banking"
@@ -19,7 +19,7 @@ exports[`NoServicesList component should render service suggestions 1`] = `
         Array [
           "hsbc119",
           "caissedepargne1",
-          "ing",
+          "ingdirect95",
           "cic45",
         ]
       }
@@ -31,7 +31,7 @@ exports[`NoServicesList component should render service suggestions 1`] = `
           "sfr",
           "free",
           "orange",
-          "bouygues",
+          "bouyguestelecom",
         ]
       }
     />


### PR DESCRIPTION
Some of the slugs were incorrect (ing and bouygues), and `impots.gouv.fr` has just been switched toi maintenance mode so we want to offer a replacement.