### PR TITLE
feat: Upgrade cozy-keys-lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Remove unused demo timeline
 * Unregister any service worker that could have been registered during development
 * Upgrade cozy-flags to remove useless some warnings flag.enable
+* Upgrade cozy-keys-lib to remove warning in the console
 
 
 # 1.45.0

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cozy-flags": "2.8.7",
     "cozy-harvest-lib": "8.3.1",
     "cozy-intent": "1.14.1",
-    "cozy-keys-lib": "3.11.0",
+    "cozy-keys-lib": "^4.1.9",
     "cozy-logger": "1.8.1",
     "cozy-realtime": "4.0.5",
     "cozy-sharing": "4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5344,21 +5344,21 @@ cozy-interapp@^0.5.4:
   resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.5.7.tgz#75cafe1732ad660e2caf1ccf412f302594705f39"
   integrity sha512-laIL/ATYV9oZnmqS+LMoO9qzk8XjJ1v2/YrA1Po2rI8ia/MDgjYO07424x2RuvHhNOBPGjD+JmqwQ0rNDlLW+Q==
 
-cozy-keys-lib@3.11.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-3.11.0.tgz#4c7c89247e15b1deb298ba0ef5d1341ae3942d53"
-  integrity sha512-5HxzThZ2oK/g8l3eOFWqh7PZ0j5pE4hmkXiaDCSCV5ZeKwwG/eYumljaYOOsBWmhS7FDNlaNwowMWuhfppZk0Q==
+cozy-keys-lib@^4.1.9:
+  version "4.1.9"
+  resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-4.1.9.tgz#cc1ad201ea936ea62aa12f01417e14dcd44aaeba"
+  integrity sha512-OE0yCxoLRrnCRTRdgjTzVnR0dolaaLq/3Ry/YzK09SH4+1Sj9BCven7600JtsLotgKZlqO4SKTHb78VteXjPLw==
   dependencies:
     "@aspnet/signalr" "^1.1.4"
     "@aspnet/signalr-protocol-msgpack" "^1.1.0"
+    "@cozy/minilog" "^1.0.0"
     big-integer "^1.6.44"
     classnames "^2.2.6"
     cozy-device-helper "^1.7.5"
     lodash "^4.17.15"
     lunr "^2.3.6"
     microee "^0.0.6"
-    minilog "https://github.com/cozy/minilog.git#master"
-    node-forge "^0.9.0"
+    node-forge "^1.3.0"
     papaparse "^5.1.1"
     prop-types "^15.7.2"
     sweetalert "^2.1.2"
@@ -10549,12 +10549,6 @@ mini-css-extract-plugin@0.5.0:
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
 
-"minilog@https://github.com/cozy/minilog.git#master":
-  version "3.1.0"
-  resolved "https://github.com/cozy/minilog.git#6da0aa58759c4f1a1a7e0fd093dbe2a67c035c55"
-  dependencies:
-    microee "0.0.6"
-
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -10816,7 +10810,7 @@ node-fetch@2.6.7, node-fetch@^2.0.0, node-fetch@^2.6.1:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@0.9.0, node-forge@^0.9.0:
+node-forge@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"
   integrity sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==
@@ -10825,6 +10819,11 @@ node-forge@^0.8.5:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.8.5.tgz#57906f07614dc72762c84cef442f427c0e1b86ee"
   integrity sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==
+
+node-forge@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
+  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
We have a few warnings in the console because of this lib. Upgrading the lib fix them. 

Mostly this one: https://github.com/cozy/cozy-keys-lib/compare/v4.1.0...v4.1.1