### PR TITLE
fix: Add bottom margin to desktop service list

### DIFF
--- a/src/styles/lists.styl
+++ b/src/styles/lists.styl
@@ -58,8 +58,7 @@ heavyShadow = 0 4px 24px 0 rgba(50, 54, 63, .08)
     serviceGridGutter = 17px
     width 100%
     max-width 'calc(%s * 7 + %s * 6)' % (serviceTileSize serviceGridGutter) // 7 columns + 6 column gaps@
-    margin auto
-    margin-top rem(48)
+    margin rem(48) auto rem(24)
     display grid
     grid-template-columns repeat(auto-fit, serviceTileSize)
     grid-auto-rows serviceTileSize


### PR DESCRIPTION
On desktop, we had no margin under the service list, so when there were many services…

<img width="743" alt="Capture d'écran 2019-12-05 11 18 27" src="https://user-images.githubusercontent.com/2261445/70226360-06143980-1751-11ea-8de2-52908f5e66e1.png">
