### PR TITLE
fix: Use origin to deploy build on remote branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "watch:mobile": "cozy-scripts watch --mobile",
     "start": "cozy-scripts start --hot --browser",
     "cozyPublish": "cozy-scripts publish --token $REGISTRY_TOKEN --prepublish downcloud --postpublish mattermost",
-    "deploy": "git-directory-deploy --directory build/ --branch ${DEPLOY_BRANCH:-build} --repo=${DEPLOY_REPOSITORY:-https://$GITHUB_TOKEN@github.com/cozy/cozy-home.git}",
+    "deploy": "git-directory-deploy --directory build/ --branch ${DEPLOY_BRANCH:-build} --repo=${DEPLOY_REPOSITORY:-origin}",
     "test": "jest"
   },
   "repository": {


### PR DESCRIPTION
No need for a GITHUB_TOKEN, this is a relicate of an era when we deployed the
build folder on github n CI before release.