### PR TITLE
docs: Fix broken link

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Cozy Home Configuration
 
-The main configuration file is [/src/config.collect.json](../src/config/collect.json). Its provides a convenient way to centralize global parameters of Cozy Home.
+The main configuration file is [/src/config/home.json](../src/config/home.json). Its provides a convenient way to centralize global parameters of Cozy Home.
 
 Configuration parameters are:
 


### PR DESCRIPTION
https://github.com/cozy/cozy-home/pull/1502 renamed `collect.json` config file to `home.json` however documentation link in `configuration.md` was not updated.

This PR fixes broken link

#### Checklist

Before merging this PR, the following things must have been done:

* [**N/A**] Faithful integration of the mockups at all screen sizes 
* [**N/A**] Tested on supported browsers, including responsive mode
* [**N/A**] Localized in english and french
* [**N/A**] All changes have test coverage
* [**N/A**] Updated README & CHANGELOG, if necessary

