### PR TITLE
feat(splashscreen): hide splashscreen when app is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # 1.46.0
 
+## ✨ Features
+
+* When displaying cozy-home from Cozy's native application, the splash screen is now correctly shown during the page loading
+
+## 🐛 Bug Fixes
+
+## 🔧 Tech
+
 # 1.45.0
 
 ## ✨ Features

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cozy-doctypes": "1.83.5",
     "cozy-flags": "2.8.4",
     "cozy-harvest-lib": "^7.3.1",
-    "cozy-intent": "1.10.3",
+    "cozy-intent": "1.12.0",
     "cozy-keys-lib": "3.11.0",
     "cozy-logger": "1.8.1",
     "cozy-realtime": "4.0.5",

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import PropTypes from 'react-proptypes'
-import { Route, Switch, Redirect, withRouter } from 'react-router-dom'
+import { Redirect, Route, Switch, withRouter } from 'react-router-dom'
 import isObjectLike from 'lodash/isObjectLike'
 import isArray from 'lodash/isArray'
 import keys from 'lodash/keys'
@@ -43,8 +42,6 @@ export const toFlagNames = (flagName, prefix = '') => {
     )
 }
 const App = ({
-  // eslint-disable-next-line no-unused-vars
-  store,
   client,
   accounts,
   konnectors,
@@ -53,23 +50,12 @@ const App = ({
   wallpaperLink
 }) => {
   const [status, setStatus] = useState(IDLE)
-  // eslint-disable-next-line no-unused-vars
-  const [error, setError] = useState(null)
   const [contentWrapper, setContentWrapper] = useState(undefined)
 
   useEffect(() => {
     setStatus(FETCHING_CONTEXT)
 
-    async function fetchContext() {
-      return await client.stackClient
-        .fetchJSON('GET', '/settings/context')
-        .catch(error => {
-          setError(error)
-          setStatus(IDLE)
-        })
-    }
-
-    const context = fetchContext()
+    const context = client.stackClient.fetchJSON('GET', '/settings/context')
     if (context && context.attributes && context.attributes.features) {
       const flags = toFlagNames(context.attributes.features)
       enableFlags(flags)
@@ -142,10 +128,6 @@ const App = ({
       )}
     </div>
   )
-}
-
-App.contextTypes = {
-  store: PropTypes.object
 }
 
 /*

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -51,6 +51,30 @@ const App = ({
 }) => {
   const [status, setStatus] = useState(IDLE)
   const [contentWrapper, setContentWrapper] = useState(undefined)
+  const [isFetching, setIsFetching] = useState(false)
+  const [hasError, setHasError] = useState(false)
+  const [isReady, setIsReady] = useState(false)
+  const [backgroundURL, setBackgroundURL] = useState(null)
+
+  const showTimeline = flag('home.timeline.show') // used in demo envs
+
+  useEffect(() => {
+    const { cozyDefaultWallpaper } = client.getInstanceOptions()
+    setBackgroundURL(wallpaperLink || cozyDefaultWallpaper)
+  }, [wallpaperLink, wallpaperFetchStatus, client])
+
+  useEffect(() => {
+    setIsFetching(
+      [accounts, konnectors, triggers].find(collection =>
+        ['pending', 'loading'].includes(collection.fetchStatus)
+      )
+    )
+    setHasError(
+      [accounts, konnectors, triggers].find(
+        collection => collection.fetchStatus === 'failed'
+      )
+    )
+  }, [accounts, konnectors, triggers])
 
   useEffect(() => {
     setStatus(FETCHING_CONTEXT)
@@ -64,24 +88,9 @@ const App = ({
     setStatus(IDLE)
   }, [client.stackClient])
 
-  const isFetching = [accounts, konnectors, triggers].find(collection =>
-    ['pending', 'loading'].includes(collection.fetchStatus)
-  )
-
-  const { cozyDefaultWallpaper } = client.getInstanceOptions()
-  let backgroundURL = null
-  if (wallpaperFetchStatus !== 'loading') {
-    backgroundURL = wallpaperLink || cozyDefaultWallpaper
-  }
-
-  const hasError = [accounts, konnectors, triggers].find(
-    collection => collection.fetchStatus === 'failed'
-  )
-
-  const isFetchingContext = status === FETCHING_CONTEXT
-
-  const isReady = !hasError && !isFetching && !isFetchingContext
-  const showTimeline = flag('home.timeline.show') // used in demo envs
+  useEffect(() => {
+    setIsReady(!hasError && !isFetching && !(status === FETCHING_CONTEXT))
+  }, [hasError, isFetching, status])
 
   return (
     <div

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -79,14 +79,16 @@ const App = ({
   useEffect(() => {
     setStatus(FETCHING_CONTEXT)
 
-    const context = client.stackClient.fetchJSON('GET', '/settings/context')
+    const context = client
+      .getStackClient()
+      .fetchJSON('GET', '/settings/context')
     if (context && context.attributes && context.attributes.features) {
       const flags = toFlagNames(context.attributes.features)
       enableFlags(flags)
     }
 
     setStatus(IDLE)
-  }, [client.stackClient])
+  }, [client])
 
   useEffect(() => {
     setIsReady(!hasError && !isFetching && !(status === FETCHING_CONTEXT))

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -66,15 +66,17 @@ const App = ({
   useEffect(() => {
     setStatus(FETCHING_CONTEXT)
 
-    const context = client
-      .getStackClient()
-      .fetchJSON('GET', '/settings/context')
-    if (context && context.attributes && context.attributes.features) {
-      const flags = toFlagNames(context.attributes.features)
-      enableFlags(flags)
+    const fetchContext = async () => {
+      const context = await client
+        .getStackClient()
+        .fetchJSON('GET', '/settings/context')
+      if (context && context.attributes && context.attributes.features) {
+        const flags = toFlagNames(context.attributes.features)
+        enableFlags(flags)
+      }
+      setStatus(IDLE)
     }
-
-    setStatus(IDLE)
+    fetchContext()
   }, [client])
 
   useEffect(() => {

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -1,9 +1,5 @@
 import React, { useEffect, useState } from 'react'
 import { Redirect, Route, Switch, withRouter } from 'react-router-dom'
-import isObjectLike from 'lodash/isObjectLike'
-import isArray from 'lodash/isArray'
-import keys from 'lodash/keys'
-import flatten from 'lodash/flatten'
 
 import { withClient } from 'cozy-client'
 import flag, { enable as enableFlags } from 'cozy-flags'
@@ -24,6 +20,7 @@ import IntentRedirect from 'components/IntentRedirect'
 import StoreRedirection from 'components/StoreRedirection'
 import DemoTimeline from 'assets/images/timeline.png'
 import withCustomWallpaper from 'hoc/withCustomWallpaper'
+import { toFlagNames } from './toFlagNames'
 
 const IDLE = 'idle'
 const FETCHING_CONTEXT = 'FETCHING_CONTEXT'
@@ -31,16 +28,6 @@ const FETCHING_CONTEXT = 'FETCHING_CONTEXT'
 window.flag = window.flag || flag
 window.minilog = minilog
 
-// TODO add this to cozy-flags ?
-export const toFlagNames = (flagName, prefix = '') => {
-  if (typeof flagName === 'string') return `${prefix}${flagName}`
-  else if (isArray(flagName))
-    return flatten(flagName.map(flagName => toFlagNames(flagName, prefix)))
-  else if (isObjectLike(flagName))
-    return flatten(
-      keys(flagName).map(key => toFlagNames(flagName[key], `${prefix}${key}.`))
-    )
-}
 const App = ({
   client,
   accounts,

--- a/src/containers/toFlagNames.js
+++ b/src/containers/toFlagNames.js
@@ -1,0 +1,15 @@
+import isObjectLike from 'lodash/isObjectLike'
+import isArray from 'lodash/isArray'
+import keys from 'lodash/keys'
+import flatten from 'lodash/flatten'
+
+// TODO add this to cozy-flags ?
+export const toFlagNames = (flagName, prefix = '') => {
+  if (typeof flagName === 'string') return `${prefix}${flagName}`
+  else if (isArray(flagName))
+    return flatten(flagName.map(flagName => toFlagNames(flagName, prefix)))
+  else if (isObjectLike(flagName))
+    return flatten(
+      keys(flagName).map(key => toFlagNames(flagName[key], `${prefix}${key}.`))
+    )
+}

--- a/src/containers/toFlagNames.spec.js
+++ b/src/containers/toFlagNames.spec.js
@@ -1,4 +1,4 @@
-import { toFlagNames } from './App'
+import { toFlagNames } from './toFlagNames'
 
 describe('toFlagNames', () => {
   it('should convert a data structure to flag names', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5256,10 +5256,10 @@ cozy-harvest-lib@^7.3.1:
     react-markdown "^4.2.2"
     uuid "^3.3.2"
 
-cozy-intent@1.10.3:
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-1.10.3.tgz#8c57e54b3f70228b8e7189a63cabc9e021c701f6"
-  integrity sha512-DOy40/BtJOoPEZjv1+eiPCQaXB1QVenbTQWYWVfq3PqdRyfjeuSGntIlLL79BqOco/yFAwHP6yL89GBVG9UwTA==
+cozy-intent@1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-1.12.0.tgz#9bc755c8c9cb397056fff8651355ba4a1f7be8d7"
+  integrity sha512-0b2keAZWxkxt3ISHDrqEUvXdEu55XAm5kfieVLIrsRQcc5ueasbqHJX+/r2JIUWT8y9V6gkkn4Qgs+mj9CPvSg==
   dependencies:
     post-me "0.4.5"
 


### PR DESCRIPTION
- Send hideSplashScreen message to Flagship app when Home App is ready
- related to https://github.com/cozy/cozy-react-native/pull/94
- related to https://github.com/cozy/cozy-libs/pull/1478
- Refactor App component in order to use the `useWebviewIntent` hook
- Clean App code during the refactor

#### Checklist

Before merging this PR, the following things must have been done:

* [x] Faithful integration of the mockups at all screen sizes
* [x] Tested on supported browsers, including responsive mode
* [ ] Localized in english and french
* [ ] All changes have test coverage
* [x] Updated README & CHANGELOG, if necessary

![2022-03-04 10 54 17](https://user-images.githubusercontent.com/8363334/156789276-ce9396a2-4b06-4744-b791-60c679122c7f.gif)

