### PR TITLE
Candidates improvements

### DIFF
--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -90,7 +90,11 @@ Services.propTypes = {
 }
 
 const query = client =>
-  client.find('io.cozy.apps.suggestions').where({ silenced: false })
+  client
+    .find('io.cozy.apps.suggestions')
+    .where({ silenced: false })
+    .sortBy([{ silenced: 'asc' }, { slug: 'asc' }])
+    .indexFields(['silenced', 'slug'])
 
 const mapStateToProps = state => {
   return {

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -40,6 +40,11 @@ export const Services = ({
             isInMaintenance={has(appsInMaintenanceBySlug, konnector.slug)}
           />
         ))}
+        {!hasConnections &&
+          suggestedKonnectors.length === 0 &&
+          candidatesConfig.konnectors.map(candidate => (
+            <CandidateServiceTile key={candidate.slug} konnector={candidate} />
+          ))}
         {suggestedKonnectors
           // TODO turn this into a method on the model
           .filter(

--- a/src/components/Services.spec.jsx
+++ b/src/components/Services.spec.jsx
@@ -47,6 +47,18 @@ describe('Services component', () => {
     expect(emptyServicesListTip.getElement()).toMatchSnapshot()
   })
 
+  it('should show default suggestions when there are no services and no suggestions', () => {
+    const component = shallow(
+      <Services
+        t={tMock}
+        installedKonnectors={[]}
+        suggestedKonnectorsQuery={{ data: [] }}
+        client={{}}
+      />
+    )
+    expect(component.getElement()).toMatchSnapshot()
+  })
+
   it('should display suggestions after installed services', () => {
     const installedKonnectors = [
       { slug: 'test-1' },

--- a/src/components/__snapshots__/Services.spec.jsx.snap
+++ b/src/components/__snapshots__/Services.spec.jsx.snap
@@ -227,5 +227,6 @@ exports[`Services component should show default suggestions when there are no se
       label="Add"
     />
   </div>
+  <Wrapper />
 </React.Fragment>
 `;

--- a/src/components/__snapshots__/Services.spec.jsx.snap
+++ b/src/components/__snapshots__/Services.spec.jsx.snap
@@ -157,3 +157,75 @@ exports[`Services component should display the empty component when there are no
 `;
 
 exports[`Services component should display the empty component when there are no services 2`] = `<EmptyServicesListTip />`;
+
+exports[`Services component should show default suggestions when there are no services and no suggestions 1`] = `
+<React.Fragment>
+  <div
+    className="services-list"
+  >
+    <Wrapper
+      konnector={
+        Object {
+          "name": "Ameli",
+          "slug": "ameli",
+        }
+      }
+    />
+    <Wrapper
+      konnector={
+        Object {
+          "name": "Impôts.gouv.fr",
+          "slug": "impots",
+        }
+      }
+    />
+    <Wrapper
+      category="banking"
+      slugs={
+        Array [
+          "hsbc119",
+          "caissedepargne1",
+          "ingdirect95",
+          "cic45",
+        ]
+      }
+    />
+    <Wrapper
+      category="isp"
+      slugs={
+        Array [
+          "sfr",
+          "free",
+          "orange",
+          "bouyguestelecom",
+        ]
+      }
+    />
+    <Wrapper
+      category="insurance"
+      slugs={
+        Array [
+          "maifecheancier",
+          "alan",
+          "harmonie",
+          "macif",
+        ]
+      }
+    />
+    <Wrapper
+      category="energy"
+      slugs={
+        Array [
+          "engie",
+          "planeteoui",
+          "veoliaeau",
+          "ekwateur",
+        ]
+      }
+    />
+    <withClient(AddServiceTile)
+      label="Add"
+    />
+  </div>
+</React.Fragment>
+`;

--- a/src/config/candidates.json
+++ b/src/config/candidates.json
@@ -1,4 +1,8 @@
 {
+  "konnectors": [
+    { "slug": "ameli", "name": "Ameli" },
+    { "slug": "impots", "name": "Impôts.gouv.fr" }
+  ],
   "categories": {
     "banking": ["hsbc119", "caissedepargne1", "ingdirect95", "cic45"],
     "isp": ["sfr", "free", "orange", "bouyguestelecom"],


### PR DESCRIPTION
This PR adds a list of backup konnectors to suggest, which is especially useful for the first connection on a cozy when there are no legitimate suggestions yet. It also sorts the real suggestions by alphabetical order.