### PR TITLE
feat: Upgrade Harvest to 6.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 🐛 Bug Fixes
 - fix translation during the loading phase
 - fix spinner position for the ShortcutView during the loading phase
+- cozy-harvest-lib 6.14.4 : change timeout for createTemporaryToken [PR](https://github.com/cozy/cozy-libs/pull/1391)
 ## 🔧 Tech
 
 * useAppsInMaintenance hook is now moved in cozy client and can be used in other apps

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cozy-device-helper": "1.12.0",
     "cozy-doctypes": "1.81.0",
     "cozy-flags": "2.6.0",
-    "cozy-harvest-lib": "6.14.2",
+    "cozy-harvest-lib": "6.14.4",
     "cozy-keys-lib": "3.8.0",
     "cozy-logger": "1.7.0",
     "cozy-realtime": "3.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3732,10 +3732,10 @@ cozy-flags@2.7.1:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@6.14.2:
-  version "6.14.2"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-6.14.2.tgz#91fa256c4413736d69606d95f01d597a4547a398"
-  integrity sha512-bwX+seFv5knD3jYpFdQ990G5lhTy8aVsGvLAL1N+hSC2RJyq0e2OMCr0NJYS+/qiYCtfsLLMUNM/joaeHdAKdg==
+cozy-harvest-lib@6.14.4:
+  version "6.14.4"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-6.14.4.tgz#12cd072218b1be9041c65c0bcd1fb44b66fb0dfa"
+  integrity sha512-jpYoUf9e2XTHyTHllFRKddiKWL0g5HGFABukh58S79+aXJY9ObCIAMu8GSSkfoD4cNQfUKB8k/YRw0ck1ge1Yw==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
To get https://github.com/cozy/cozy-libs/commit/9dda46f. To change the
timeout to get BI token from createTemporaryToken job and avoid timeout
error on BI connectors.

