### PR TITLE
style(home): don't set height 100% on mobile, it blocks ios safari address bar always displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## 🐛 Bug Fixes
 
+* On IOS Safari, the URL and Navigation bar were always displayed
+
 ## 🔧 Tech
 
 # 1.45.0

--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -10,14 +10,15 @@ body
     // has been solved
     height 100% !important // @stylint ignore
     +medium-screen()
-        height 100% !important // @stylint ignore
-
         main > [role=main].u-flex
             display flex
 
+    +mobile()
+        height inherit !important // @stylint ignore
+
 body
     // Allows horizontal swipe on mobile
-    +mobile()
+    +mobile() // @stylint ignore
         max-width 100vw
         overflow-x hidden
 


### PR DESCRIPTION
Navigation bar and url bar used to always appear completely
Only bug on Safari ios device

The height 100% came from an issue from cozy-bar to fix

_Please explain what this PR does here._

#### Checklist

Before merging this PR, the following things must have been done:

* [x] Faithful integration of the mockups at all screen sizes
* [x] Tested on supported browsers, including responsive mode
* [x] Localized in english and french
* [x] All changes have test coverage
* [x] Updated README & CHANGELOG, if necessary


<img width="382" alt="Capture d’écran 2022-03-07 à 17 29 25" src="https://user-images.githubusercontent.com/8363334/157077057-ce9c43d3-18c7-4f52-b64e-d03799d21b02.png">

