### PR TITLE
feat: Open apps using their native mobile version when available

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cozy-realtime": "3.13.1",
     "cozy-sharing": "3.12.9",
     "cozy-stack-client": "23.17.0",
-    "cozy-ui": "^59.0.0",
+    "cozy-ui": "^60.6.0",
     "date-fns": "1.30.1",
     "form-data": "2.5.1",
     "husky": "1.3.1",

--- a/src/components/AppTile.jsx
+++ b/src/components/AppTile.jsx
@@ -13,7 +13,7 @@ export class AppTile extends Component {
     const displayName = applications.getAppDisplayName(app, lang)
     const appHref = app.links && app.links.related
     return (
-      <AppLinker slug={app.slug} href={appHref}>
+      <AppLinker slug={app.slug} href={appHref} app={app}>
         {({ onClick, href }) => (
           <a onClick={onClick} href={href} className="scale-hover">
             <SquareAppIcon app={app} name={displayName} />

--- a/src/components/MoveModal.spec.jsx
+++ b/src/components/MoveModal.spec.jsx
@@ -5,7 +5,7 @@ import CozyClient, { CozyProvider } from 'cozy-client'
 import useInstanceSettings from 'hooks/useInstanceSettings'
 import AppLike from '../../test/AppLike'
 
-configure({ testIdAttribute: 'data-test-id' })
+configure({ testIdAttribute: 'data-testid' })
 
 jest.mock('hooks/useInstanceSettings', () => jest.fn())
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4142,16 +4142,17 @@ cozy-stack-client@^27.6.5:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-ui@^59.0.0:
-  version "59.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-59.0.0.tgz#9bd81716da70de23df4e234cbdd6562498eafaea"
-  integrity sha512-d9R3iniRv93l7oU1dNgc3L+niXbXDAdT2a/cd817kghnILPSV+WmSCyZamhPxogNee+6MJU7T27156LATOi/Fw==
+cozy-ui@^60.6.0:
+  version "60.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-60.6.0.tgz#8454767932ff4f9d078b8780d3433b6a93e6b855"
+  integrity sha512-bNVK+TRjmtEtHzh272npmOiK64MCSIlo2bvWsBzevHhksd6x+TzazXkGR84iBQGGmm+CQI7F1+YNcg6gE7s2Yw==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"
     classnames "^2.2.5"
     cozy-interapp "^0.5.4"
     date-fns "^1.28.5"
+    filesize "8.0.7"
     hammerjs "^2.0.8"
     intersection-observer "0.11.0"
     mui-bottom-sheet "https://github.com/cozy/mui-bottom-sheet.git#v1.0.6"
@@ -5741,6 +5742,11 @@ file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
+filesize@8.0.7:
+  version "8.0.7"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-8.0.7.tgz#695e70d80f4e47012c132d57a059e80c6b580bd8"
+  integrity sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==
 
 filesize@^3.6.1:
   version "3.6.1"


### PR DESCRIPTION
AppLinker can now send app data to the native host in order to open the
native app when available instead of its webview version

---

Related PRs: https://github.com/cozy/cozy-ui/pull/2015 and https://github.com/cozy/cozy-react-native/pull/65

---

TODO:
- [x] Upgrade `cozy-ui` when https://github.com/cozy/cozy-ui/pull/2015 is merged