### PR TITLE
feat: Fix back navigation on konnector dismiss

### DIFF
--- a/src/components/Konnector.jsx
+++ b/src/components/Konnector.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import flow from 'lodash/flow'
@@ -10,14 +10,15 @@ import { getKonnector } from 'ducks/konnectors'
 
 import { getTriggersByKonnector } from 'reducers'
 
-const Konnector = ({ konnector, history, triggers }) => {
+export const Konnector = ({ konnector, history, triggers }) => {
   const konnectorWithTriggers = { ...konnector, triggers: { data: triggers } }
+  const onDismiss = useCallback(() => history.replace('/connected'), [history])
 
   return (
     <HarvestRoutes
       konnectorRoot={`/connected/${konnector.slug}`}
       konnector={konnectorWithTriggers}
-      onDismiss={() => history.push('/connected')}
+      onDismiss={onDismiss}
       datacardOptions={datacardOptions}
     />
   )

--- a/src/components/Konnector.spec.jsx
+++ b/src/components/Konnector.spec.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Router } from 'react-router-dom'
+import { createMemoryHistory } from 'history'
+import { fireEvent, render } from '@testing-library/react'
+
+import { Konnector } from './Konnector'
+
+jest.mock('cozy-harvest-lib', () => ({
+  Routes: ({ konnector, triggers, onDismiss }) => (
+    <div konnector={konnector} triggers={triggers} onClick={onDismiss}>
+      {konnector.slug}
+    </div>
+  )
+}))
+
+it('it correctly goes back to the home page onDismiss', () => {
+  const history = createMemoryHistory()
+
+  const { getByText } = render(
+    <Router history={history} initialEntries={['/connected']}>
+      <Konnector history={history} konnector={{ slug: 'alan' }} />
+    </Router>
+  )
+
+  history.push('connected/alan/accounts/123')
+  fireEvent.click(getByText('alan'))
+
+  expect(history.location.pathname).toBe('/connected')
+})


### PR DESCRIPTION
History.push() is not good here, it will go back to /connected/:connectorName. Replace is better so we don't go back to the connector endlessly
