### PR TITLE
fix: gandi banking connectors with harvest upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cozy-device-helper": "1.8.0",
     "cozy-doctypes": "1.72.2",
     "cozy-flags": "2.2.3",
-    "cozy-harvest-lib": "^1.34.1",
+    "cozy-harvest-lib": "^1.36.1",
     "cozy-keys-lib": "^3.1.1",
     "cozy-logger": "1.6.0",
     "cozy-realtime": "3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3265,23 +3265,23 @@ cozy-flags@2.2.3:
   dependencies:
     microee "^0.0.6"
 
-cozy-flags@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.2.4.tgz#7485a9c828d2ab068683f265eed634dee201fb34"
-  integrity sha512-lcjDko8eeIyUCVm1AqAiWMcKopoevKmgQQ63syBAQej6WV6yG35rvjU97MTPVkj3yzYBBf5SHwjOjBKKoOEtIw==
+cozy-flags@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.2.5.tgz#38e9036de7084268a153462f7fe87e093a120a4b"
+  integrity sha512-K/TEWpWlQqVZ8OossknxwMOu1nEYLtKRHxqDJ7rMQBvl6s8Ef8Z703viUlhJ6RMlVDR75iSCokiXR8XoNAdY5Q==
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^1.34.1:
-  version "1.34.1"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-1.34.1.tgz#bcfc9034ae76b76f05c3d077582c394e065918da"
-  integrity sha512-5HHPvMnXMT/EQtkS1SXDYBM0TIha0vDEejSWOVTGRh5DPL01SnMh0oEubU56O02ui6MmychnKLscftgy7hRM3g==
+cozy-harvest-lib@^1.36.1:
+  version "1.36.1"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-1.36.1.tgz#1fdfbcce4f8b0a0f5f2ee18da2e0f4e77a897124"
+  integrity sha512-mykcCzj8dEMd20D0SOhbZr5XYA1Rab0EWLjQwLmJ3ubUg0gsWIzpeJS730ao7YvWrWs3VAMip0VdYAZhRl5aeA==
   dependencies:
     "@babel/runtime" "^7.5.2"
     "@material-ui/core" "3"
     cozy-bi-auth "0.0.6"
     cozy-doctypes "^1.72.2"
-    cozy-flags "^2.2.4"
+    cozy-flags "^2.2.5"
     cozy-keys-lib "3.1.1"
     cozy-logger "1.6.0"
     date-fns "^1.30.1"


### PR DESCRIPTION
See https://github.com/cozy/cozy-libs/pull/1026