### PR TITLE
fix(service-worker): install new service worker without waiting

### DIFF
--- a/src/serviceWorker/service-worker.js
+++ b/src/serviceWorker/service-worker.js
@@ -2,10 +2,12 @@ import { precacheAndRoute } from 'workbox-precaching'
 
 precacheAndRoute(self.__WB_MANIFEST)
 
-addEventListener('message', event => {
-  if (event.data && event.data.type === 'SKIP_WAITING') {
-    self.skipWaiting()
-  }
+self.addEventListener('install', () => {
+  self.skipWaiting()
+
+  // Perform any other actions required for your
+  // service worker to install, potentially inside
+  // of event.waitUntil();
 })
 
 // I choose https://developer.chrome.com/docs/workbox/the-ways-of-workbox/#workbox-cli


### PR DESCRIPTION
Fix bug when installing a new version, the service worker is not activated. Skip waiting prevents that behaviour

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [x] Tested on supported browsers, including responsive mode
* [ ]  Localized in english and french
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

