### PR TITLE
fix: Rename timeline flag

### DIFF
--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -91,7 +91,7 @@ class App extends Component {
     const isFetchingContext = status === FETCHING_CONTEXT
 
     const isReady = !hasError && !isFetching && !isFetchingContext
-    const showTimeline = flag('hide_konnector_errors') // TODO harmonize flag names
+    const showTimeline = flag('home_show_timeline') // used in demo envs
 
     return (
       <div className="App">


### PR DESCRIPTION
[I said](https://github.com/cozy/cozy-home/pull/1409#discussion_r352580548) we would unify the flag names, but actually it makes more sense to keep them separate for now, because [one of the "demo" flags](https://github.com/cozy/cozy-home/blob/master/src/components/Applications.jsx#L57) is not a simple true/false.