### PR TITLE
fix: Intent redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,13 @@
 * On IOS Safari, the URL and Navigation bar were always displayed
 * Now show the jobs as running after first account configuration in Harvest [PR](https://github.com/cozy/cozy-libs/pull/1515)
 * cozy-harvest-lib 8.2.1 : Get correct bi mapping for bnp_es and cic_es [PR](https://github.com/cozy/cozy-libs/pull/1531)
-
+* Fix a bug when opening a konnector from the store is opening briefly the home to redirect to... the store. Now we redirect to the right place.
 ## 🔧 Tech
 
 * Remove unused demo timeline
 * Unregister any service worker that could have been registered during development
 * Upgrade cozy-flags to remove useless some warnings flag.enable
 * Upgrade cozy-keys-lib to remove warning in the console
-
 
 # 1.45.0
 

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -40,7 +40,11 @@ const App = ({
 }) => {
   const [status, setStatus] = useState(IDLE)
   const [contentWrapper, setContentWrapper] = useState(undefined)
-  const [isFetching, setIsFetching] = useState(false)
+  const [isFetching, setIsFetching] = useState(
+    [accounts, konnectors, triggers].some(collection =>
+      ['pending', 'loading'].includes(collection.fetchStatus)
+    )
+  )
   const [hasError, setHasError] = useState(false)
   const [isReady, setIsReady] = useState(false)
   const [backgroundURL, setBackgroundURL] = useState(null)
@@ -53,7 +57,7 @@ const App = ({
 
   useEffect(() => {
     setIsFetching(
-      [accounts, konnectors, triggers].find(collection =>
+      [accounts, konnectors, triggers].some(collection =>
         ['pending', 'loading'].includes(collection.fetchStatus)
       )
     )


### PR DESCRIPTION
If we came from the store, by clicking on "open" on a konnector,
we're redirected to the Home application with the /redirect path

Inside this redirect path, we render the IntentRedirect component.
This component reads the redux store to fetch the current installed
konnectors.

But since we were setting isFetching to false by default, we had, at the
first render, isReady to true. So we redirected to /redirected without
having the informations about the konnectors yet.

The fix is pretty simple. We need to check if at the first render, one
query is in loading state.

Also, I refactored to use `some` instead of `find` to only deal with
boolean.

