### PR TITLE
fix: Fallback to slug name in URL

### DIFF
--- a/src/components/Konnector.jsx
+++ b/src/components/Konnector.jsx
@@ -5,6 +5,7 @@ import flow from 'lodash/flow'
 
 import { Routes as HarvestRoutes } from 'cozy-harvest-lib'
 import datacardOptions from 'cozy-harvest-lib/dist/datacards/datacardOptions'
+import log from 'cozy-logger'
 
 import { getKonnector } from 'ducks/konnectors'
 
@@ -13,10 +14,22 @@ import { getTriggersByKonnector } from 'reducers'
 export const Konnector = ({ konnector, history, triggers }) => {
   const konnectorWithTriggers = { ...konnector, triggers: { data: triggers } }
   const onDismiss = useCallback(() => history.push('/connected'), [history])
+  const slug = konnector?.slug || location.hash.split('/')[2]
+
+  if (!slug) {
+    log(
+      'error',
+      `<Konnector /> failed to render. No Konnector slug was provided to the component props.
+      Tried to recover with window location but couldn't find a slug.
+      Hypertext Reference is "${location.href}".`
+    )
+
+    return null
+  }
 
   return (
     <HarvestRoutes
-      konnectorRoot={`/connected/${konnector.slug}`}
+      konnectorRoot={`/connected/${slug}`}
       konnector={konnectorWithTriggers}
       onDismiss={onDismiss}
       datacardOptions={datacardOptions}


### PR DESCRIPTION
When there is no `Konnector` prop, the application will crash (it can happen if Home App is opened directly on a konnector URL for instance).
This happens because no slug is passed to `Konnector` component.
In order to fix this, we can read the URL and get the slug from there.
As URLs are predictable, we can safely assume the slug will always be
the third string in the hash pathname.
