### PR TITLE
fix: Avoid a crash when the manifest as an id attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## 🐛 Bug Fixes
 
+* ignore manifest's id if any to avoid a crash
 
 ## 🔧 Tech
 

--- a/src/lib/redux-cozy-client/adapters/CozyStackAdapter.js
+++ b/src/lib/redux-cozy-client/adapters/CozyStackAdapter.js
@@ -75,6 +75,7 @@ export default class CozyStackAdapter {
         ? data.map(konnector => ({
             ...konnector,
             ...konnector.attributes,
+            id: konnector.id,
             _type: 'io.cozy.konnectors'
           }))
         : [],

--- a/test/lib/redux-cozy-client/adapters/CozyStackAdapter.spec.js
+++ b/test/lib/redux-cozy-client/adapters/CozyStackAdapter.spec.js
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+import CozyStackAdapter from '../../../../src/lib/redux-cozy-client/adapters/CozyStackAdapter'
+
+describe('CozyStack Adapter', () => {
+  describe('fetchKonnectors', () => {
+    it('should ignore manifest id', async () => {
+      const stackClient = {
+        fetchJSON: async () => {
+          return {
+            data: [
+              {
+                slug: 'test',
+                id: 'io.cozy.konnectors/test',
+                attributes: {
+                  id: 'manifest id'
+                }
+              }
+            ]
+          }
+        }
+      }
+      const adapter = new CozyStackAdapter(stackClient)
+      const konnectors = await adapter.fetchKonnectors()
+      expect(konnectors).toEqual({
+        data: [
+          {
+            _type: 'io.cozy.konnectors',
+            attributes: {
+              id: 'manifest id'
+            },
+            id: 'io.cozy.konnectors/test',
+            slug: 'test'
+          }
+        ],
+        meta: undefined,
+        next: false,
+        skip: 0
+      })
+    })
+  })
+})


### PR DESCRIPTION
The id attribute (which has no documented use) is now ignored by the
home application to keep stack's elements id

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari)
* [ ] Localized in english and french
* [X] All changes have test coverage
* [ ] Updated README, if necessary
