### PR TITLE
fix: Prevent flow crash when adding a banking account from intent

### DIFF
--- a/src/ducks/connections/index.js
+++ b/src/ducks/connections/index.js
@@ -40,11 +40,17 @@ const reducer = (state = {}, action) => {
     case UPDATE_CONNECTION_ERROR:
     case UPDATE_CONNECTION_RUNNING_STATUS:
     case LAUNCH_TRIGGER:
-      // Trigger is launched, connection should be running.
-      if (!action.trigger || !action.trigger._id)
-        throw new Error('Missing trigger id')
-      if (!action.trigger.message || !action.trigger.message.konnector)
-        throw new Error('Malformed trigger message')
+      // Ignore the action if trigger does not have an id
+      // This is possible that an enqueue connection is dispatched
+      // with a trigger without _id, this is because for banking
+      // konnectors, the LOGIN_SUCCESS action is dispatched before
+      // the trigger has been created, thus a fake trigger is created
+      if (!action.trigger || !action.trigger._id) {
+        return state
+      }
+      if (!action.trigger.message || !action.trigger.message.konnector) {
+        return state
+      }
       return {
         ...state,
         [getTriggerKonnectorSlug(action.trigger)]: konnectorReducer(

--- a/src/ducks/connections/test/__snapshots__/connections.spec.js.snap
+++ b/src/ducks/connections/test/__snapshots__/connections.spec.js.snap
@@ -1,11 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Connections Duck Action creators enqueueConnection marks account as queued 1`] = `
+exports[`Connections Duck Action creators enqueueConnection marks trigger as queued 1`] = `
 Object {
-  "testprovider": Object {
-    "17375ac5a59e4d6585fc7d1e1c75ec74": Object {
-      "isEnqueued": true,
+  "creation": null,
+  "konnectors": Object {
+    "testprovider": Object {
+      "triggers": Object {
+        "trigger-1": Object {
+          "isEnqueued": true,
+        },
+      },
     },
+  },
+}
+`;
+
+exports[`Connections Duck Action creators enqueueConnection should ignore when trigger has no _id 1`] = `
+Object {
+  "creation": null,
+  "konnectors": Object {
+    "testprovider": Object {},
   },
 }
 `;

--- a/src/ducks/connections/test/connections.spec.js
+++ b/src/ducks/connections/test/connections.spec.js
@@ -245,16 +245,49 @@ describe('Connections Duck', () => {
 
   describe('Action creators', () => {
     describe('enqueueConnection', () => {
-      it.skip('marks account as queued', () => {
+      it('marks trigger as queued', () => {
         const state = {
-          testprovider: {
-            '17375ac5a59e4d6585fc7d1e1c75ec74': {}
+          konnectors: {
+            testprovider: {}
+          }
+        }
+        const konnector = { slug: 'testprovider' }
+        const account = { _id: '17375ac5a59e4d6585fc7d1e1c75ec74' }
+        const trigger = {
+          _id: 'trigger-1',
+          message: {
+            account: account._id,
+            konnector: konnector.slug
+          }
+        }
+
+        const result = connections(state, enqueueConnection(trigger))
+
+        expect(result).toMatchSnapshot()
+      })
+
+      it('should ignore when trigger has no _id', () => {
+        const state = {
+          konnectors: {
+            testprovider: {}
           }
         }
         const konnector = { slug: 'testprovider' }
         const account = { _id: '17375ac5a59e4d6585fc7d1e1c75ec74' }
 
-        const result = connections(state, enqueueConnection(konnector, account))
+        // This is possible that an enqueue connection is dispatched
+        // with a trigger without _id, this is because for banking
+        // konnectors, the LOGIN_SUCCESS action is dispatched before
+        // the trigger has been created, thus a fake trigger is
+        // created.
+        const trigger = {
+          message: {
+            account: account._id,
+            konnector: konnector.slug
+          }
+        }
+
+        const result = connections(state, enqueueConnection(trigger))
 
         expect(result).toMatchSnapshot()
       })


### PR DESCRIPTION
Since banking account communicate directly with BI, when the
LOGIN_SUCCESS event is triggered, the trigger that is dispatched does
not contain an id (it is fake trigger, the trigger has not yet been
created). This would make the enqueueConnection action handling
crash with "Missing trigger id" problem.

Ignoring the action fixes the problem.

In a subsequent PR, I'll remove dead code since enqueueConnection
should no longer be used. Here I just bypass the problem and
minimize the risk to break other stuff.