### PR TITLE
fix: Readme link to setup dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Cozy Home is developed by Cozy Cloud and distributed under the [AGPL v3 license]
 
 
 [cozy]: https://cozy.io "Cozy Cloud"
-[setup]: https://docs.cozy.io/en/dev/app/#install-the-development-environment "Cozy dev docs: Set up the Development Environment"
+[setup]: https://docs.cozy.io/en/tutorials/app/#install-the-development-environment "Cozy dev docs: Set up the Development Environment"
 [yarn]: https://yarnpkg.com/
 [yarn-install]: https://yarnpkg.com/en/docs/install
 [cozy-ui]: https://github.com/cozy/cozy-ui


### PR DESCRIPTION
The link to setup the dev environment was broken in Readme