### PR TITLE
fix: Rename flags to respect naming convention

### DIFF
--- a/src/components/KonnectorTile.jsx
+++ b/src/components/KonnectorTile.jsx
@@ -79,7 +79,7 @@ export class KonnectorTile extends Component {
         color: palette.pomegranate
       }
     }
-    const hideKonnectorErrors = flag('hide_konnector_errors') // flag used for some demo instances where we want to ignore all konnector errors
+    const hideKonnectorErrors = flag('home.konnectors.hide-errors') // flag used for some demo instances where we want to ignore all konnector errors
 
     const status = hideKonnectorErrors
       ? STATUS.OK

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -94,7 +94,7 @@ class App extends Component {
     const isFetchingContext = status === FETCHING_CONTEXT
 
     const isReady = !hasError && !isFetching && !isFetchingContext
-    const showTimeline = flag('home_show_timeline') // used in demo envs
+    const showTimeline = flag('home.timeline.show') // used in demo envs
 
     return (
       <div className="App">


### PR DESCRIPTION
The previous flag names did not follow the new naming convention. The new flag names are already deployed on the corresponding contexts.