### PR TITLE
fix: Load lato font for mobile devices

### DIFF
--- a/src/targets/browser/index.ejs
+++ b/src/targets/browser/index.ejs
@@ -14,6 +14,7 @@
   <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
     <link rel="stylesheet" href="<%- file %>">
     <% }); %>
+  <link rel="stylesheet" href="//{{.Domain}}/assets/fonts/fonts.css">
       {{.ThemeCSS}}
       <% if (__STACK_ASSETS__) { %>
         {{.CozyClientJS}}


### PR DESCRIPTION
We found that the lato font was not rendered on icon
titles on mobile devices (android at least)

We then explicitely import this font, which fixes the problem.

