### PR TITLE
fix(service-worker): unregister existing service-worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 ## 🔧 Tech
 
 * Remove unused demo timeline
+* Unregister any service worker that could have been registered during development
+
 
 # 1.45.0
 

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -40,3 +40,21 @@ if (module.hot) {
   renderApp()
   module.hot.accept()
 }
+
+if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .getRegistrations()
+      .then(async registrations => {
+        for (let registration of registrations) {
+          await registration.unregister()
+        }
+        // eslint-disable-next-line no-console
+        return console.info('Service worker unregistered')
+      })
+      .catch(error => {
+        // eslint-disable-next-line no-console
+        console.error('Error during service worker registration:', error)
+      })
+  })
+}


### PR DESCRIPTION
Some users uses a dev version with service worker working. In order to clean them, I add a script to remove them:

https://love2dev.com/blog/how-to-uninstall-a-service-worker/

This commit can be reverted in 15 days

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on supported browsers, including responsive mode
* [ ] Localized in english and french
* [ ] All changes have test coverage
* [x] Updated README & CHANGELOG, if necessary

