### PR TITLE
fix: Logout in flagship should also kill the session

### DIFF
--- a/src/components/HeroHeader/LogoutButton.jsx
+++ b/src/components/HeroHeader/LogoutButton.jsx
@@ -9,11 +9,12 @@ const LogoutButton = () => {
   const { t } = useI18n()
   const client = useClient()
   const logout = useCallback(async () => {
-    if (window.cozy.isWebview)
-      return window.ReactNativeWebView.postMessage('LOGOUT')
-
     await client.logout()
-    window.location.reload()
+    if (window.cozy.isWebview) {
+      return window.ReactNativeWebView.postMessage('LOGOUT')
+    } else {
+      window.location.reload()
+    }
   }, [client])
   return <CornerButton label={t('logout')} icon={LogoutIcon} onClick={logout} />
 }


### PR DESCRIPTION
We've to logout() from client before calling the flagship app in order to kill the web session