### PR TITLE
fix: Don't load a null image

### DIFF
--- a/src/components/HeroHeader.jsx
+++ b/src/components/HeroHeader.jsx
@@ -17,7 +17,7 @@ const HeroHeader = ({ t, client, breakpoints: { isMobile } }) => {
   const { host } = new URL(rootURL)
   const { cozyDefaultWallpaper } = client.getInstanceOptions()
 
-  let backgroundURL = null
+  let backgroundURL = ''
   if (fetchStatus !== 'loading')
     backgroundURL = wallpaperLink || cozyDefaultWallpaper
 


### PR DESCRIPTION
While the wallpaper path was loading, null was interpreted as an image path to load.

Still need to add a test case.