### PR TITLE
Update harvest to be able to edit contracts through the home

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,12 +7,6 @@ yarn-error.log
 # Build
 build/
 
-
-# Locales
-**/locales/*
-!**/locales/en.json
-
-
 # OS generated files
 .DS_Store
 .DS_Store?

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - "10"
 env:
   global:
-    - CXX=g++-4.8
     - MATTERMOST_CHANNEL='{"dev":"app---home","beta":"app---home,publication","stable":"app---home,publication"}'
     - TARGETS_DEV=recette.cozy.works
     - TARGETS_BETA=betatest.cozy.works
@@ -14,20 +13,10 @@ env:
     - secure: r1KjnXjMYKWD9S9oQo2ubG8J0rfADXLJQFgId/L0c16f72Be0YFmpKRq8Zx3haREcydgLUSJEjrdLGp0USY6AqY+iOcKRUrJzxueqRpSWnoF2Lvh9h21zXocRsDzJcwxCUA2y4pxe8e/A9CL4IP8s9DB+DfkBwQB+I6Vm5DOPkYojWFG1uXggrxLhgf8c5AMyAwQGkpBTc9a7PqtIHjSHd5rpSdoRFUNCLJfz0Qow7mf0M8j4fKfeNe8teU7qmkUvPTI1v/SBhU9hebOHjjY9bxfG4kVSpPaCVcVtKqyyemiPU1aZ2vJpgxJ1Y2A3zGe4IA2xJGKDZY4xDz0oGWlJisPWOW6l9BALDLUV8QhVoqhFfyCHYiGEweGcIaZk9t6a1CNhNb3FXlUw8S4XMo91g4hLu2q42PnVX6862fSOGF7FyEHAha20nFOitOpqsEwmfEm8dhyi4wzVEuTEvQlQAHN9x4wRwnE2x56eHftKV0XDVMiJKybO5vpyofFUBeyWzvDxJoV/2vwGyTpG5te7g7VmyT5XzPRioWwWRJryYDHm9zZeuhYSJiG4ARgWmjkluOe5n/WAcdFeDkx+AEQ+kXBfuGuJD9IMartlWL8K4TavgfTEUdYgkCeyHHhXS8o5IMuRIkc/sl4gb3kcNtt+FHQpKV4VYQy+gPcoN51FOU=
     # MATTERMOST_HOOK_URL
     - secure: "LS+qWAoU+waiikOkwEgetLUh/60f7eTGSU6ihE9Lpyo70CZqfPn37V1tN+6xKc89OQXs2O9C5RDzZlbjUkqZnJ6s+VBxZUHT5cc6FybtT7ICcGd4/rpgZC558V6c6A2K11BUT2nKfZ38eUEDQKYudD7QgWJL40VSBYS2gPXfn/0qViHZA7Ub+AemUmJpc/RtC6MTy0epDhpim+ANKqczdHUnBkICHmN+XLrescnfRdM8OeoOdJ4jykuUuzIjR9tdU9ekR7bmZx37m0luIiqkjQJlnDamcfKh0jUc15ib+s6pfAwpkkbs7pIUaNKb+kXZgNJFUEd8d9EKGgBFJ7lxl8Ju9nfzL9FMn6O7wzjIQm/ri3e0qYp473HaUhg1+0hVHKVxYx8wEwedzeEfGXFQ222e4YRVruOLoORs56wbAahRoSC3X57kNNEZziz4S0GEoDQtNHtVb2B+GbKazcOwri/3Fvto7ZuKJNGg4waCFjerCNfkP17mlJyXcZ4l+6OVvmg4qgXr9z4vdi4sW43U9FAxFABNRUt2E6pe2H5vZMub6WIbU9FpKpl/IP6d/juT3/+055BhgrOQLO+fbqm8E2WIFVXHACysHyx8ApGdqdRdS27TWfLp/EsIBqe/T/ivT8GEPX0qYXegItBtIvQEGavQ9keLpExDbtxH7Z+N72g="
-    # TX_PASSWD
-    - secure: "rZ4o8W4/efse/icE770McLypl18bnzCdaxVOp/S/PKljdllAp+wWknowKkXiB0l3B01DN14JpkG6stAGkjMXRFigWJeKCDhIGD+HGhgZbyTBpGaRiKNuyURS3ZTVJ2bURwD80mgZWu34msEwYzbADfv86DOLYp5JPDRNw+1iogFNGj+gFmtV4ynHM8YCnPX+gzNZnyj+q/HyBP24wFkY6qpUddZxz/eczRzWfY0bbQ9oQGVtjMQHKKt4hw+f2hdjbKUiiahq6FYhVAUzFnP5T4lk1MLenxZsZmFqdYuV1CRzNC2DRpiZdZlL10v08za0oQY8qQmPWzJWvJsE3q0vtXsA24eYWOaQ0zbpy7sA9QawR71xJShIBj/U6MeKMoG7fq88xuJBaPYByt1hgQ7Hz/8B0/fd1iZz8u/EIVWP9wDD8GPzlv0HQ3KZLH6Vson04fOJWyRrv9Yac1EXaj8Guk21vIVEEWbUZnoGgQWXY9OVq/A7oU79YjPT/orB6KC7vGY0Qaq+WyroICGBMM6TF9/TE+zB2trONE+SCJw2Uy54moGXRfYvxDI1pRcmoTCq4cWAkqDElKWuhGoIfZTXX8kc3j24DKvDLXxrTBwIzNFmOkXNkJrTR45DrNSwWkuc+nV9xbKBDSREKu4NHaY/xnirglyddSjE1FgIWtET32M="
     # REGISTRY_TOKEN
     - secure: A7pRywtbi1an4bW+Hi3gDtPja4D1hA0x+P4X6XbafZQWA9GmjUY7esUVg22jjF5G+UQDe/UTC2IqCnZXcZA8WoAWTKMg/7UHp9NiehXk0qNwfl0QHhqj5Woc4rLoTQ2Xxv8aJfcRbRPAxS4dXRGW0OHJQOAl3IdtsJpxRLy3EYClRu+JviWEu+SB3rN4ffz1Ylm8E47JtuozEQF8MswOqWKZRMrzGBocXYiMuIRKPXcPT8S53HmgOl9jLEjx857thNrvwCnQ9kt8HAF3k+ev2DPGB2HPm9efEppq8frIr1AXuPZ7NzZNtHGAEwwArE4geb6uu09dB8dcAqPTYGYFTT3thTZwCw7C2M3jiKPSv9Vhy7WsFcviikm8rRwtpNxhRmmQUasliY0Mn57EQxj1Dud8FrD4Vd4cQDHz02tcacPrScisCBKmWx9PzaXqBM1dIzxPWgvQbbaxkgtg/jAEc8DpiC9GThU6RU+Cip4s1AANSHkVKBlqq7xVwgXju/E1i1yir4ldacaSM8FT1UN4nFyf992toGWa3l2P9dhRyeCYlx5SUQkojs7rKKdQPIbC5LskFKF9vu9jj4CF9CKICVVqYPu/lAr3W4pYbzn9j1hAwF9+Akcq9GwC06GKabVymDISei0aC0SWQ9pS/sJd3LeLZuP7tp4SAsC2IJIiieE=
     # RUNDECK_TOKEN
     - secure: TIuR4l+T3XBBWT1Nz/C93b8DGXO1lom8TbUiWzTcdNXNXAHW2Q/k2qt0KdohYa0m9ULemknxYMewBVyeDbmQIJ1cx/+SrgnrWkcH8Pk6GWkY2ugzicwQPPvLPS/u+MMZC0w7tcOpPdeL1AYF+f+eQxgYvumCnzR/kKWajFaYEHRXWxSQNypsbbkAQmtD4nhtg934MdNamPMMZAV7v7Y7VvmUQeZKV3B63zCr5L28KD2S1yH5l3qFcKm3KFcK5VJgOAjmhUQSg0lBztV2gXMbS/EHecCsUJtu/29EzG/6bGhjP5NSYl6gO2BaemY85oWVK9aWpnuB1fMbnzdJb9+jD4C5NQmVWTLmwlBr1Sf5GrHX0Inc+QNn/XcFe0bUg40FqAjlPPMsNuPSn745QEq+B3IKZGF9o94DIMalZdGoM6CGSqh0hDJ7B6e/7K5vEfw2PZQoVwKfzstrc6EUadkXohtdgv8+b33KHRfOH4A8171LrQn9a4J+SOcns31iGMg/0MXfA+bMZkGrwCQxcnKQ13Epvs3qDaOflbdE0YKOAsUpMDO3zLcY7uVu3FjsBp6x8PL6pYF3iKfp7jD6OSEpGBl39eUMavL8hv+2LFo1O/aiUZJ/9fLPoCqZ/Cbp87T8VMVHHiRfqWs+W0AWRCJs0BpY1qFnOxti/ZrXNo/T1qQ=
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - deadsnakes
-    packages:
-      - g++-4.8
-      - python3.5
 cache:
   yarn: true
   directories:
@@ -39,10 +28,6 @@ before_install:
   - 'if [ "$TRAVIS_SECURE_ENV_VARS" != "false" ]; then ssh-add /tmp/deploy_rsa; fi'
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0
   - export PATH="$HOME/.yarn/bin:$PATH"
