### PR TITLE
feat: Upgrade cozy-harvest-lib for banking connectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cozy-device-helper": "1.12.0",
     "cozy-doctypes": "1.81.0",
     "cozy-flags": "2.6.0",
-    "cozy-harvest-lib": "6.9.0",
+    "cozy-harvest-lib": "6.10.0",
     "cozy-keys-lib": "3.8.0",
     "cozy-logger": "1.7.0",
     "cozy-realtime": "3.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3626,10 +3626,10 @@ cozy-app-publish@0.25.0:
     request "2.88.0"
     tar "4.4.13"
 
-cozy-bi-auth@0.0.23:
-  version "0.0.23"
-  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.23.tgz#fcbf6b710622c50fad20573b3ca6cac64102b65f"
-  integrity sha512-UXzLlEeq1+g7Q7qQyDzdsIPE+4CbFmNbFVmgel7PlvBols6AunCS2SOptwAmcdCr3jI6CXSv/0TS57jmDPdukg==
+cozy-bi-auth@0.0.24:
+  version "0.0.24"
+  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.24.tgz#b9232e5c5a9828e59c88b6130a8d50043ed050b0"
+  integrity sha512-7Dr08b6uE81x1jjO8jZfy2738mvaQpUS4N+tfZthpO1MB7kSeB0RPlULG+IEMBll+NDlixypjcmVPdJ8ZJUkNA==
   dependencies:
     cozy-logger "^1.3.0"
     lodash "^4.17.20"
@@ -3732,14 +3732,14 @@ cozy-flags@2.7.1:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-6.9.0.tgz#0136f56cf72851541eafe546b27a77a489a19c85"
-  integrity sha512-TwJtyVOTwgRtoco3z9R1WNk2VRc5XHL8PDpSmxKbRxPbnY/hxHuypJJFs6FGadWV8FD3GocxWPOFI7q8HVnOLg==
+cozy-harvest-lib@6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-6.10.0.tgz#9bbe778fa46b6391b49185ccb03225cf77f7880f"
+  integrity sha512-DKt8Og579eEWF6KSHez5vnakgFSlxUGKQCLUkoa4mNVEehk2AIM/C+iAuJQfsN8DlSrZqhNWsgmK3Xu4DkOwvg==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"
-    cozy-bi-auth "0.0.23"
+    cozy-bi-auth "0.0.24"
     cozy-doctypes "^1.83.0"
     cozy-logger "^1.7.0"
     date-fns "^1.30.1"


### PR DESCRIPTION
This version of harvest will be need to make 3 new banking connectors working. 
socramcredit, socrammacif, nalo