### PR TITLE
Fix some konnector errors problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/cozy/cozy-home#readme",
   "dependencies": {
-    "cozy-client": "9.2.0",
+    "cozy-client": "9.5.1",
     "cozy-device-helper": "1.8.0",
     "cozy-doctypes": "1.69.0",
     "cozy-flags": "1.11.0",

--- a/src/components/KonnectorErrors.jsx
+++ b/src/components/KonnectorErrors.jsx
@@ -44,7 +44,15 @@ export const KonnectorErrors = ({
   const nonMutedTriggerErrors = triggersInError.filter(trigger => {
     const accountId = triggersModel.getAccountId(trigger)
     const account = accountsWithErrorsById[accountId]
-    return !triggersModel.isLatestErrorMuted(trigger, account)
+    const konnectorSlug = triggersModel.getKonnector(trigger)
+    const hasInstalledKonnector = installedKonnectors.some(
+      ({ slug }) => slug === konnectorSlug
+    )
+    return (
+      hasInstalledKonnector &&
+      account &&
+      !triggersModel.isLatestErrorMuted(trigger, account)
+    )
   })
 
   return nonMutedTriggerErrors.length > 0 ? (

--- a/src/components/KonnectorErrors.spec.jsx
+++ b/src/components/KonnectorErrors.spec.jsx
@@ -139,4 +139,41 @@ describe('KonnectorErrors', () => {
       mutedErrors: [{ mutedAt: MOCKED_DATE, type: 'LOGIN_FAILED' }]
     })
   })
+
+  it('should hide errors when the konnector or account is missing', () => {
+    const component = shallow(
+      <KonnectorErrors
+        t={s => s}
+        triggersInError={[
+          {
+            _id: '1',
+            worker: 'konnector',
+            current_state: {
+              last_error: 'LOGIN_FAILED'
+            },
+            message: {
+              konnector: 'uninstalled',
+              account: '123'
+            }
+          },
+          {
+            _id: '2',
+            worker: 'konnector',
+            current_state: {
+              last_error: 'LOGIN_FAILED'
+            },
+            message: {
+              konnector: 'uninstalled',
+              account: 'no-account'
+            }
+          }
+        ]}
+        accountsWithErrors={[{ _id: '123', mutedErrors: [] }]}
+        installedKonnectors={[]}
+        history={mockHistory}
+        client={mockClient}
+      />
+    )
+    expect(component.find('InfosCarrousel').children().length).toEqual(0)
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3147,13 +3147,13 @@ cozy-client-js@0.16.4:
     pouchdb-browser "7.0.0"
     pouchdb-find "7.0.0"
 
-cozy-client@9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-9.2.0.tgz#277f8fb36201f3767f7e116b112b8f416c38d43f"
-  integrity sha512-o2EVDrWlkqNdkwKbs5iaFSUhfoBY3sqQBdQgg5uE/PXxMo24Ee1jqiqTHEz927MRwHLjoHMQQaie/DahWscuiw==
+cozy-client@9.5.1:
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-9.5.1.tgz#0672477520d55a73c90ff674f37d511dc391ebdd"
+  integrity sha512-ea65cgG4CQVg52dYFd5jRD9tkRbnF0UQU8oizvjGhijDaVJdxHjYrs5LTqf30TysP4dlpl6V30Fw+TKgmDAOqQ==
   dependencies:
     cozy-device-helper "^1.7.3"
-    cozy-stack-client "^9.2.0"
+    cozy-stack-client "^9.5.0"
     lodash "^4.17.13"
     microee "^0.0.6"
     prop-types "^15.6.2"
@@ -3298,10 +3298,10 @@ cozy-scripts@1.13.2:
     webpack-dev-server "3.1.10"
     webpack-merge "4.2.1"
 
-cozy-stack-client@^9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-9.2.0.tgz#3d6a9af9e42f6f2d8fad7fe57e83713a3bcafc77"
-  integrity sha512-ivMjA+EtV7lu6lKzuOIiS00XcTVL6WRbycSmfO7SJrAU12kWp54rlKDS9rMFA2NjCEShjTVdu0intkxYbuimsw==
+cozy-stack-client@^9.5.0:
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-9.5.0.tgz#ca2bea74a9d7d8a81f4fa6189c3178ba38da694f"
+  integrity sha512-RNCQEfmhO1wmiCv2svCK4HdGHKVXqOhM5vbawgls6i7SN/n1/dIPZgakNYkkL6szLQ8P0k2ZSi/jAlfOLJz4lg==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
We had 2 problems:

- https://github.com/cozy/cozy-client/pull/613
- On some instances, there are triggers with errors, but no matching konnector installed. This is not supposed to happen, but when it does, we need to handle it here by filtering out these errors