### PR TITLE
fix: Ignore errors that the user can't fix

### DIFF
--- a/src/components/KonnectorErrors.jsx
+++ b/src/components/KonnectorErrors.jsx
@@ -17,6 +17,7 @@ import {
 } from 'reducers/index'
 import ReactMarkdownWrapper from 'components/ReactMarkdownWrapper'
 import AppIcon from 'components/AppIcon'
+import homeConfig from 'config/collect'
 
 const {
   triggers: { triggers: triggersModel, triggerStates: triggerStatesModel },
@@ -42,13 +43,16 @@ export const KonnectorErrors = ({
 }) => {
   const accountsWithErrorsById = keyBy(accountsWithErrors, '_id')
   const nonMutedTriggerErrors = triggersInError.filter(trigger => {
+    const errorType = triggerStatesModel.getLastErrorType(trigger)
     const accountId = triggersModel.getAccountId(trigger)
     const account = accountsWithErrorsById[accountId]
     const konnectorSlug = triggersModel.getKonnector(trigger)
     const hasInstalledKonnector = installedKonnectors.some(
       ({ slug }) => slug === konnectorSlug
     )
+
     return (
+      homeConfig.displayedErrorTypes.includes(errorType) &&
       hasInstalledKonnector &&
       account &&
       !triggersModel.isLatestErrorMuted(trigger, account)

--- a/src/components/KonnectorErrors.spec.jsx
+++ b/src/components/KonnectorErrors.spec.jsx
@@ -73,7 +73,7 @@ describe('KonnectorErrors', () => {
     expect(component.html()).toBe(null)
   })
 
-  it('should render all the errors', () => {
+  it('should render active errors', () => {
     const component = shallow(
       <KonnectorErrors
         t={s => s}
@@ -93,7 +93,7 @@ describe('KonnectorErrors', () => {
             _id: '2',
             worker: 'konnector',
             current_state: {
-              last_error: 'MUTED_ERROR',
+              last_error: 'LOGIN_FAILED.NEEDS_SECRET', // this one is muted
               last_success: '2019-10-01T00:48:01.404911778Z'
             },
             message: {
@@ -105,7 +105,18 @@ describe('KonnectorErrors', () => {
             _id: '3',
             worker: 'konnector',
             current_state: {
-              last_error: 'USER_ACTION_REQUIRED'
+              last_error: 'USER_ACTION_NEEDED'
+            },
+            message: {
+              konnector: 'test',
+              account: '123'
+            }
+          },
+          {
+            _id: '4',
+            worker: 'konnector',
+            current_state: {
+              last_error: 'VENDOR_DOWN' // This type of error is not displayed
             },
             message: {
               konnector: 'test',
@@ -119,7 +130,7 @@ describe('KonnectorErrors', () => {
             _id: '456',
             mutedErrors: [
               {
-                type: 'MUTED_ERROR',
+                type: 'LOGIN_FAILED.NEEDS_SECRET',
                 mutedAt: '2019-12-01T00:48:01.404911778Z'
               }
             ]

--- a/src/config/collect.json
+++ b/src/config/collect.json
@@ -2,5 +2,20 @@
   "defaultDateFormat": "MM/DD/YYYY",
   "defaultTriggerTimeInterval": [0, 5],
   "filteredApps": ["home"],
+  "displayedErrorTypes": [
+    "DISK_QUOTA_EXCEEDED",
+    "CHALLENGE_ASKED",
+    "LOGIN_FAILED",
+    "LOGIN_FAILED.NEEDS_SECRET",
+    "LOGIN_FAILED.TOO_MANY_ATTEMPTS",
+    "NOT_EXISTING_DIRECTORY",
+    "USER_ACTION_NEEDED",
+    "USER_ACTION_NEEDED.OAUTH_OUTDATED",
+    "USER_ACTION_NEEDED.ACCOUNT_REMOVED",
+    "USER_ACTION_NEEDED.CHANGE_PASSWORD",
+    "USER_ACTION_NEEDED.PERMISSIONS_CHANGED",
+    "USER_ACTION_NEEDED.TWOFA_EXPIRED",
+    "USER_ACTION_NEEDED.WRONG_TWOFA_CODE"
+  ],
   "customWallpaperPath": "/Photos/Settings/Wallpaper.jpg"
 }


### PR DESCRIPTION
Until now we were displaying all konnector errors, but we'd rather show only errors that the user is abble to fix themselves. For this we use a whitelist of error codes that we want to show, all other errors aren't highlighted on the home page.