### PR TITLE
feat: Upgrade cozy-ui to 57.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * cozy-harvest-lib 6.6.O : new BI slug for palatine bank
   * new home layout
 * Change matomo url from piwik.cozycloud.cc to matomo.cozycloud.cc
+* New home design
 
 ## 🐛 Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "cozy-realtime": "3.13.1",
     "cozy-sharing": "3.12.0",
     "cozy-stack-client": "23.17.0",
-    "cozy-ui": "57.5.0",
+    "cozy-ui": "57.5.2",
     "date-fns": "1.30.1",
     "form-data": "2.5.1",
     "husky": "1.3.1",

--- a/src/components/Shortcuts/__snapshots__/ShortcutsView.spec.jsx.snap
+++ b/src/components/Shortcuts/__snapshots__/ShortcutsView.spec.jsx.snap
@@ -59,7 +59,7 @@ Object {
                 </span>
               </span>
               <h6
-                class="MuiTypography-root makeStyles-name-31 u-ellipsis u-ov-hidden MuiTypography-h6 MuiTypography-alignCenter"
+                class="MuiTypography-root makeStyles-name-31 u-spacellipsis MuiTypography-h6 MuiTypography-alignCenter"
               >
                 List item
               </h6>
@@ -124,7 +124,7 @@ Object {
               </span>
             </span>
             <h6
-              class="MuiTypography-root makeStyles-name-31 u-ellipsis u-ov-hidden MuiTypography-h6 MuiTypography-alignCenter"
+              class="MuiTypography-root makeStyles-name-31 u-spacellipsis MuiTypography-h6 MuiTypography-alignCenter"
             >
               List item
             </h6>
@@ -246,7 +246,7 @@ Object {
                 </span>
               </span>
               <h6
-                class="MuiTypography-root makeStyles-name-67 u-ellipsis u-ov-hidden MuiTypography-h6 MuiTypography-alignCenter"
+                class="MuiTypography-root makeStyles-name-67 u-spacellipsis MuiTypography-h6 MuiTypography-alignCenter"
               >
                 b
               </h6>
@@ -308,7 +308,7 @@ Object {
                 </span>
               </span>
               <h6
-                class="MuiTypography-root makeStyles-name-67 u-ellipsis u-ov-hidden MuiTypography-h6 MuiTypography-alignCenter"
+                class="MuiTypography-root makeStyles-name-67 u-spacellipsis MuiTypography-h6 MuiTypography-alignCenter"
               >
                 d
               </h6>
@@ -373,7 +373,7 @@ Object {
               </span>
             </span>
             <h6
-              class="MuiTypography-root makeStyles-name-67 u-ellipsis u-ov-hidden MuiTypography-h6 MuiTypography-alignCenter"
+              class="MuiTypography-root makeStyles-name-67 u-spacellipsis MuiTypography-h6 MuiTypography-alignCenter"
             >
               b
             </h6>
@@ -435,7 +435,7 @@ Object {
               </span>
             </span>
             <h6
-              class="MuiTypography-root makeStyles-name-67 u-ellipsis u-ov-hidden MuiTypography-h6 MuiTypography-alignCenter"
+              class="MuiTypography-root makeStyles-name-67 u-spacellipsis MuiTypography-h6 MuiTypography-alignCenter"
             >
               d
             </h6>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4398,10 +4398,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@57.5.0:
-  version "57.5.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-57.5.0.tgz#507de41be21669a94add37fd7d3356be4f82bd3d"
-  integrity sha512-+X5zPtZ9GoMZ97UZ0dHFw0hPpNzWKlCFxxLENEHzLaF/Z2UBBpKybzC4/pq1hM0KP69oDtMp/D7yiAr/fTMWOQ==
+cozy-ui@57.5.2:
+  version "57.5.2"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-57.5.2.tgz#119733fb586151371ca59675e7549e2f13c9e919"
+  integrity sha512-ScHuq/64pibbt1RYkcSPxFNTUPUntpV19l9lpGx4zG6SSc/I7pU4p18rfNvKWEY7sbjrIKcr/W0D3foX+iivdQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"
@@ -9802,9 +9802,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
   version "1.0.6"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
To get correct display of SquareAppIcon name in 2 lines and with
ellipsis when needed

_Please explain what this PR does here._

#### Checklist

Before merging this PR, the following things must have been done:

* [X] Faithful integration of the mockups at all screen sizes
* [X] Tested on supported browsers, including responsive mode
* [ ] Localized in english and french
* [X] All changes have test coverage
* [X] Updated README & CHANGELOG, if necessary

