### PR TITLE
fix: We can have triggers error but no installed konnectors

### DIFF
--- a/src/components/KonnectorErrors.jsx
+++ b/src/components/KonnectorErrors.jsx
@@ -54,9 +54,9 @@ export const KonnectorErrors = ({
     const accountId = triggersModel.getAccountId(trigger)
     const account = accountsWithErrorsById[accountId]
     const konnectorSlug = triggersModel.getKonnector(trigger)
-    const hasInstalledKonnector = installedKonnectors.some(
-      ({ slug }) => slug === konnectorSlug
-    )
+    const hasInstalledKonnector =
+      installedKonnectors &&
+      installedKonnectors.some(({ slug }) => slug === konnectorSlug)
 
     return (
       homeConfig.displayedErrorTypes.includes(errorType) &&

--- a/src/components/KonnectorErrors.spec.jsx
+++ b/src/components/KonnectorErrors.spec.jsx
@@ -38,6 +38,35 @@ describe('KonnectorErrors', () => {
     expect(component.html()).toBe(null)
   })
 
+  it('should render nothing when there are errors but no installed konnector', () => {
+    const component = shallow(
+      <KonnectorErrors
+        t={s => s}
+        triggersInError={[
+          {
+            _id: '2',
+            worker: 'konnector',
+            current_state: {
+              last_error: 'MUTED_ERROR',
+              last_success: '2019-10-01T00:48:01.404911778Z'
+            },
+            message: {
+              konnector: 'test',
+              account: '456'
+            }
+          }
+        ]}
+        accountsWithErrors={[]}
+        installedKonnectors={false}
+        history={mockHistory}
+        client={mockClient}
+        breakpoints={{ isMobile: false }}
+      />
+    )
+
+    expect(component.html()).toBe(null)
+  })
+
   it('should render nothing when all errors are muted', () => {
     const component = shallow(
       <KonnectorErrors


### PR DESCRIPTION
We have a blank screen on a few production cozies because they have error in triggers but no installed konnector 