### PR TITLE
style: Transform scale to 1.0625 for a less blurry text

### DIFF
--- a/src/styles/lists.styl
+++ b/src/styles/lists.styl
@@ -56,5 +56,5 @@
         padding-left .5rem
 
 .scale-hover:hover
-    transform scale(1.06)
+    transform scale(1.0625)
     transition transform 50ms ease


### PR DESCRIPTION
On hover, the icons' text can be blurry depending on the configuration :
- browser (especially chrome and safari)
- screen resolution

We found that the text is less blurry with transform: scale(1.0625)

