### PR TITLE
chore: Only check tx at publish time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,12 +54,12 @@ deploy:
   - provider: script
     repo: cozy/cozy-home
     skip-cleanup: true
-    script: yarn cozyPublish
+    script: yarn txcheck && yarn cozyPublish
     on:
       branch: master
   - provider: script
     repo: cozy/cozy-home
     skip-cleanup: true
-    script: yarn cozyPublish
+    script: yarn txcheck && yarn cozyPublish
     on:
       tags: true

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "src/index.jsx",
   "scripts": {
     "tx": "tx pull --all || true",
-    "posttx": "./scripts/check-locales.sh",
+    "txcheck": "./scripts/check-locales.sh",
     "lint": "yarn lint:js && yarn lint:styles",
     "lint:js": "cozy-scripts lint '{src,test}/**/*.{js,jsx}'",
     "lint:styles": "stylint src/styles --config ./.stylintrc",


### PR DESCRIPTION
We have a script that runs on the CI that checks for mismatches in translation files. It requires to push translations to transifex *before* the PR can be merged which I think is misguided, since transifex should always be on par with master and it prevents concurrent PRs.

However the check is still useful to avoid publishing a release with broken locales, so this PR moves the check before the publication step.