### PR TITLE
fix: Revert cozy-keys-lib to 3.11.0 to avoid a bug with intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## 🔧 Tech
 
 * useAppsInMaintenance hook is now moved in cozy client and can be used in other apps
+- Revert to cozy-keys-lib 3.11.0 to avoid a bug with intent
 
 # 1.44.0
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cozy-flags": "2.8.4",
     "cozy-harvest-lib": "^7.3.1",
     "cozy-intent": "1.10.3",
-    "cozy-keys-lib": "4.1.1",
+    "cozy-keys-lib": "3.11.0",
     "cozy-logger": "1.8.1",
     "cozy-realtime": "4.0.5",
     "cozy-sharing": "4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5268,10 +5268,10 @@ cozy-interapp@^0.5.4:
   resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.5.7.tgz#75cafe1732ad660e2caf1ccf412f302594705f39"
   integrity sha512-laIL/ATYV9oZnmqS+LMoO9qzk8XjJ1v2/YrA1Po2rI8ia/MDgjYO07424x2RuvHhNOBPGjD+JmqwQ0rNDlLW+Q==
 
-cozy-keys-lib@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-4.1.1.tgz#0643f7fbc92183ca569a427303c591aa5580d4fa"
-  integrity sha512-qjpO23+w/SGADgM/KPPXCVxVxhPOSXdshjDHZpsNf9na53sA75d+rdbR1Vj0QaOWVDLPUYH86gBnHpPJJg7o3A==
+cozy-keys-lib@3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-3.11.0.tgz#4c7c89247e15b1deb298ba0ef5d1341ae3942d53"
+  integrity sha512-5HxzThZ2oK/g8l3eOFWqh7PZ0j5pE4hmkXiaDCSCV5ZeKwwG/eYumljaYOOsBWmhS7FDNlaNwowMWuhfppZk0Q==
   dependencies:
     "@aspnet/signalr" "^1.1.4"
     "@aspnet/signalr-protocol-msgpack" "^1.1.0"
@@ -10448,9 +10448,9 @@ mini-css-extract-plugin@0.5.0:
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
 
-"minilog@https://github.com/cozy/minilog.git#master":
+"minilog@git+https://github.com/cozy/minilog.git#master":
   version "3.1.0"
-  resolved "https://github.com/cozy/minilog.git#6da0aa58759c4f1a1a7e0fd093dbe2a67c035c55"
+  resolved "git+https://github.com/cozy/minilog.git#6da0aa58759c4f1a1a7e0fd093dbe2a67c035c55"
   dependencies:
     microee "0.0.6"
 


### PR DESCRIPTION
Here is the error message :
"Konnector policy `saveInVault` is true, but no vault has been passed in
the context of the TriggerManager. You can wrap it the TriggerManager in
a VaultUnlockProvider or VaultProvider (from cozy-keys-lib)"

Could not find a quick fix for this issue. New features comming with
4.XX version do not seem to be related to the need of the home
application.
