### PR TITLE
fix: Use push on dismiss

### DIFF
--- a/src/components/Konnector.jsx
+++ b/src/components/Konnector.jsx
@@ -12,7 +12,7 @@ import { getTriggersByKonnector } from 'reducers'
 
 export const Konnector = ({ konnector, history, triggers }) => {
   const konnectorWithTriggers = { ...konnector, triggers: { data: triggers } }
-  const onDismiss = useCallback(() => history.replace('/connected'), [history])
+  const onDismiss = useCallback(() => history.push('/connected'), [history])
 
   return (
     <HarvestRoutes

--- a/src/components/Konnector.spec.jsx
+++ b/src/components/Konnector.spec.jsx
@@ -13,7 +13,7 @@ jest.mock('cozy-harvest-lib', () => ({
   )
 }))
 
-it('it correctly goes back to the home page onDismiss', () => {
+it('it correctly goes back to the home page onDismiss and allows nav goBack', () => {
   const history = createMemoryHistory()
 
   const { getByText } = render(
@@ -23,7 +23,12 @@ it('it correctly goes back to the home page onDismiss', () => {
   )
 
   history.push('connected/alan/accounts/123')
+
   fireEvent.click(getByText('alan'))
 
   expect(history.location.pathname).toBe('/connected')
+
+  history.go(-1)
+
+  expect(history.location.pathname).toBe('/connected/alan/accounts/123')
 })


### PR DESCRIPTION
A recent commit replaced the `push()` call with a `replace` call to fix a bug. This must be reverted to keep the going back to connector behavior when navigating backward.

### Defect:

With `history.push`, some environments will go back to the connector when going back through navigation. Firefox, Chrome, and Webview browser are not affected by the native UI of these environments. Broken environments can be mouse navigation or other more exotic navigation means which are not tested at this time.

Testing script:

```
window.onpopstate = function (event) {
  console.log(event.path[0].location.href)
}
```
### Working scenario: 

1. Click on a connector

- `http://home.cozy.localhost:8080/#/connected/alan`
- `http://home.cozy.localhost:8080/#/connected/alan/accounts/123`

2. Ask the browser to go back

- `http://home.cozy.localhost:8080/#/connected`

### Broken scenario: 

1. Click on a connector

- `http://home.cozy.localhost:8080/#/connected/alan`
- `http://home.cozy.localhost:8080/#/connected/alan/accounts/123`

2. Ask the browser to go back

- `http://home.cozy.localhost:8080/#/connected`
- ❗ `http://home.cozy.localhost:8080/#/connected/alan/accounts/123`

At this time it was not possible to locate which piece of code was doing that push back to the connector computed URL. As it seems to be occurring only in obscure environments it could probably be ignored for now. But it's not sure at this time if the main environments (Chrome/Firefox/Webview) could be affected by this anomaly under unknown circumstances.