### PR TITLE
fix: Now show the jobs as running after first account configuration in Harvest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## 🐛 Bug Fixes
 
 * On IOS Safari, the URL and Navigation bar were always displayed
+* Now show the jobs as running after first account configuration in Harvest [PR](https://github.com/cozy/cozy-libs/pull/1515)
 
 ## 🔧 Tech
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cozy-device-helper": "1.17.0",
     "cozy-doctypes": "1.83.5",
     "cozy-flags": "2.8.4",
-    "cozy-harvest-lib": "^8.0.0",
+    "cozy-harvest-lib": "^8.1.0",
     "cozy-intent": "1.12.0",
     "cozy-keys-lib": "3.11.0",
     "cozy-logger": "1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5313,10 +5313,10 @@ cozy-flags@2.8.4:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-8.0.0.tgz#63908ee0a75b62600c71d8e82852aeaecafb15d2"
-  integrity sha512-tZhy+zQRLYgw5twRkHhiEOAI1qoRYXU31OMC2JyoVLFplKlWamlyADapxsVj80BSHYCwRyjxO8jaMrpcf5qYXQ==
+cozy-harvest-lib@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-8.1.0.tgz#e6d09f80c637012197a2576c9982e5baefb2ffa4"
+  integrity sha512-heeMv2qVQuR38950AwoJ88eLc0cCu4377j92A+RpbW+hFxLs+By+vMnepCiY8we/WL8GomiCGCtXPjxKAiRMeg==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"
@@ -10706,9 +10706,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
   version "1.0.6"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
This is an upgrade of cozy-harvest-lib

_Please explain what this PR does here._

