### PR TITLE
fix: Even the LegacyClientProvider takes the new cozy-client

### DIFF
--- a/src/appContext.js
+++ b/src/appContext.js
@@ -39,5 +39,5 @@ export const setupAppContext = memoize(() => {
     ...homeConfig
   })
 
-  return { cozyClient, legacyClient, store, data, lang, context }
+  return { cozyClient, store, data, lang, context }
 })

--- a/src/appContext.spec.js
+++ b/src/appContext.spec.js
@@ -18,7 +18,6 @@ describe('app context', () => {
     expect(appContext).toEqual(
       expect.objectContaining({
         cozyClient: expect.any(Object),
-        legacyClient: expect.any(Object),
         store: expect.any(Object),
         data: expect.any(Object),
         lang: 'fr',

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -22,14 +22,7 @@ import PiwikHashRouter from 'lib/PiwikHashRouter'
 const renderApp = () => {
   if (handleOAuthResponse()) return
 
-  const {
-    cozyClient,
-    legacyClient,
-    store,
-    data,
-    lang,
-    context
-  } = setupAppContext()
+  const { cozyClient, store, data, lang, context } = setupAppContext()
   const dictRequire = lang => require(`locales/${lang}.json`)
   const App = require('containers/App').default
   render(
@@ -37,7 +30,7 @@ const renderApp = () => {
       <CozyProvider client={cozyClient}>
         <LegacyCozyProvider
           store={store}
-          client={legacyClient}
+          client={cozyClient}
           domain={data.cozyDomain}
           secure={!__DEVELOPMENT__}
         >

--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -16,14 +16,7 @@ import IntentHandler from 'containers/IntentHandler'
 import { setupAppContext } from '../../appContext'
 
 document.addEventListener('DOMContentLoaded', () => {
-  const {
-    cozyClient,
-    legacyClient,
-    data,
-    store,
-    lang,
-    context
-  } = setupAppContext()
+  const { cozyClient, data, store, lang, context } = setupAppContext()
 
   const dictRequire = lang => require(`locales/${lang}.json`)
 
@@ -32,7 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
       <LegacyCozyProvider
         domain={data.cozyDomain}
         store={store}
-        client={legacyClient}
+        client={cozyClient}
         secure={!__DEVELOPMENT__}
       >
         <ReduxProvider store={store}>


### PR DESCRIPTION
The LegacyClientProvider takes the new cozy-client, not the
ad-hoc one from the home.