### PR TITLE
Filter apps through context

### DIFF
--- a/src/components/Applications.jsx
+++ b/src/components/Applications.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 
 import { Query } from 'cozy-client'
 import { translate } from 'cozy-ui/react/I18n'
+import flag from 'cozy-flags'
 
 import AppTile from 'components/AppTile'
 import LoadingPlaceholder from 'components/LoadingPlaceholder'
@@ -52,7 +53,8 @@ export class Applications extends PureComponent {
                 .filter(
                   app =>
                     app.state !== 'hidden' &&
-                    !homeConfig.filteredApps.includes(app.slug)
+                    !homeConfig.filteredApps.includes(app.slug) &&
+                    !flag(`home_hidden_apps.${app.slug.toLowerCase()}`) // can be set in the context with `home_hidden_apps: - drive - banks`for example
                 )
                 .map((app, index) => <AppTile key={index} app={app} />)
             )

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -2,6 +2,10 @@
 import React, { Component } from 'react'
 import PropTypes from 'react-proptypes'
 import { Route, Switch, Redirect, withRouter } from 'react-router-dom'
+import isObjectLike from 'lodash/isObjectLike'
+import isArray from 'lodash/isArray'
+import keys from 'lodash/keys'
+import flatten from 'lodash/flatten'
 
 import flag, { enable as enableFlags } from 'cozy-flags'
 import Alerter from 'cozy-ui/react/Alerter'
@@ -21,6 +25,17 @@ const IDLE = 'idle'
 const FETCHING_CONTEXT = 'FETCHING_CONTEXT'
 
 window.flag = window.flag || flag
+
+// TODO add this to cozy-flags ?
+export const toFlagNames = (flagName, prefix = '') => {
+  if (typeof flagName === 'string') return `${prefix}${flagName}`
+  else if (isArray(flagName))
+    return flatten(flagName.map(flagName => toFlagNames(flagName, prefix)))
+  else if (isObjectLike(flagName))
+    return flatten(
+      keys(flagName).map(key => toFlagNames(flagName[key], `${prefix}${key}.`))
+    )
+}
 
 class App extends Component {
   state = {
@@ -52,7 +67,8 @@ class App extends Component {
       })
 
     if (context && context.attributes && context.attributes.features) {
-      enableFlags(context.attributes.features)
+      const flags = toFlagNames(context.attributes.features)
+      enableFlags(flags)
     }
 
     this.setState({

--- a/src/containers/App.spec.jsx
+++ b/src/containers/App.spec.jsx
@@ -1,0 +1,35 @@
+import { toFlagNames } from './App'
+
+describe('toFlagNames', () => {
+  it('should convert a data structure to flag names', () => {
+    const initialData = [
+      'simple-string-1',
+      'simple-string-2',
+      ['array-1', 'array-2'],
+      [['sub-array-1', 'sub-array-2']],
+      ['mixed-array-1', ['mixed-sub-array-1', 'mixed-sub-array-2']],
+      {
+        'object-1': ['nested-array-1', 'nested-array-2'],
+        'object-2': {
+          'sub-object-1': ['deep-array-1', 'deep-array-2']
+        }
+      }
+    ]
+
+    expect(toFlagNames(initialData)).toEqual([
+      'simple-string-1',
+      'simple-string-2',
+      'array-1',
+      'array-2',
+      'sub-array-1',
+      'sub-array-2',
+      'mixed-array-1',
+      'mixed-sub-array-1',
+      'mixed-sub-array-2',
+      'object-1.nested-array-1',
+      'object-1.nested-array-2',
+      'object-2.sub-object-1.deep-array-1',
+      'object-2.sub-object-1.deep-array-2'
+    ])
+  })
+})


### PR DESCRIPTION
Allows to hide certain apps though the context, by specifying them in the context yaml, for example

```
home_hidden_apps:
  - drive
  - banks
```