### PR TITLE
fix: Fix the height of html,body to 100%

### DIFF
--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -6,9 +6,11 @@
 // overriding the general layout to allow a sticky footer
 html,
 body
-    height 100%
+    // TODO Remove the !important when https://github.com/cozy/cozy-bar/issues/705
+    // has been solved
+    height 100% !important // @stylint ignore
     +medium-screen()
-        height 100%
+        height 100% !important // @stylint ignore
 
         main > [role=main].u-flex
             display flex


### PR DESCRIPTION
The bar is injecting html,body{height:auto} which is messing with
the height set by the home CSS. We can see this bug due to a
change of order in the CSS. Normally the bar should not inject
this height:auto (see https://github.com/cozy/cozy-bar/issues/705)
but at the moment to solve the problem, !important is needed