### PR TITLE
fix(styles): background filter should be fixed over the full page

### DIFF
--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -47,7 +47,7 @@ body
 // black filter effect above the wallpaper image
 .App::before
     content ''
-    position absolute
+    position fixed
     top 0
     left 0
     width 100%


### PR DESCRIPTION
After:
<img width="547" alt="Capture d’écran 2022-03-24 à 17 56 00" src="https://user-images.githubusercontent.com/8363334/159969635-6d038eec-b271-42d9-8ec0-077640dd5296.png">
Before:
<img width="416" alt="Capture d’écran 2022-03-24 à 17 56 25" src="https://user-images.githubusercontent.com/8363334/159969642-f387ffbd-7d8d-4af1-ac2e-c15fa8fbfa02.png">


#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on supported browsers, including responsive mode
* [ ] Localized in english and french
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

