### PR TITLE
fix: Logout Issue on Tile inside flagship

### DIFF
--- a/src/components/LogoutTile.jsx
+++ b/src/components/LogoutTile.jsx
@@ -1,20 +1,27 @@
 import React, { useCallback } from 'react'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
 import { useClient } from 'cozy-client'
+import { useWebviewIntent } from 'cozy-intent'
+import { isFlagshipApp } from 'cozy-device-helper'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Icon from 'cozy-ui/transpiled/react/Icon'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import SquareAppIcon from 'cozy-ui/transpiled/react/SquareAppIcon'
-
 import LogoutLargeIcon from 'cozy-ui/transpiled/react/Icons/LogoutLarge'
 
 const LogoutTile = () => {
   const { t } = useI18n()
   const client = useClient()
+  const webviewIntent = useWebviewIntent()
 
   const logout = useCallback(async () => {
     await client.logout()
-    window.location.reload()
-  }, [client])
+
+    return isFlagshipApp() && webviewIntent
+      ? webviewIntent.call('logout')
+      : window.location.reload()
+  }, [client, webviewIntent])
+
   const { isMobile } = useBreakpoints()
 
   return (


### PR DESCRIPTION
When we added the new mechanism to logout
the user when using the flagship app, we
forgot to change to edit all the place
where the logout is done.

Let's fix that issue.