-  - curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3.5 - --user
-  - travis_retry pip3.5 install --user transifex-client==0.12.5
-  - install -m0644 .transifexrc.tpl ~/.transifexrc
-  - echo "password = $TX_PASSWD" >> ~/.transifexrc
 script:
   - set -e
   - yarn lint

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -45,7 +45,7 @@
       "verbs": ["ALL"]
     },
     "contacts": {
-      "description": "Required for the service to update the myself contact",
+      "description": "Required for the service to update the myself contact, and to add contacts to contracts/accounts",
       "type": "io.cozy.contacts",
       "verbs": ["ALL"]
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cozy-keys-lib": "^3.1.1",
     "cozy-logger": "1.6.0",
     "cozy-realtime": "3.10.1",
-    "cozy-ui": "35.38.0",
+    "cozy-ui": "35.39.0",
     "date-fns": "1.30.1",
     "form-data": "2.5.1",
     "husky": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cozy-device-helper": "1.10.0",
     "cozy-doctypes": "1.72.2",
     "cozy-flags": "2.3.2",
-    "cozy-harvest-lib": "1.41.0",
+    "cozy-harvest-lib": "2.0.0",
     "cozy-keys-lib": "^3.1.1",
     "cozy-logger": "1.6.0",
     "cozy-realtime": "3.10.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "cozy-bar": "7.7.6",
     "cozy-client-js": "0.16.4",
-    "cozy-scripts": "4.3.0",
+    "cozy-scripts": "4.3.1",
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.15.2",
     "git-directory-deploy": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "lint": "yarn lint:js && yarn lint:styles",
     "lint:js": "cozy-scripts lint '{src,test}/**/*.{js,jsx}'",
     "lint:styles": "stylint src/styles --config ./.stylintrc",
-    "prebuild": "yarn tx",
     "build": "yarn build:browser",
     "build:browser": "cozy-scripts build --browser",
     "build:mobile": "cozy-scripts build --mobile",

--- a/src/appContext.js
+++ b/src/appContext.js
@@ -1,0 +1,43 @@
+import CozyClient from 'cozy-client'
+import memoize from 'lodash/memoize'
+import { CozyClient as LegacyCozyClient } from 'lib/redux-cozy-client'
+import flag from 'cozy-flags'
+
+import configureStore from 'store/configureStore'
+import schema from './schema'
+import homeConfig from 'config/home.json'
+
+/**
+ * Setups clients and store
+ *
+ * Is memoized to avoid several clients in case of hot-reload
+ */
+export const setupAppContext = memoize(() => {
+  const lang = document.documentElement.getAttribute('lang') || 'en'
+  const context = window.context || 'cozy'
+  const root = document.querySelector('[role=application]')
+  const data = root.dataset
+
+  // New improvements must be done with CozyClient
+  const cozyClient = new CozyClient({
+    uri: `${window.location.protocol}//${data.cozyDomain}`,
+    schema,
+    token: data.cozyToken
+  })
+
+  cozyClient.registerPlugin(flag.plugin)
+
+  const legacyClient = new LegacyCozyClient({
+    cozyURL: `//${data.cozyDomain}`,
+    token: data.cozyToken,
+    cozyClient
+  })
+
+  // store
+  const store = configureStore(legacyClient, cozyClient, context, {
+    lang,
+    ...homeConfig
+  })
+
+  return { cozyClient, store, data, lang, context }
+})

--- a/src/components/HeroHeader/CornerButton.jsx
+++ b/src/components/HeroHeader/CornerButton.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Button, { ButtonLink } from 'cozy-ui/react/Button'
-import { useBreakpoints } from 'cozy-ui/transpiled/react'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 const CornerButton = props => {
   const { isMobile } = useBreakpoints()

--- a/src/components/KonnectorErrors.jsx
+++ b/src/components/KonnectorErrors.jsx
@@ -10,7 +10,7 @@ import InfosCarrousel from 'cozy-ui/transpiled/react/InfosCarrousel'
 import Button from 'cozy-ui/transpiled/react/Button'
 import Text, { SubTitle } from 'cozy-ui/transpiled/react/Text'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
-import { withBreakpoints } from 'cozy-ui/transpiled/react'
+import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 import {
   getTriggersInError,
   getAccountsWithErrors,

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,0 +1,578 @@
+{
+  "app": {
+    "logo": {
+      "alt": "%{name} logo"
+    }
+  },
+  "date": {
+    "format": "DD/MM/YYYY",
+    "placeholder": "dd/mm/yyyy"
+  },
+  "manifest": {
+    "name": "Inicio",
+    "short_description": "Cozy Collect es la aplicación que le ayuda a recopilar todos sus datos personales que están en Cozy.",
+    "long_description": "Con Cozy Collect, usted puede facilmente:\n* Descargar documentos de todos sus proveedores\n* Establecer la frecuencia con la que Cozy recopilará sus facturas\n* Acceder directoamente a los documentos recopilados por su Cozy",
+    "changes": "Seguro ya se ha dado cuenta, el Store ha llegado a su Cozy\nAprovechamos para mejorar Collect:\n*Adaptación a Store.\n*Fusión de fichas: cuando se tienen diversas cuentas en un proveedor, la primera se fusiona baja la ficha del proveedor.\n*Mejora de algunas páginas de Conectores."
+  },
+  "add_service": "Añadir",
+  "fix_konnector_error": "Arreglar ahora",
+  "logout": "Cerrar sesión",
+  "help": "Ayuda",
+  "help_link": "https://help.cozy.io/",
+  "home_config_magic_folder": "V",
+  "account": {
+    "config": {
+      "default_folder": "/Administrative/%{name}",
+      "optional": "(Opcional)",
+      "title": "Conecte su cuenta %{name} ",
+      "data": {
+        "title": "Datos recopilados:",
+        "service": {
+          "description": "Descripción del servicio:"
+        }
+      },
+      "tabs": {
+        "sync": "sincronización",
+        "account": "cuenta",
+        "data": "datos recopilados"
+      }
+    },
+    "disconnect": {
+      "title": "Desconexión",
+      "description": "Usted se desconectará de esta cuenta, pero se guardarán los datos importados"
+    },
+    "form": {
+      "title": "Cuenta",
+      "label": {
+        "firstname": "Nombre",
+        "lastname": "Apellido",
+        "login": "Login",
+        "consumerKey": "Clave del usuario",
+        "consumerSecret": "Secreto del usuario",
+        "appKey": "Clave de la aplicación",
+        "appSecret": "Secreto de la aplicación",
+        "tricountUrl": "URL Tricount",
+        "cardNumber": "Número de tarjeta",
+        "dob": "Fecha de nacimiento",
+        "password": "Contraseña",
+        "email": "Email",
+        "bank_identifier": "Identificante bancario (opcional)",
+        "profileName": "Nombre del perfil",
+        "identifier": "Identificador",
+        "new_identifier": "Identificador",
+        "secret": "Contraseña",
+        "answer": "Respuesta secreta",
+        "access_token": "Token de acceso",
+        "accessTokenSecret": "Token de acceso secreto",
+        "apikey": "Clave Api",
+        "phoneNumber": "Número de teléfono",
+        "folderPath": "Ruta de la carpeta",
+        "namePath": "Nombre de la carpeta",
+        "authCode": "Código de autorización",
+        "accountName": "Nombre de la cuenta",
+        "loginUrl": "URL de acceso",
+        "token": "Token",
+        "agreement": "Acepto",
+        "refreshToken": "Recargar el token",
+        "timeout": "Retardo (ms)",
+        "branchName": "Oficina",
+        "code": "Código confidencial"
+      },
+      "placeholder": {
+        "password": "La contraseña que usted usa para acceder al servicio",
+        "update_password": "Actualizar la contraseña",
+        "accountName": "Ejemplo: Cuenta personal",
+        "namePath": "Ejemplo: Facturas de Camille. La ruta de nombre predeterminado es su login."
+      },
+      "button": {
+        "connect": "Conectar",
+        "cancel": "Cancelar",
+        "save": "Guardar",
+        "disconnect": "Desconectar esta cuenta",
+        "delete": "Borrar esta cuenta",
+        "advanced": "Opciones avanzadas",
+        "synchronize": "Sincronizar ahora"
+      }
+    },
+    "folder": {
+      "title": "Configuración de carpetas relacionadas",
+      "withoutSettings": {
+        "title": "Carpeta relacionada"
+      },
+      "link": "Abrir la carpeta en Cozy Drive",
+      "changePath": "cambiar la ruta de acceso",
+      "error": "Oops, algo salió mal. No se asuste, sus archivos siguen ahí, por favor vuelva a intentarlo más tarde.",
+      "close": "cerrar",
+      "warning": "Usted cambia su ruta de acceso",
+      "oldFiles": "Todas sus facturas serán trasladadas a su nueva ruta de acceso",
+      "newFiles": "Sus nuevas facturas serán descargadas a su nueva ruta de acceso",
+      "newPath": "Todo salió bien, el nuevo camino de acceso para su cuenta %{name} es:",
+      "placeholder": {
+        "administrative": "Administrativa",
+        "photos": "Fotos"
+      }
+    },
+    "success": {
+      "title": {
+        "connect": "Configuración correcta!",
+        "update": "¡Su cuenta %{name} ha sido actualizada!"
+      },
+      "banksLinkText": "Ver mis cuentas en %{appName}",
+      "driveLinkText": "Abrir la carpeta en Cozy Drive",
+      "button": "Cerrar"
+    },
+    "message": {
+      "folder": {
+        "title": "Carpeta",
+        "link": "Abrir la carpeta en Cozy Drive"
+      },
+      "success": {
+        "connect": "Sus datos estarán disponibles en su Cozy en pocos minutos y a partir de ese momento, los siguientes lo estarán automáticamente.",
+        "update": "¡Su cuenta %{name} ha sido actualizada exitosamente.",
+        "delete": "Cuenta suprimida exitosamente."
+      },
+      "syncing": {
+        "bill": "Sus facturas están sincronizándose y estarán disponibles en la siguiente dirección:"
+      },
+      "synced": {
+        "title": "Sincronización de sus datos",
+        "cron": "Frecuencia de sincronización: %{frequency}",
+        "cron_hourly": "cada hora",
+        "cron_daily": "una vez por día",
+        "cron_weekly": "una vez por semana",
+        "cron_monthly": "una vez por mes",
+        "cron_undefined": "manualmente",
+        "syncing": "ejecutándose...",
+        "unknown": "desconocido",
+        "last_sync": "Última sincronización: **%{date}**",
+        "date_format": "MMMM D[,] YYYY [a las] HH[:]mm",
+        "bill": "Encuentre sus datos en la aplicación Drive en este sitio:"
+      },
+      "error": {
+        "server": "Discúlpenos, nuestro servidor tuvo un contratiempo, le importaría arrancar de nuevo?",
+        "bad_credentials": "Lo siento, uste ha escrito un login o una contraseña incorrectos.",
+        "delete": "Discúlpenos, nuestro servidor tuvo un contratiempo, le importaría arrancar de nuevo?"
+      }
+    },
+    "forceConnection": "Vuelva a ejecutar",
+    "editor_detail": "Servicio desarrolado por %{editor}"
+  },
+  "account_picker": {
+    "add_account_button": {
+      "label": "Añadir una cuenta"
+    }
+  },
+  "apps": {
+    "title": "Mis apps"
+  },
+  "connection": {
+    "CTA": {
+      "twofa_failed": "Vuelva a ejecutar"
+    },
+    "error": {
+      "default": {
+        "title": "Ha ocurrido un error",
+        "description": "Desafortunadamente, algo salió mal al intentar conectar con %{name}. Por favor, controle otra vez la información de su cuenta, visite nuestra ayuda en línea o contáctenos en contact@cozycloud.cc."
+      },
+      "DISK_QUOTA_EXCEEDED": {
+        "title": "El amacenamiento de Cozy está lleno",
+        "description": "Este servicio no puede recuperar sus documentos ahora. Por favor, borre algunos archivos o vaya a \"Ajustes > Almacenamiento** para obtener más espacio libre."
+      },
+      "CHALLENGE_ASKED": {
+        "title": "Se requiere Challenge",
+        "description": "Parece que el sitio web requiere un segundo factor de autenticación que aún no está disponible. Puede intentar resolver el problema en el sitio web[%{name}](%{link}) antes de volver a intentarlo."
+      },
+      "LOGIN_FAILED": {
+        "title": "Malas credenciales",
+        "description": "Malas credenciales. Controle los campos de su conector y vuelva a ejecutarlo."
+      },
+      "LOGIN_FAILED.NEEDS_SECRET": {
+        "title": "Secreto exigido",
+        "description": "Se debe llenar un campo adicional antes de controlar sus credenciales."
+      },
+      "LOGIN_FAILED.TOO_MANY_ATTEMPTS": {
+        "title": "Bloqueado temporalmente",
+        "description": "Se hicieron demasiados intentos. Por favor, actualice sus credenciales en el sitio web[%{name}](%{link}) y actualice el conector más tarde."
+      },
+      "MAINTENANCE": {
+        "title": "Sitio web no disponible",
+        "description": "Parece que el sitio web [%{name}](%{link}) no está disponible o que el konnector debe actualizarse. Vuelva a ejecutar el conector más tarde o visite nuestra ayuda en línea."
+      },
+      "NOT_EXISTING_DIRECTORY": {
+        "title": "Falta la carpeta de destino",
+        "description": "Parece que la carpeta de destino de esta cuenta ha sido borrada. Por favor desconéctese de la cuenta, restáurela y vuelva a conectarse."
+      },
+      "UNKNOWN_ERROR": {
+        "title": "Error de conexión",
+        "description": "Ha ocurrido un error no identificado."
+      },
+      "USER_ACTION_NEEDED": {
+        "title": "Acción necesaria con el proveedor",
+        "description": "Parece que el sitio web[%{name}](%{link}) requiere que inicie sesión y realice una acción específica. Vuelva a ejecutar el conector una vez que haya resuelto el problema en la página web."
+      },
+      "USER_ACTION_NEEDED.OAUTH_OUTDATED": {
+        "title": "Se requiere volver a acceder",
+        "description": "El servicio [%{name}](%{link}) requiere que usted vuelva a acceder. Por favor desconecte y reconecte su cuenta %{name} a esta aplicación. No se perderá ningún dato."
+      },
+      "USER_ACTION_NEEDED.ACCOUNT_REMOVED": {
+        "title": "Cuenta no disponible",
+        "description": "Parece que su cuenta no está activa. Compruebe su cuenta en[%{name}](%{link}) antes de volver a intentarlo."
+      },
+      "USER_ACTION_NEEDED.CHANGE_PASSWORD": {
+        "title": "Se requiere actualizar la contraseña",
+        "description": "Parece que el sitio web[%{name}](%{link}) requiere que inicie sesión y actualice su contraseña. Por favor, vuelva a ejecutar el conector una vez que haya resuelto el problema en la página web."
+      },
+      "USER_ACTION_NEEDED.PERMISSIONS_CHANGED": {
+        "title": "Se necesitan nuevos permisos de validación",
+        "description": "Su conector fue actualizado y los permisos cambiados. Por favor, valídelos antes de volver a lanzar el conector."
+      },
+      "USER_ACTION_NEEDED.TWOFA_EXPIRED": {
+        "title": "Relanzar la conexión al servicio para recuperar sus datos",
+        "description": "La última conexión al servicio ha fallado; por favor, láncela de nuevo. Es posible que tenga que proporcionar un código de validación."
+      },
+      "USER_ACTION_NEEDED.WRONG_TWOFA_CODE": {
+        "title": "Código suministrado para dos factores es equivocado",
+        "description": "El código para dos factores suministrado esta errado, ensaye de nuevo por favor."
+      },
+      "VENDOR_DOWN": {
+        "title": "Servicio no disponible",
+        "description": "Parece que el servicio[%{name}](%{link}) no está disponible en este momento. Por favor, vuelva a ejecutar el conector más tarde."
+      },
+      "VENDOR_DOWN.BANK_DOWN": {
+        "title": "Sitio web no disponible",
+        "description": "Parece que el sitio web [%{name}](%{link}) no está disponible en este momento. Por favor, vuelva a ejecutar el conector más tarde."
+      },
+      "VENDOR_DOWN.LINXO_DOWN": {
+        "title": "Servicio no disponible",
+        "description": "Parece que en este momento estamos experimentando una sobrecarga con nuestros conectores bancarios. Por favor, vuelva a ejecutar el conector más tarde."
+      }
+    }
+  },
+
+  "intent": {
+    "konnector": {
+      "install": {
+        "error": {
+          "message": "Este conector no se puede instalar"
+        }
+      }
+    },
+    "service": {
+      "return": "Volver a la lista de conectores",
+      "success": {
+        "button": {
+          "label": "Cerrar"
+        }
+      },
+      "error": {
+        "initialization": "El servicio ha fallado al inicializarse. Sentimos los inconvenientes.",
+        "creation": "Imposible crear una cuenta, ha ocurrido un error.",
+        "cause": "Causa: %{error}"
+      },
+      "cancel": "Cancelar",
+      "terminate": "Terminar"
+    }
+  },
+
+  "field": {
+    "password": {
+      "visibility": {
+        "hide": "Ocultar",
+        "show": "Mostrar",
+        "title": {
+          "hide": "Ocultar la contraseña",
+          "show": "Mostrar la contraseña"
+        }
+      }
+    }
+  },
+
+  "nav": {
+    "services": "Servicios instalados"
+  },
+
+  "category": {
+    "all": "Todo",
+    "banking": "Bancos",
+    "health": "Salud",
+    "insurance": "Seguros",
+    "transport": "Transporte",
+    "social": "Social",
+    "isp": "PSI",
+    "telecom": "Telecom",
+    "energy": "Energía",
+    "host_provider": "Huesped",
+    "productivity": "Productividad",
+    "shopping": "Compras",
+    "public_service": "Servicios Públicos",
+    "other": "Otros"
+  },
+
+  "loading": {
+    "initial": "Cargando cuentas...",
+    "working": "Cargando"
+  },
+
+  "validation": {
+    "exact_length": "Debe estar compuesto de %{length} caracteres exactamente.",
+    "max_length": "La longitud máxima es de %{length}  caracteres.",
+    "min_length": "Debe contener al menos %{length} caracteres.",
+    "pattern": "El valor debe coincidir con un patrón específico: %{pattern}.\n"
+  },
+
+  "update": {
+    "title": "Está disponible una actualización de este servicio.",
+    "regular": "Actualice esta versión para seguir obteniendo sus datos y disponer de las últimas mejoras.",
+    "blocking": "Actualícela para seguir obteniendo sus datos",
+    "CTA": "Actualizar"
+  },
+
+  "error": {
+    "initial": "Algo ocurrió al recolectar sus colectores y sus datos. por favor, vuelva a cargar la página.",
+    "LOGIN_FAILED": "Malas credenciales. Controle los campos de su conector y vuelva a ejecutarlo.",
+    "UNKNOWN_ERROR": "Algo inesperado ha ocurrido al ejecutar el conector",
+    "JOB_TIMEOUT": "La ejecución del conector ha tardado mucho",
+    "button": {
+      "reload": "Volver a cargar la página ahora"
+    }
+  },
+  "tutorial": {
+    "cozy_collect": {
+      "title": "Automatice la recolección de sus datos",
+      "text": "Ellos serán almacenados en su Cozy, usted no tendrá que buscarlos en parte alguna.",
+      "button": "Siguiente"
+    },
+    "home": {
+      "apps": {
+        "button": "Siguiente",
+        "text": "Organice facilmente su vida numérica (archivos, imágenes, cuentas de banco, ...)",
+        "title": "Acceda a todas sus aplicaciones Cozy"
+      },
+      "services": {
+        "button": "Configurar mis cuentas",
+        "text": "Ellos serán almacenados en su Cozy, usted no tendrá que buscarlos en parte alguna.",
+        "title": "Automatice la recolección de sus datos"
+      }
+    },
+    "menu_apps": {
+      "title": "Su Cozy es mucho más que un simple agregador de datos",
+      "text": "Abra el menú de Aplicaciones para descubrir las características que Cozy puede ofrecerle.",
+      "button": "Descubrir mis aplicaciones"
+    }
+  },
+
+  "maintenance": {
+    "icon": "Este conector está en mantenimiento",
+    "service": "Servicio interrumpido",
+    "problem": "%{konnectorName} no permite que su Cozy acceda a sus datos",
+    "title": "¿Qué sucede?"
+  },
+
+  "connector": {
+    "debug": {
+      "successMessage": "Este konnector es sólo para fines de debug, este es un mensaje habitual adicional de éxito."
+    },
+    "empty": {
+      "title": "¡Empiece a recopilar sus datos!",
+      "text": "Sincronice sus cuentas con su Cozy para recuperar automáticamente sus datos (facturas, reembolsos, gastos...)"
+    },
+    "silenced": "%{name} no se sugerirá más. Siempre puede encontrar un proveedor haciendo clic en el botón \"Añadir\".",
+    "noAccount": "Cuenta inexistente",
+    "add": "Añadir un servicio",
+    "update": "Actualización disponible",
+    "logo": {
+      "alt": "%{name} logo\n"
+    },
+    "enedis": {
+      "description": {
+        "service": "Recupere sus datos de Linky conectandose a su cuenta de Enedis. Debe tener un medidor Linky y haber creado antes su cuenta de Enedis [en el sitio web de Enedis] (https://espace-client-connexion.enedis.fr/auth/UI/Login?realm=particuliers). Fing proporciona este conector para el proyecto MesInfos. Recupera los datos de su contrato de electricidad y descarga su consumo de electricidad del día anterior. Este conector se ejecuta en su Cozy y Fing no tendrá acceso a estos datos."
+      }
+    },
+    "orange": {
+      "message": {
+        "delay": "Una vez conectado, se envía al sistema de información de Orange una solicitud para extraer sus datos. Estos datos son válidos durante 15 días. Sus datos se actualizan automáticamente cada quince días."
+      }
+    },
+    "orangemobile": {
+      "description": {
+        "connector": "En el contexto de 'MesInfos', Orange le permite localizar permanentemente su teléfono.\n\n**La recopilación de datos exige su acuerdo previo**\n\nHaciendo clic en \"Apruebo\", usted consiente que se recopile la posición de su teléfono, cada 30 minutos. La información recopilada será la siguiente:\nFecha y hora de la ubicación.\nDatos de la ubicación de la antena más cercana en el momento de la recopimación.\nLos datos recopilados por Orange después de su aceptación estarán disponibles sólo en el Cozy que usted ha asignado en el contexto de 'MesInfos'. Se añadirán a sus datos de ubicación almacenados en su registro de llamadas.",
+        "service": "Este conector carga datos de su cuenta Orange a su Cozy. Carga automáticamente los registros de llamadas de su teléfono. Estos registros de llamadas incluyen su número de teléfono, el número de teléfono de su corresponsal, fecha, duración de la llamada  y datos sobre la localización de la antena radio más cercana en el momento de la recopilación.\n\nUsted podrá utilizar esos datos en diferentes aplicaciones de su Cozy, por ejemplo \"Mapeando Mi Vida\" (pronto disponible en el Cozy Store).",
+        "field": {
+          "agreement": "¿En el contexto de \"Mes infos\", aprueba usted que Orange localice regularmente su teléfono ?"
+        }
+      }
+    },
+    "orangevideos": {
+      "description": {
+        "service": "Este conector carga datos de su cuenta Orange a su Cozy. Carga automáticamente la lista de las películas que usted ha descargado gratis (TV Replay) o pagando VOD desde em 01/01/2015 (no se incluyen películos con contenido para adultos°.\\n\\nUsted podrá utilizar esos datos en diferentes aplicaciones de su Cozy, por ejemplo \"My Movies Music\" (pronto disponible en el Cozy Store)."
+      }
+    },
+    "axabanque102": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "banquepopulaire": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "barclays136": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "bforbank97": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "bnpparibas82": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "boursorama83": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "bred": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "caatlantica3": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "caissedepargne1": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "carrefour159": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "casden173": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "cdngroup109": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "cdngroup88": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "cic45": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "cic63": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "comptenickel168": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "creditcooperatif148": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "creditmaritime": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "fortuneo84": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "hellobank145": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "hsbc119": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo).",
+        "connector": "La respuesta secreta es [pregunta por HSBC](https://www.hsbc.fr/1/2/hsbc-france/particuliers/connexion) cuando usted se conecta sin doble autenticación. Ejemplo: ¿Cómo se llama su mascota?"
+      }
+    },
+    "ingdirect95": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "labanquepostale44": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "lcl143": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "lcl144": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "lcl146": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "monabanq96": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "societegenerale": {
+      "description": {
+        "service": "La conexión con su banco la opera y asegura nuestro asociado: Linxo. [Más información en] (https://support.cozy.io/article/147-linxo)."
+      }
+    }
+  },
+  "Queue": {
+    "header": "Sincronizando cuentas",
+    "header_mobile": "%{done} de %{total}",
+    "header_done": "Sincronizado %{done}  de %{total}",
+    "item": {
+      "pending": "Pendiente"
+    },
+    "close": "Cerrar"
+  },
+  "services": {
+    "title": "Servicios instalados"
+  },
+  "status": {
+    "interrupted": "SEVICIO INTERRUMPIDO",
+    "edf": {
+      "maintenance": "El sistema de información de EDF ha cambiado y el acceso a los datos relacionados no funciona. Este konnector no puede recuperar actualmente sus datos de EDF. Estamos tratando de restaurar la situación y le notificaremos cuando se arregle. [Más información en](%{supportLink})",
+      "support_link": "https://support.cozy.io/article/123-le-connecteur-edf-ne-fonctionne-pas"
+    }
+  },
+  "tile": {
+    "konnector": {
+      "lastSyncDate": {
+        "format": "DD MMM"
+      }
+    }
+  }
+}

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,0 +1,578 @@
+{
+  "app": {
+    "logo": {
+      "alt": "Logo de %{name}"
+    }
+  },
+  "date": {
+    "format": "DD/MM/YYYY",
+    "placeholder": "dd/mm/yyyy"
+  },
+  "manifest": {
+    "name": "Accueil",
+    "short_description": "Cozy Collect est l'application de récupération de vos données personnelles disponible sur Cozy.",
+    "long_description": "Avec Cozy Collect, vous pouvez facilement :\n\n * Télécharger les documents de tous vos fournisseurs\n * Configurer la fréquence à laquelle Cozy va récupérer vos factures\n * Accéder directement aux documents récupérés par votre Cozy",
+    "changes": "Cela ne vous aura pas échappé, le Store est arrivé dans Cozy !\nNous en avons profité pour améliorer Collect :\n\n * Adaptation au Store.\n * Fusion des tuiles : lorsque vous avez plusieurs comptes pour un même fournisseur ces derniers sont désormais réunis sous la tuile de ce fournisseur.\n * Amélioration des pages des connecteurs."
+  },
+  "add_service": "Ajouter",
+  "fix_konnector_error": "Corriger maintenant",
+  "logout": "Déconnexion",
+  "help": "Aide",
+  "help_link": "https://support.cozy.io/",
+  "home_config_magic_folder": "/Settings/Home",
+  "account": {
+    "config": {
+      "default_folder": "/Administratif/%{name}",
+      "optional": "(Optionnel)",
+      "title": "Connectez votre compte %{name}",
+      "data": {
+        "title": "Données collectées :",
+        "service": {
+          "description": "Description du service :"
+        }
+      },
+      "tabs": {
+        "sync": "Synchronisation",
+        "account": "Compte",
+        "data": "Données collectées"
+      }
+    },
+    "disconnect": {
+      "title": "Déconnexion",
+      "description": "Vous serez déconnecté de ce compte, mais les données importées seront conservées"
+    },
+    "form": {
+      "title": "Compte",
+      "label": {
+        "firstname": "Prénom",
+        "lastname": "Nom",
+        "login": "Identifiant",
+        "consumerKey": "Clé client",
+        "consumerSecret": "Secret client",
+        "appKey": "Clé de l'application",
+        "appSecret": "Secret de l'application",
+        "tricountUrl": "URL Tricount",
+        "cardNumber": "Numéro de carte",
+        "dob": "Date de naissance",
+        "password": "Mot de passe",
+        "email": "Mail",
+        "bank_identifier": "Identifiant bancaire (optionnel)",
+        "profileName": "Nom de Profil",
+        "identifier": "Identifiant",
+        "new_identifier": "Identifiant",
+        "secret": "Mot de passe",
+        "answer": "Réponse secrète",
+        "access_token": "Jeton d'accès",
+        "accessTokenSecret": "Secret du jeton d'accès",
+        "apikey": "Clé d'API",
+        "phoneNumber": "Numéro de téléphone",
+        "folderPath": "Emplacement du dossier",
+        "namePath": "Nom du dossier",
+        "authCode": "Code d'authentification",
+        "accountName": "Nom du compte",
+        "loginUrl": "URL d'authentification",
+        "token": "Jeton",
+        "agreement": "J'accepte",
+        "refreshToken": "Mettre à jour le jeton",
+        "timeout": "Délai (ms)",
+        "branchName": "Agence",
+        "code": "Code confidentiel"
+      },
+      "placeholder": {
+        "password": "Le mot de passe utilisé pour vous connecter au service",
+        "update_password": "Mettre à jour le mot de passe",
+        "accountName": "Exemple: Compte personnel",
+        "namePath": "Example : Factures de Camille. Le dossier par défaut sera votre identifiant."
+      },
+      "button": {
+        "connect": "Se connecter",
+        "cancel": "Annuler",
+        "save": "Sauvegarder",
+        "disconnect": "Déconnecter ce compte",
+        "delete": "Supprimer ce compte",
+        "advanced": "Configuration avancée",
+        "synchronize": "Mettre à jour maintenant"
+      }
+    },
+    "folder": {
+      "title": "Paramètres du dossier associé",
+      "withoutSettings": {
+        "title": "Dossier associé"
+      },
+      "link": "Ouvrir le dossier dans Cozy Drive",
+      "changePath": "Changer le dossier",
+      "error": "Mince, quelque chose c'est mal passé. Ne vous inquiétez pas, vos fichiers sont toujours là.",
+      "close": "fermer",
+      "warning": "Vous êtes en train de modifier le dossier de votre connecteur",
+      "oldFiles": "Toutes vos anciennes factures seront déplacées dans votre nouveau dossier.",
+      "newFiles": "Toutes vos nouvelles factures seront téléchargées dans votre nouveau dossier.",
+      "newPath": "Tout s'est bien passé, le nouveau dossier de votre compte %{name} est :",
+      "placeholder": {
+        "administrative": "Administratif",
+        "photos": "Photos"
+      }
+    },
+    "success": {
+      "title": {
+        "connect": "Configuration réussie !",
+        "update": "Votre compte %{name} est mis à jour !"
+      },
+      "banksLinkText": "Voir mes comptes dans %{appName}",
+      "driveLinkText": "Ouvrir le dossier dans Cozy Drive",
+      "button": "Fermer"
+    },
+    "message": {
+      "folder": {
+        "title": "Dossier",
+        "link": "Ouvrir le dossier dans Cozy Drive"
+      },
+      "success": {
+        "connect": "Vos données existantes seront disponibles dans votre Cozy dans quelques minutes et les prochaines suivront automatiquement.",
+        "update": "Votre compte %{name} a été mis à jour avec succès.",
+        "delete": "Compte supprimé avec succès."
+      },
+      "syncing": {
+        "bill": "Vos factures sont en cours de synchronisation et seront disponibles au chemin suivant :"
+      },
+      "synced": {
+        "title": "Mise à jour de vos données",
+        "cron": "Fréquence de mise à jour : %{frequency}",
+        "cron_hourly": "une fois par heure",
+        "cron_daily": "une fois par jour",
+        "cron_weekly": "hebdomadaire",
+        "cron_monthly": "une fois par mois",
+        "cron_undefined": "manuellement",
+        "syncing": "en cours…",
+        "unknown": "indéterminée",
+        "last_sync": "Dernière mise à jour : **%{date}**",
+        "date_format": "Le D MMMM YYYY [à] HH[:]mm",
+        "bill": "Retrouvez vos données dans l'application Cozy Drive à l'emplacement :"
+      },
+      "error": {
+        "server": "Une erreur est survenue, vos identifiants n'ont pas pu être enregistrés. Pouvez-vous recommencer ?",
+        "bad_credentials": "Votre identifiant et/ou mot de passe ne sont pas corrects.",
+        "delete": "Une erreur est survenue, vos identifiants n'ont pas pu être enregistrés. Pouvez-vous recommencer ?"
+      }
+    },
+    "forceConnection": "Relancer maintenant",
+    "editor_detail": "Service développé par %{editor}"
+  },
+  "account_picker": {
+    "add_account_button": {
+      "label": "Ajouter un compte"
+    }
+  },
+  "apps": {
+    "title": "Mes applications"
+  },
+  "connection": {
+    "CTA": {
+      "twofa_failed": "Relancer maintenant"
+    },
+    "error": {
+      "default": {
+        "title": "Une erreur est survenue",
+        "description": "Un problème semble s'être produit pendant la tentative de connexion à %{name}. Merci de revérifier vos informations de compte, de consulter notre aide en ligne ou de nous contacter à contact@cozycloud.cc"
+      },
+      "DISK_QUOTA_EXCEEDED": {
+        "title": "Espace Cozy plein",
+        "description": "Actuellement, le service ne peut plus récupérer vos documents.\nLibérez de l'espace en supprimant des fichiers ou rendez-vous dans **Paramètres > Stockage** pour augmenter l'espace de stockage de votre Cozy"
+      },
+      "CHALLENGE_ASKED": {
+        "title": "Second facteur d’authentification demandé",
+        "description": "Un second facteur d’authentification que nous ne gérons pas encore est demandé. Vous pouvez essayer de vous connecter directement sur le site [%{name}](%{link}) avant de réessayer."
+      },
+      "LOGIN_FAILED": {
+        "title": "Mauvais identifiants",
+        "description": "Données de connexion incorrectes. Vérifiez les données de connexion dans le connecteur et relancez la connexion."
+      },
+      "LOGIN_FAILED.NEEDS_SECRET": {
+        "title": "Informations requise",
+        "description": "Un champ additionnel doit être rempli pour vérifier vos identifiants."
+      },
+      "LOGIN_FAILED.TOO_MANY_ATTEMPTS": {
+        "title": "Temporairement bloqué",
+        "description": "Trop de tentatives erronées ont eu lieu. Merci de modifier votre mot de passe sur le site [%{name}](%{link}) et de mettre à jour le connecteur ensuite."
+      },
+      "MAINTENANCE": {
+        "title": "Site non disponible",
+        "description": "Il semble que le site [%{name}](%{link}) soit indisponible. Merci de relancer ultérieurement ou de consulter notre aide en ligne."
+      },
+      "NOT_EXISTING_DIRECTORY": {
+        "title": "Dossier de destination manquant",
+        "description": "Il semble que le dossier de destination pour ce compte ait été supprimé. Merci de le restaurer en déconnectant ce compte puis en le reconnectant à nouveau."
+      },
+      "UNKNOWN_ERROR": {
+        "title": "Erreur de Connexion",
+        "description": "Une erreur inconnue est survenue"
+      },
+      "USER_ACTION_NEEDED": {
+        "title": "Action nécessaire chez le fournisseur",
+        "description": "Il semble que le site [%{name}](%{link}) ait besoin que vous vous y authentifiiez pour faire une action spécifique. Merci de relancer le connecteur une fois cette action effectuée."
+      },
+      "USER_ACTION_NEEDED.OAUTH_OUTDATED": {
+        "title": "Actualisation de l'accès requis",
+        "description": "Il semble que le site [%{name}](%{link}) demande d'autoriser à nouveau le connecteur. Merci de déconnecter puis reconnecter votre compte %{name}. Aucune donnée ne sera perdue."
+      },
+      "USER_ACTION_NEEDED.ACCOUNT_REMOVED": {
+        "title": "Compte client non accessible",
+        "description": "Il semble que votre compte ne soit plus actif. Merci de vérifier son statut sur le site [%{name}](%{link}) avant de réessayer."
+      },
+      "USER_ACTION_NEEDED.CHANGE_PASSWORD": {
+        "title": "Renouvellement de mot de passe demandé",
+        "description": "Il semble que le site [%{name}](%{link}) ait besoin que vous vous y authentifiiez pour renouveler votre mot de passe. Merci de relancer le connecteur une fois cette action effectuée."
+      },
+      "USER_ACTION_NEEDED.PERMISSIONS_CHANGED": {
+        "title": "Validation des nouvelles permissions nécessaire",
+        "description": "Votre connecteur a été mis à jour et les permissions nécessaires ont changé. Merci de valider les nouvelles permissions avant de relancer le connecteur."
+      },
+      "USER_ACTION_NEEDED.TWOFA_EXPIRED": {
+        "title": "Relancez la connexion au service pour récupérer vos données.",
+        "description": "La dernière connexion au service a échoué; merci de la relancer.\nIl vous faudra peut-être renseigner un code de validation."
+      },
+      "USER_ACTION_NEEDED.WRONG_TWOFA_CODE": {
+        "title": "Le code fournis ne semble pas correct",
+        "description": "Le code de deux facteurs est incorrect, veuillez recommencer."
+      },
+      "VENDOR_DOWN": {
+        "title": "Service non disponible",
+        "description": "Il semble que le service [%{name}](%{link}) ne nous réponde pas dans les temps actuellement. Merci de relancer ultérieurement."
+      },
+      "VENDOR_DOWN.BANK_DOWN": {
+        "title": "Site non disponible",
+        "description": "Site non disponible"
+      },
+      "VENDOR_DOWN.LINXO_DOWN": {
+        "title": "Service non disponible",
+        "description": "Il semble que le site [%{name}](%{link}) ne nous réponde pas dans les temps actuellement. Merci de relancer ultérieurement."
+      }
+    }
+  },
+
+  "intent": {
+    "konnector": {
+      "install": {
+        "error": {
+          "message": "Le connecteur ne peut pas être installé"
+        }
+      }
+    },
+    "service": {
+      "return": "Revenir à la liste des connecteurs",
+      "success": {
+        "button": {
+          "label": "Fermer"
+        }
+      },
+      "error": {
+        "initialization": "L'initialisation du service a échoué.",
+        "creation": "Impossible de créer le compte, il y a eu une erreur.",
+        "cause": "Raison : %{error}"
+      },
+      "cancel": "Annuler",
+      "terminate": "Terminer"
+    }
+  },
+
+  "field": {
+    "password": {
+      "visibility": {
+        "hide": "Masquer",
+        "show": "Afficher",
+        "title": {
+          "hide": "Masquer le mot de passe",
+          "show": "Afficher le mot de passe"
+        }
+      }
+    }
+  },
+
+  "nav": {
+    "services": "Services installés"
+  },
+
+  "category": {
+    "all": "Tous",
+    "banking": "Banques",
+    "health": "Santé",
+    "insurance": "Assurance",
+    "transport": "Voyage et transport",
+    "social": "Social",
+    "isp": "Internet",
+    "telecom": "Mobile",
+    "energy": "Énergie",
+    "host_provider": "Hébergeur",
+    "productivity": "Productivité",
+    "shopping": "Shopping",
+    "public_service": "Services publics",
+    "other": "Autres"
+  },
+
+  "loading": {
+    "initial": "Chargement des comptes…",
+    "working": "Chargement"
+  },
+
+  "validation": {
+    "exact_length": "La valeur doit faire exactement %{length} caractères.",
+    "max_length": "La longueur maximum est de %{length} caractères.",
+    "min_length": "La valeur doit contenir au moins %{length} caractères.",
+    "pattern": "La valeur doit respecter un format spécifique : %{pattern}"
+  },
+
+  "update": {
+    "title": "Une mise à jour est disponible pour ce service.",
+    "regular": "Effectuez la mise à jour pour continuer à récupérer vos données et profiter des dernières fonctionnalités",
+    "blocking": "Mettez-le à jour pour continuer à récupérer vos données",
+    "CTA": "Mettre à jour"
+  },
+
+  "error": {
+    "initial": "Quelque chose s’est mal passé pendant la récupération de vos connecteurs et de vos informations. Merci de recharger la page.",
+    "LOGIN_FAILED": "Données de connexion incorrectes. Vérifiez les données de connexion dans le connecteur et relancez la connexion.",
+    "UNKNOWN_ERROR": "Quelque-chose d’inattendu s‘est produit pendant l’exécution du connecteur",
+    "JOB_TIMEOUT": "L’exécution du connecteur a pris trop de temps",
+    "button": {
+      "reload": "Rechargez la page maintenant"
+    }
+  },
+  "tutorial": {
+    "cozy_collect": {
+      "title": "Automatisez la récupération de vos données",
+      "text": "Elles seront conservées dans votre Cozy pour que vous n'ayez plus à les chercher.",
+      "button": "Suivant"
+    },
+    "home": {
+      "apps": {
+        "button": "Suivant",
+        "text": "Gérez facilement toute votre vie numérique (photos, fichiers, compte bancaires, …)",
+        "title": "Retrouvez toutes les applications de votre Cozy"
+      },
+      "services": {
+        "button": "Je connecte mes comptes",
+        "text": "Elles seront conservées dans votre Cozy pour que vous n'ayez plus à les chercher.",
+        "title": "Automatisez la récupération de vos données"
+      }
+    },
+    "menu_apps": {
+      "title": "Votre Cozy est bien plus qu’un simple agrégateur de données",
+      "text": "Ouvrez le menu Applications pour découvrir toutes les possibilités offertes par votre Cozy.",
+      "button": "Je découvre mes Applications"
+    }
+  },
+
+  "maintenance": {
+    "icon": "Ce connecteur est en cours de maintenance",
+    "service": "Service interrompu",
+    "problem": "%{konnectorName} ne permet pas à votre Cozy d'accéder à vos données",
+    "title": "Que se passe-t-il ?"
+  },
+
+  "connector": {
+    "debug": {
+      "successMessage": "Ce konnecteur est utilisé uniquement pour déboguer l'application, ceci est un message de succès additionnel."
+    },
+    "empty": {
+      "title": "Commencez à réunir vos données !",
+      "text": "Synchronisez vos marques avec votre Cozy pour récupérer automatiquement vos données (factures, remboursements, dépenses…)"
+    },
+    "silenced": "%{name} n’est plus proposé. Vous pourrez toujours retrouver un fournisseur en cliquant sur \"Ajouter\"",
+    "noAccount": "Aucun compte",
+    "add": "Ajouter un service",
+    "update": "Mise à jour dispo.",
+    "logo": {
+      "alt": "Logo de %{name}"
+    },
+    "enedis": {
+      "description": {
+        "service": "Retrouvez vos données Linky en connectant votre compte Enedis. Vous devez avoir un compteur Linky et avoir préalablement créé votre compte Enedis (sur [Enedis website](https://espace-client-connexion.enedis.fr/auth/UI/Login?realm=particuliers). Ce connecteur est proposé par Fing pour le projet MesInfos. Il récupère les données de votre contrat d'électricité et télécharge vos consommations électriques de la veille. Ce connecteur fonctionne sur votre Cozy et Fing n'aura aucun accès à vos données."
+      }
+    },
+    "orange": {
+      "message": {
+        "delay": "Une demande d’extraction de vos données a été émise vers le système d’information d’Orange. Ces données seront disponibles sous 7 jours. Par la suite, vos données seront mises à jour automatiquement dans votre espace Cozy Cloud, à intervalles de 7 jours."
+      }
+    },
+    "orangemobile": {
+      "description": {
+        "connector": "**De manière optionnelle et dans le cadre du pilote « Mes Infos »**, Orange vous offre aussi la possibilité de localiser votre téléphone mobile de manière régulière.\n\n**Le recueil de ces données nécessite votre accord explicite.**\n\nCet accord pourra être révoqué à tout moment via ce même connecteur de données.\n\nEn cliquant sur « Accepter », vous donnerez votre accord pour qu’une localisation de votre téléphone mobile soit effectuée à compter de ce jour, deux fois par heure. Les informations recueillies contiendront uniquement :\n<ul><li>La date et l’heure de cette localisation.</li><li>Les coordonnées géographiques de l’antenne radio à laquelle le mobile est rattaché au moment de la localisation.</li></ul>Les données récoltées par Orange  seront accessibles, après votre accord, uniquement dans le Cozy Cloud qui vous a été attribué dans le cadre du pilote « Mes Infos ». Elles viendront compléter les informations de localisation déjà présentes dans les comptes rendus d’appels.",
+        "service": "Les données mises à disposition par Orange via ce connecteur contiennent les comptes rendus des appels émis et reçus depuis votre mobile à partir du 01/07/2016. Ces comptes rendus incluent votre numéro, celui de votre correspondant, l’heure et la durée de l’appel, ainsi que la localisation géographique de l’antenne radio à laquelle le mobile était rattaché au moment de l’appel.\n\nVous pourrez utiliser ces données dans différentes applications de votre Cozy Cloud, par exemple « Mapping My Life » (disponibilité prochaine sur le Cozy Store)",
+        "field": {
+          "agreement": "Acceptez-vous qu’Orange localise régulièrement votre téléphone mobile dans le cadre du pilote « Mes Infos » ?"
+        }
+      }
+    },
+    "orangevideos": {
+      "description": {
+        "service": "Les données mises à disposition par Orange via ce connecteur contiennent la liste des films que vous avez visionnés à partir du 01/01/2015 en VOD payante ou gratuite (Replay TV) à partir de votre Livebox (à l’exception des contenus « adulte »). \n\nVous pourrez utiliser ces données dans différentes applications de votre Cozy, par exemple « La Musique de mes Films » (disponibilité prochaine sur le Cozy Store) "
+      }
+    },
+    "axabanque102": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "banquepopulaire": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "barclays136": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo). "
+      }
+    },
+    "bforbank97": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "bnpparibas82": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "boursorama83": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "bred": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "caatlantica3": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "caissedepargne1": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "carrefour159": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "casden173": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "cdngroup109": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "cdngroup88": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "cic45": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "cic63": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "comptenickel168": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "creditcooperatif148": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "creditmaritime": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "fortuneo84": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "hellobank145": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "hsbc119": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo).",
+        "connector": "La réponse secrète est [demandée par HSBC](https://www.hsbc.fr/1/2/hsbc-france/particuliers/connexion) lors d'une connexion sans double authentification. Exemple: quel est le nom de votre animal de compagnie? "
+      }
+    },
+    "ingdirect95": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "labanquepostale44": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "lcl143": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "lcl144": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "lcl146": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "monabanq96": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    },
+    "societegenerale": {
+      "description": {
+        "service": "La connexion à votre banque est opérée et sécurisée par notre partenaire Linxo. [En savoir plus](https://support.cozy.io/article/147-linxo)."
+      }
+    }
+  },
+  "Queue": {
+    "header": "Synchronisation :",
+    "header_mobile": "%{done} sur %{total}",
+    "header_done": "Synchronisé %{done} sur %{total}",
+    "item": {
+      "pending": "En cours"
+    },
+    "close": "Fermer"
+  },
+  "services": {
+    "title": "Mes services"
+  },
+  "status": {
+    "interrupted": "SERVICE INTERROMPU",
+    "edf": {
+      "maintenance": "EDF a modifié son système d'information et son accès à vos données ne fonctionne plus. Ce connecteur n'est donc pas actuellement en mesure de récupérer vos données personnelles détenues par EDF. Nous tentons de rétablir la situation et vous informerons dès que le service sera rétabli. [En savoir plus](%{supportLink})",
+      "support_link": "https://support.cozy.io/article/123-le-connecteur-edf-ne-fonctionne-pas"
+    }
+  },
+  "tile": {
+    "konnector": {
+      "lastSyncDate": {
+        "format": "DD MMM"
+      }
+    }
+  }
+}

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,0 +1,29 @@
+import { Application } from 'cozy-doctypes'
+
+const ACCOUNTS_DOCTYPE = 'io.cozy.accounts'
+
+const schema = {
+  app: Application.schema,
+  accounts: {
+    doctype: ACCOUNTS_DOCTYPE,
+    attributes: {},
+    relationships: {
+      master: {
+        type: 'has-one',
+        doctype: ACCOUNTS_DOCTYPE
+      }
+    }
+  },
+  permissions: {
+    doctype: 'io.cozy.permissions',
+    attributes: {}
+  },
+  triggers: {
+    doctype: 'io.cozy.triggers'
+  },
+  jobs: {
+    doctype: 'io.cozy.jobs'
+  }
+}
+
+export default schema

