### PR TITLE
fix: Avoid blur effect when hover icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * ignore manifest's id if any to avoid a crash
 * login and passwords fields do not enforce upercase on first letter anymore when login to a Konnector
+* avoid blur effect when hover icon
 
 ## 🔧 Tech
 

--- a/src/components/CandidateServiceTile.jsx
+++ b/src/components/CandidateServiceTile.jsx
@@ -33,7 +33,10 @@ const CandidateServiceTile = ({ konnector }) => {
           }}
         />
       )}
-      <div className="scale-hover" onClick={() => setModalDisplayed(true)}>
+      <div
+        className="scale-hover u-c-pointer"
+        onClick={() => setModalDisplayed(true)}
+      >
         <SquareAppIcon app={slug} name={name} variant="ghost" />
       </div>
     </>

--- a/src/styles/lists.styl
+++ b/src/styles/lists.styl
@@ -29,7 +29,10 @@
         margin-left 1rem
         position relative
         &:hover
-            transform scale(1.05)
+            @supports (zoom : 1.05)
+                zoom 1.05
+            @supports not (zoom : 1.05)
+                transform scale(1.05)
         @media (pointer coarse)
             &:hover
                 transform none
@@ -135,4 +138,9 @@
         line-height 1rem
 
 .scale-hover:hover
-    transform scale(1.05)
+    /* transform scale can be blurry in other browser than firefox
+       and firefox does not support the zoom property */
+    @supports (zoom : 1.05)
+        zoom 1.05
+    @supports not (zoom : 1.05)
+        transform scale(1.05)


### PR DESCRIPTION
On browser other than firefox, the hover effect on icons gives a "blurry"
effect.
The zoom property does not have this problem but is not supported
by firefox.

We use @supports to get the best of both worlds

![image](https://user-images.githubusercontent.com/228695/140926921-c802bc71-8120-4b9f-b7ee-cb0fed2d0756.png)


