### PR TITLE
fix: Border for app items

### DIFF
--- a/src/styles/lists.styl
+++ b/src/styles/lists.styl
@@ -27,6 +27,7 @@ heavyShadow = 0 4px 24px 0 rgba(50, 54, 63, .08)
 
     .item
         background-color var(--white)
+        border 0
         box-shadow outsideBorder, lightShadow
         padding 20px 4px 12px
         transition box-shadow .05s ease, transform .05s ease


### PR DESCRIPTION
We added an optional logout button in the app bar — but since it's a button, it comes with a default border, and the corresponding css class did not explicitly remove borders.