--- a/src/schema.js
+++ b/src/schema.js
@@ -23,6 +23,20 @@ const schema = {
   },
   jobs: {
     doctype: 'io.cozy.jobs'
+  },
+  bankAccounts: {
+    doctype: 'io.cozy.bank.accounts',
+    attributes: {},
+    relationships: {
+      checkingsAccount: {
+        type: 'has-one',
+        doctype: 'io.cozy.bank.accounts'
+      },
+      owners: {
+        type: 'has-many',
+        doctype: 'io.cozy.contacts'
+      }
+    }
   }
 }
 

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -1,97 +1,29 @@
 /* global __DEVELOPMENT__ */
 import 'cozy-ui/transpiled/react/stylesheet.css'
 
-import memoize from 'lodash/memoize'
 import React from 'react'
 import { render } from 'react-dom'
 import { Provider as ReduxProvider } from 'react-redux'
-import {
-  CozyClient as LegacyCozyClient,
-  CozyProvider as LegacyCozyProvider
-} from 'lib/redux-cozy-client'
+import { CozyProvider as LegacyCozyProvider } from 'lib/redux-cozy-client'
 import 'url-search-params-polyfill'
-import CozyClient, { CozyProvider } from 'cozy-client'
-import { Application } from 'cozy-doctypes'
+import { CozyProvider } from 'cozy-client'
 import { handleOAuthResponse } from 'cozy-harvest-lib'
 import I18n from 'cozy-ui/react/I18n'
 import { BreakpointsProvider } from 'cozy-ui/react/hooks/useBreakpoints'
