### PR TITLE
feat: Upgrade harvest

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cozy-device-helper": "1.8.0",
     "cozy-doctypes": "1.72.0",
     "cozy-flags": "2.2.0",
-    "cozy-harvest-lib": "1.24.0",
+    "cozy-harvest-lib": "1.27.0",
     "cozy-keys-lib": "2.5.4",
     "cozy-logger": "1.6.0",
     "cozy-realtime": "3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3248,23 +3248,17 @@ cozy-flags@2.2.0:
   dependencies:
     microee "^0.0.6"
 
-cozy-flags@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.1.0.tgz#46eda64317da44f357d37241cc160189b83878c9"
-  integrity sha512-oESKiuBzcJxrnH4Md/qWoeo3oteZNIjPzzugYU8OG6lXtbxcP5fvoFe26M2B7YAw3PDIIQuLicukao8g+yc+0g==
-  dependencies:
-    microee "^0.0.6"
-
-cozy-harvest-lib@1.24.0:
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-1.24.0.tgz#943df3c0f4dd58000b7f8daac8a13a6a0c15ed9f"
-  integrity sha512-bT+0DNvVpEB/kMQ456yAz5EAY96x4Yx0EaxseSPxo8W2WTUzRbqxmDQvBcNQrmI8bNoBmdq2V4uWofi/sO7n1w==
+cozy-harvest-lib@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-1.27.0.tgz#9558d27453c3469b7a7fa446be523d2c87e2f34c"
+  integrity sha512-5M8HKfSRt+dxvErLLutleZ5SROlAMsAnMdWUeT5GiMuZGHkj5Gy/WENbwvW+GEuokbRdNJl098RgXpEqftq2bg==
   dependencies:
     "@babel/runtime" "^7.5.2"
     "@material-ui/core" "3"
     cozy-bi-auth "0.0.3"
     cozy-doctypes "^1.72.0"
-    cozy-flags "^2.1.0"
+    cozy-flags "2.2.0"
+    cozy-logger "1.6.0"
     date-fns "^1.30.1"
     final-form "4.18.5"
     lodash "4.17.15"
@@ -8154,6 +8148,13 @@ mini-css-extract-plugin@0.5.0:
 minilog@3.1.0, "minilog@https://github.com/cozy/minilog.git#master":
   version "3.1.0"
   resolved "https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
+  dependencies:
+    microee "0.0.6"
+
+"minilog@git+https://github.com/cozy/minilog.git#master":
+  version "3.1.0"
+  uid f01f7d9dfe20981177dd34b9662c2f077d818f82
+  resolved "git+https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
   dependencies:
     microee "0.0.6"
 


### PR DESCRIPTION
Brings this branch on par with the 1.26.0 release + links to the store for apps that aren't installed in harvest.