### PR TITLE
fix: Account creation for Oauth connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## ✨ Features
 
 ## 🐛 Bug Fixes
+
+* We had a bug in Harvest which caused a fatal error for OAuth connectors : See [this PR](https://github.com/cozy/cozy-libs/pull/1390)
+
 ## 🔧 Tech
 
 # 1.43.0

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cozy-device-helper": "1.12.0",
     "cozy-doctypes": "1.81.0",
     "cozy-flags": "2.6.0",
-    "cozy-harvest-lib": "6.14.1",
+    "cozy-harvest-lib": "6.14.2",
     "cozy-keys-lib": "3.8.0",
     "cozy-logger": "1.7.0",
     "cozy-realtime": "3.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3732,10 +3732,10 @@ cozy-flags@2.7.1:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@6.14.1:
-  version "6.14.1"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-6.14.1.tgz#616516e734a0a2af904b61b516bbf09c73976d7a"
-  integrity sha512-r9TVJkEIMffkTKD7E0JUA/GQD0ePFcG+rTHMiFF0F93Bv7wNtVuLF3EscDpssV7uZVy26w9ED5WUhVz6lkRelQ==
+cozy-harvest-lib@6.14.2:
+  version "6.14.2"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-6.14.2.tgz#91fa256c4413736d69606d95f01d597a4547a398"
+  integrity sha512-bwX+seFv5knD3jYpFdQ990G5lhTy8aVsGvLAL1N+hSC2RJyq0e2OMCr0NJYS+/qiYCtfsLLMUNM/joaeHdAKdg==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
Upgrade cozy-harvest-lib to 6.14.2 to avoid a fatal error on account
creation for OAuth connectors

https://github.com/cozy/cozy-libs/pull/1390

