### PR TITLE
feat: Upgrade cozy-harvest-lib to 7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.45.0
 ## ✨ Features
 - cozy-harvest-lib 6.15.0 : get support email according to the contect [PR](https://github.com/cozy/cozy-libs/pull/1392)
+- cozy-harvest-lib 7.1.0 : no multi account for client side connectors [PR](https://github.com/cozy/cozy-libs/pull/1406)
 
 ## 🐛 Bug Fixes
 - fix translation during the loading phase

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cozy-device-helper": "^1.16.0",
     "cozy-doctypes": "1.81.0",
     "cozy-flags": "2.6.0",
-    "cozy-harvest-lib": "6.15.0",
+    "cozy-harvest-lib": "7.1.0",
     "cozy-intent": "^1.2.0",
     "cozy-keys-lib": "3.8.0",
     "cozy-logger": "1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3962,10 +3962,10 @@ cozy-flags@2.7.1:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@6.15.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-6.15.0.tgz#1d286dce3731fbd0619f2f5b7f88432688ae0a83"
-  integrity sha512-+c84ltBGVKdCMHtHPD7KLUo0M62rdEwj+Q7u4pIjwSi0OyRmn/RocXffz48q464ycZlBIi8LAl/8aJU18hjGyQ==
+cozy-harvest-lib@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-7.1.0.tgz#6093487402e6831dfa2cc4c574e7ae9199c368ad"
+  integrity sha512-PPhcR+RTqQnpwt1FX947YqgDuAv9h0zXEhz8FAOc0L7oWXAYqeEFbww+DzQZmmpPfOZM9dIa+abn0wnK0caD8Q==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
To get multi-account deactivation for client side connectors

See https://github.com/cozy/cozy-libs/commit/1a9d157

And https://trello.com/c/HoTn7eGr/119-%F0%9F%9A%80%F0%9F%8F%A0-e87-d%C3%A9sactiver-le-multi-compte-sur-les-connecteurs-c%C3%B4t%C3%A9-clients-05-jh

The breaking change for cozy-harvest-lib is related to linting and has no impact on the home application

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on supported browsers, including responsive mode
* [ ] Localized in english and french
* [ ] All changes have test coverage
* [X] Updated README & CHANGELOG, if necessary

