### PR TITLE
fix: Prevent timeline cutoff

### DIFF
--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -36,8 +36,9 @@ body
 
 .Timeline
     flex-shrink 0
-    overflow-x auto
-    box-shadow 0 0 0 1px rgba(0, 0, 0, .08), 0 4px 12px 0 rgba(0, 0, 0, .08)
+
+    img
+        box-shadow 0 0 0 1px rgba(0, 0, 0, .08), 0 4px 12px 0 rgba(0, 0, 0, .08)
 
 .main-loader
     display flex


### PR DESCRIPTION
With lots of apps, the timeline was cutoff instead of taking as much space as available. Fixing the scroll behavior would risk breaking the scroll behavior when there is no timeline.