-import flag from 'cozy-flags'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 
 import homeConfig from 'config/home.json'
+import { setupAppContext } from '../../appContext'
 import PiwikHashRouter from 'lib/PiwikHashRouter'
-import configureStore from 'store/configureStore'
 
 import 'cozy-ui/dist/cozy-ui.min.css'
 import 'intro.js-fix-cozy/minified/introjs.min.css'
 import 'styles/index.styl'
 
-const lang = document.documentElement.getAttribute('lang') || 'en'
-const context = window.context || 'cozy'
-
-const ACCOUNTS_DOCTYPE = 'io.cozy.accounts'
-
-const schema = {
-  app: Application.schema,
-  accounts: {
-    doctype: ACCOUNTS_DOCTYPE,
-    attributes: {},
-    relationships: {
-      master: {
-        type: 'has-one',
-        doctype: ACCOUNTS_DOCTYPE
-      }
-    }
-  },
-  permissions: {
-    doctype: 'io.cozy.permissions',
-    attributes: {}
-  },
-  triggers: {
-    doctype: 'io.cozy.triggers'
-  },
-  jobs: {
-    doctype: 'io.cozy.jobs'
-  }
-}
-
-/**
- * Setups clients and store
- *
- * Is memoized to avoid several clients in case of hot-reload
- */
-const setupAppContext = memoize(() => {
-  const root = document.querySelector('[role=application]')
-  const data = root.dataset
-
-  // New improvements must be done with CozyClient
-  const cozyClient = new CozyClient({
-    uri: `${window.location.protocol}//${data.cozyDomain}`,
-    schema,
-    token: data.cozyToken
-  })
-
-  cozyClient.registerPlugin(flag.plugin)
-
-  const legacyClient = new LegacyCozyClient({
-    cozyURL: `//${data.cozyDomain}`,
-    token: data.cozyToken,
-    cozyClient
-  })
-
-  // store
-  const store = configureStore(legacyClient, cozyClient, context, {
-    lang,
-    ...homeConfig
-  })
-
-  return { cozyClient, store, data }
-})
-
 const renderApp = () => {
   if (handleOAuthResponse()) return
 
-  const { cozyClient, store, data } = setupAppContext()
+  const { cozyClient, store, data, lang, context } = setupAppContext()
   const dictRequire = lang => require(`locales/${lang}.json`)
   const App = require('containers/App').default
   render(

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -16,6 +16,7 @@ import { handleOAuthResponse } from 'cozy-harvest-lib'
 import I18n from 'cozy-ui/react/I18n'
 import { BreakpointsProvider } from 'cozy-ui/react/hooks/useBreakpoints'
 import flag from 'cozy-flags'
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 
 import homeConfig from 'config/home.json'
 import PiwikHashRouter from 'lib/PiwikHashRouter'
@@ -94,24 +95,26 @@ const renderApp = () => {
   const dictRequire = lang => require(`locales/${lang}.json`)
   const App = require('containers/App').default
   render(
-    <CozyProvider client={cozyClient}>
-      <LegacyCozyProvider
-        store={store}
-        client={cozyClient}
-        domain={data.cozyDomain}
-        secure={!__DEVELOPMENT__}
-      >
-        <ReduxProvider store={store}>
-          <I18n lang={lang} dictRequire={dictRequire} context={context}>
-            <BreakpointsProvider>
-              <PiwikHashRouter>
-                <App {...homeConfig} />
-              </PiwikHashRouter>
-            </BreakpointsProvider>
-          </I18n>
-        </ReduxProvider>
-      </LegacyCozyProvider>
-    </CozyProvider>,
+    <MuiCozyTheme>
+      <CozyProvider client={cozyClient}>
+        <LegacyCozyProvider
+          store={store}
+          client={cozyClient}
+          domain={data.cozyDomain}
+          secure={!__DEVELOPMENT__}
+        >
+          <ReduxProvider store={store}>
+            <I18n lang={lang} dictRequire={dictRequire} context={context}>
+              <BreakpointsProvider>
+                <PiwikHashRouter>
+                  <App {...homeConfig} />
+                </PiwikHashRouter>
+              </BreakpointsProvider>
+            </I18n>
+          </ReduxProvider>
+        </LegacyCozyProvider>
+      </CozyProvider>
+    </MuiCozyTheme>,
     document.querySelector('[role=application]')
   )
 }

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -1,5 +1,8 @@
 /* global __DEVELOPMENT__ */
 import 'cozy-ui/transpiled/react/stylesheet.css'
+import 'cozy-ui/dist/cozy-ui.min.css'
+import 'intro.js-fix-cozy/minified/introjs.min.css'
+import 'styles/index.styl'
 
 import React from 'react'
 import { render } from 'react-dom'
@@ -15,10 +18,6 @@ import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import homeConfig from 'config/home.json'
 import { setupAppContext } from '../../appContext'
 import PiwikHashRouter from 'lib/PiwikHashRouter'
-
-import 'cozy-ui/dist/cozy-ui.min.css'
-import 'intro.js-fix-cozy/minified/introjs.min.css'
-import 'styles/index.styl'
 
 const renderApp = () => {
   if (handleOAuthResponse()) return

--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -1,9 +1,10 @@
 /* global __DEVELOPMENT__ */
+import 'cozy-ui/transpiled/react/stylesheet.css'
+import 'cozy-ui/dist/cozy-ui.min.css'
+
 import React from 'react'
 import { render } from 'react-dom'
 import { HashRouter } from 'react-router-dom'
-import 'cozy-ui/transpiled/react/stylesheet.css'
-import 'cozy-ui/dist/cozy-ui.min.css'
 import { CozyProvider } from 'cozy-client'
 import { I18n } from 'cozy-ui/react/I18n'
 

--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -4,71 +4,25 @@ import { render } from 'react-dom'
 import { HashRouter } from 'react-router-dom'
 import 'cozy-ui/transpiled/react/stylesheet.css'
 import 'cozy-ui/dist/cozy-ui.min.css'
-import MostRecentCozyClient, {
-  CozyProvider as MostRecentCozyClientProvider
-} from 'cozy-client'
+import { CozyProvider } from 'cozy-client'
 import { I18n } from 'cozy-ui/react/I18n'
 
-import configureStore from 'store/configureStore'
-import { CozyClient, CozyProvider } from 'lib/redux-cozy-client'
-
-import { Application } from 'cozy-doctypes'
+import { CozyProvider as LegacyCozyProvider } from 'lib/redux-cozy-client'
 
 import IntentHandler from 'containers/IntentHandler'
+import { setupAppContext } from '../../appContext'
 
 import 'styles/intents.styl'
 
-const lang = document.documentElement.getAttribute('lang') || 'en'
-const context = window.context || 'cozy'
-
-const ACCOUNTS_DOCTYPE = 'io.cozy.accounts'
-
 document.addEventListener('DOMContentLoaded', () => {
-  const root = document.querySelector('[role=application]')
-  const appData = root.dataset
-
-  const legacyClient = new CozyClient({
-    cozyURL: `//${appData.cozyDomain}`,
-    token: appData.cozyToken
-  })
-
-  // New improvements must be done with CozyClient
-  const cozyClient = new MostRecentCozyClient({
-    uri: `${window.location.protocol}//${appData.cozyDomain}`,
-    schema: {
-      app: Application.schema,
-      accounts: {
-        doctype: ACCOUNTS_DOCTYPE,
-        attributes: {},
-        relationships: {
-          master: {
-            type: 'has-one',
-            doctype: ACCOUNTS_DOCTYPE
-          }
-        }
-      },
-      permissions: {
-        doctype: 'io.cozy.permissions',
-        attributes: {}
-      },
-      triggers: {
-        doctype: 'io.cozy.triggers'
-      }
-    },
-    token: appData.cozyToken
-  })
-
-  // store
-  const store = configureStore(legacyClient, cozyClient, context, {
-    lang
-  })
+  const { client, data, store, lang, context } = setupAppContext()
 
   render(
-    <MostRecentCozyClientProvider client={cozyClient}>
-      <CozyProvider
-        domain={appData.cozyDomain}
+    <CozyProvider client={client}>
+      <LegacyCozyProvider
+        domain={data.cozyDomain}
         store={store}
-        client={cozyClient}
+        client={client}
         secure={!__DEVELOPMENT__}
       >
         <I18n
@@ -77,11 +31,11 @@ document.addEventListener('DOMContentLoaded', () => {
           context={context}
         >
           <HashRouter>
-            <IntentHandler appData={appData} />
+            <IntentHandler appData={data} />
           </HashRouter>
         </I18n>
-      </CozyProvider>
-    </MostRecentCozyClientProvider>,
+      </LegacyCozyProvider>
+    </CozyProvider>,
     document.querySelector('[role=application]')
   )
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3631,10 +3631,10 @@ cozy-realtime@3.2.1:
   dependencies:
     minilog "3.1.0"
 
-cozy-scripts@4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/cozy-scripts/-/cozy-scripts-4.3.0.tgz#2a89b485eb341127e2a769723d15df818fa870d1"
-  integrity sha512-baci+PQq/a7cWux3d/ZF/yCESxS/X61P8ft2CSfADQWy99KpW/l/FvflqwDzdNa1614oMNckOziHSr8PTw3dkw==
+cozy-scripts@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/cozy-scripts/-/cozy-scripts-4.3.1.tgz#440ab971ffaf71ddf10cea2a663d70c46cb7fbce"
+  integrity sha512-TGwvdSTPCj32ymGY76AT7gwRAYL8qOsfcs5XgcIJY7TpSxsvdp4jq7R4D6Xl5rv+EQmig1NvfmUruJ+O+BFDgA==
   dependencies:
     "@babel/core" "7.9.0"
     "@babel/polyfill" "^7.10.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1001,6 +1001,14 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz#02c3029743150188edeb66541195f54600278419"
+  integrity sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime-corejs3@^7.8.3":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.10.2.tgz#3511797ddf9a3d6f3ce46b99cc835184817eaa4e"
@@ -1043,6 +1051,13 @@
   integrity sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==
   dependencies:
     regenerator-runtime "^0.12.0"
+
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.5.5":
   version "7.8.7"
@@ -1367,6 +1382,17 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@jest/types@^26.3.0":
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.3.0.tgz#97627bf4bdb72c55346eef98e3b3f7ddc4941f71"
+  integrity sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@material-ui/core@3", "@material-ui/core@3.9.4":
   version "3.9.4"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-3.9.4.tgz#5297fd4ad9e739a87da4a6d34fc4af5396886e13"
@@ -1485,6 +1511,30 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@testing-library/dom@^7.22.3":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.22.5.tgz#178fb0bfb52540538667f2f72d4b7fb406a49499"
+  integrity sha512-qALmosaNSny/JqQ+mDhdT0N5u1a76pEcOvfWFDpBQOchtkxDm/w/bCfe0J/K7nHrwJPHelFiAZksaBs//P9fsw==
+  dependencies:
+    "@babel/runtime" "^7.10.3"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    dom-accessibility-api "^0.5.1"
+    pretty-format "^26.4.2"
+
+"@testing-library/react@^10.4.9":
+  version "10.4.9"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.4.9.tgz#9faa29c6a1a217bf8bbb96a28bd29d7a847ca150"
+  integrity sha512-pHZKkqUy0tmiD81afs8xfiuseXfU/N7rAX3iKjeZYje86t9VaB0LrxYVa+OOsvkrveX5jCK3IjajVn2MbePvqA==
+  dependencies:
+    "@babel/runtime" "^7.10.3"
+    "@testing-library/dom" "^7.22.3"
+
+"@types/aria-query@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
+  integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
+
 "@types/babel__core@^7.1.0":
   version "7.1.8"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.8.tgz#057f725aca3641f49fc11c7a87a9de5ec588a5d7"
@@ -1557,6 +1607,13 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
+  integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
+  dependencies:
+    "@types/istanbul-lib-report" "*"
+
 "@types/json-schema@^7.0.4":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
@@ -1619,6 +1676,13 @@
   version "13.0.9"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.9.tgz#44028e974343c7afcf3960f1a2b1099c39a7b5e1"
   integrity sha512-xrvhZ4DZewMDhoH1utLtOAwYQy60eYFoXeje30TzM3VOvQlBwQaEpKFq5m34k1wOw2AKIi2pwtiAjdmhvlBUzg==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^15.0.0":
+  version "15.0.5"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.5.tgz#947e9a6561483bdee9adffc983e91a6902af8b79"
+  integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -1947,6 +2011,11 @@ ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -1959,7 +2028,7 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
   integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
@@ -2021,6 +2090,14 @@ argsarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/argsarray/-/argsarray-0.0.1.tgz#6e7207b4ecdb39b0af88303fa5ae22bda8df61cb"
   integrity sha1-bnIHtOzbObCviDA/pa4ivajfYcs=
+
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -2916,6 +2993,14 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 change-emitter@^0.1.2:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
@@ -3535,10 +3620,10 @@ cozy-doctypes@1.72.2:
     lodash "4.17.15"
     prop-types "^15.7.2"
 
-cozy-doctypes@^1.74.1:
-  version "1.74.1"
-  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.74.1.tgz#8b14a44b15b33da768234171e317a3fe5bd1bebe"
-  integrity sha512-7X4ouRVI5d0eWDio9n2DqQUI3YJhxaTKiPKAwOw2j9BjZaawHw5KBen9tAAVhEvcg+ya/Cb7cRS2ANPUvSeKtQ==
+cozy-doctypes@^1.74.4:
+  version "1.74.4"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.74.4.tgz#658f8ce8086b0b59130ed6dc431d097c52d79cdf"
+  integrity sha512-+XC2SyJYIhHAduEvQ9vbkf2UNZJbzRXkDMlj7473zcfBm4G0vKFUqjkbz/uoQchdvksjuiJxSCcC9yNLFg6CnA==
   dependencies:
     "@babel/runtime" "7.5.5"
     cozy-logger "^1.6.0"
@@ -3547,24 +3632,32 @@ cozy-doctypes@^1.74.1:
     lodash "4.17.19"
     prop-types "^15.7.2"
 
-cozy-flags@2.3.2, cozy-flags@^2.3.2:
+cozy-flags@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.3.2.tgz#79849c28a0ad94e2ceb6d9f0126f957cfd78455d"
   integrity sha512-U9TZrC+ViBoptrkcDq31jLStRGIx8lpxvjFICIa37ITyHEVs7W2LKKJxSViO16gEh1UBA+m2p/TvdQ/mP/xJjA==
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@1.41.0:
-  version "1.41.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-1.41.0.tgz#64b701e6e28f940e4b5dfed7567d14b78e4e0268"
-  integrity sha512-M9G6BF7XXGq5PBE+hH0ICTnoLpWPt87FPvmwZhZx/zqMVBOAuvw6TCoMmmgn5TG1NgP3Pn73u+OEl9aaTakYcQ==
+cozy-flags@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.3.3.tgz#4f9cca9190d46f7c47062da47be77cc005ab3850"
+  integrity sha512-5fDbaRSI8fw+WT6miLcf7ufEUJeHrS11+hoZGXShfqQU6DnepDphUpt7osSFhd26T7L54c1YFTKR9gMgCqeJNg==
+  dependencies:
+    microee "^0.0.6"
+
+cozy-harvest-lib@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-2.0.0.tgz#720b9d20407f25c84c98a7ded7822994660932bf"
+  integrity sha512-oGwcHzMMPxG0+2Wn+vYkaCm/IQfqt2rVrSVN/aRcNIsVoQqG556mK4qfL4GWzl1mhQMKekUTRgbN/TULTSv6+w==
   dependencies:
     "@babel/runtime" "^7.5.2"
     "@material-ui/core" "3"
+    "@testing-library/react" "^10.4.9"
     cozy-bi-auth "0.0.6"
-    cozy-doctypes "^1.74.1"
-    cozy-flags "^2.3.2"
-    cozy-keys-lib "3.1.1"
+    cozy-doctypes "^1.74.4"
+    cozy-flags "^2.3.3"
+    cozy-keys-lib "3.1.2"
     cozy-logger "1.6.0"
     date-fns "^1.30.1"
     final-form "4.18.5"
@@ -3587,7 +3680,28 @@ cozy-interapp@0.5.4:
   resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.5.4.tgz#2573f1800f073c84c289267d04234954d88eae0c"
   integrity sha512-f0UaKpBkRUnIKgAWND0e1IwfTTINjizlgDmfQwX3aMyWp8t9wX0xkNFn53TSyKUoBUnfovrclS3hm9fngjEp7A==
 
-cozy-keys-lib@3.1.1, cozy-keys-lib@^3.1.1:
+cozy-keys-lib@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-3.1.2.tgz#524b4360d8e6008c3f234aeb9bd9730f1d2276fc"
+  integrity sha512-AgCO7otBoUvNs5lYWZquXm/YItM3Go+WseeFx99e6KuYs4219cSlEjzNyHgIGythfXRiBlQjWVuZaK4t/yvaPQ==
+  dependencies:
+    "@aspnet/signalr" "^1.1.4"
+    "@aspnet/signalr-protocol-msgpack" "^1.1.0"
+    big-integer "^1.6.44"
+    classnames "^2.2.6"
+    cozy-device-helper "^1.7.5"
+    lodash "^4.17.15"
+    lunr "^2.3.6"
+    microee "^0.0.6"
+    minilog "https://github.com/cozy/minilog.git#master"
+    node-forge "^0.9.0"
+    papaparse "^5.1.1"
+    prop-types "^15.7.2"
+    sweetalert "^2.1.2"
+    tldjs "^2.3.1"
+    zxcvbn "^4.4.2"
+
+cozy-keys-lib@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-3.1.1.tgz#d2e896498f168e28bc82801a59062f8bea47c2d5"
   integrity sha512-3RHbTB12YKlFUqBqxYovbNZ3dLUz1L9YkwmIuksVBUk6Kk3NZuMLd9BMgvgZRhanKhXQZQYMri6hmnZOya9ItQ==
@@ -4342,6 +4456,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.1.tgz#152f5e88583d900977119223e3e76c2d93d23830"
+  integrity sha512-8DhtmKTYWXNpPiL/QOszbnkAbCGuPz9ieVwDrmWM1rNx4KRI3zqmvKANAD1PJdvvov3+eq1BPLXQkYTpqTrWng==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -8331,6 +8450,13 @@ minilog@3.1.0, "minilog@https://github.com/cozy/minilog.git#master":
   dependencies:
     microee "0.0.6"
 
+"minilog@git+https://github.com/cozy/minilog.git#master":
+  version "3.1.0"
+  uid f01f7d9dfe20981177dd34b9662c2f077d818f82
+  resolved "git+https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
+  dependencies:
+    microee "0.0.6"
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -10225,6 +10351,16 @@ pretty-format@^24.9.0:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
+
+pretty-format@^26.4.2:
+  version "26.4.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.4.2.tgz#d081d032b398e801e2012af2df1214ef75a81237"
+  integrity sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==
+  dependencies:
+    "@jest/types" "^26.3.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
 
 private@^0.1.6:
   version "0.1.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3711,10 +3711,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@35.38.0:
-  version "35.38.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.38.0.tgz#0477dedba671728d8a79a6ac0d7cc1a639106393"
-  integrity sha512-vd48PeCRd/BGyMtTDA2Q2ztDkY6T1dnUs+wf+PnUDGy7OxVWslLKWOjCzYehlZpwd5Z9LERlL12UifDMlJmetQ==
+cozy-ui@35.39.0:
+  version "35.39.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.39.0.tgz#b15532a809a29f097569b2ef3ebb1991226ef646"
+  integrity sha512-4aKCB6IvDeSV/Mu2fX754UUz6P7A5t0Cqk63CD4wKigLxaNd6rhNZUFpISJy9pkqbl3lX1KgNiesryBt6+gM5g==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
- Harvest update (brings contract display/edition behind a the harvest.show-contracts)
  - Refactored entrypoints (see next point)
  - Schema update so that the home knows about bankAccounts (TODO, share schemas across apps via cozy-client ?)

- DX
  - Store locales in repository
  - Update cozy-scripts so that webpack-dev-server works correctly