### PR TITLE
feat: Upgrade cozy-client to 28.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Remove unused demo timeline
 * Unregister any service worker that could have been registered during development
 * Upgrade cozy-flags to remove useless some warnings flag.enable
+* Upgrade cozy-client to get ability to force HTTPs fetches when `window.cozy.isSecureProtocol` is `true`
 
 # 1.45.0
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@cozy/minilog": "1.0.0",
     "@material-ui/core": "4.12.3",
     "@material-ui/lab": "4.0.0-alpha.60",
-    "cozy-client": "^27.22.0",
+    "cozy-client": "^28.3.0",
     "cozy-device-helper": "1.18.0",
     "cozy-doctypes": "1.83.5",
     "cozy-flags": "2.8.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5249,19 +5249,16 @@ cozy-client-js@0.20.0:
     pouchdb-browser "7.0.0"
     pouchdb-find "7.0.0"
 
-cozy-client@^27.22.0:
-  version "27.22.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-27.22.0.tgz#bf3136ae8667222e5709d4dd9e8270cc18f0b330"
-  integrity sha512-ATFrJ0RLwto6GN7lyRdG6P5m86LxJQlO+t/Ap/APGX/VYnXWIXzmkawmP+yK05B7aBJ3ASkJGXEapZUOtyFb1A==
+cozy-client@^28.3.0:
+  version "28.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-28.3.0.tgz#8d32b0c107961a626e62392c6ed84a8c07e4d9d3"
+  integrity sha512-JUT7PbS1kRl0KmEMfBlZHXtBUzN3yr2eGgWp3YeGwDhEQtZOrDmOpTuKgq+mJphKQpELmlNIhtW0Q19wtjmcJg==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-device-helper "^1.12.0"
-    cozy-flags "2.7.1"
-    cozy-logger "^1.6.0"
-    cozy-stack-client "^27.21.0"
+    cozy-stack-client "^28.2.1"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -5280,13 +5277,6 @@ cozy-device-helper@1.18.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.18.0.tgz#45b37e68c30ec1104c8c40180b472d3662bc2534"
   integrity sha512-/s9X5oUH/Fpu3NKx1RS5T/iYzpfOlBD3tRGGsjth4VDYhqATlApUZLghmzvFvskEeC4eCAvNYfEkyo9UPrZbFQ==
-  dependencies:
-    lodash "^4.17.19"
-
-cozy-device-helper@^1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.12.0.tgz#619a24b0d3caf2d3f616a1524daef7c7b71eab7a"
-  integrity sha512-7pFbltgkD8rSO0PEf8pd6aBB37RUnNYH7fb3pkbcvo5rk4quCfSLREV94gZwXxowzP4vjZcAumTM09DfI42mJA==
   dependencies:
     lodash "^4.17.19"
 
@@ -5400,7 +5390,7 @@ cozy-logger@1.8.1:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
 
-cozy-logger@^1.3.0, cozy-logger@^1.6.0:
+cozy-logger@^1.3.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.7.0.tgz#945ff84df66f7e7e9640db00f8c632d4ff776fc8"
   integrity sha512-JBOAmfgujZZASE4TCRfeNvHoDnxPwFbLMO3G6UReByjR3Ix1/RSEtOL9b4hReuG2XX0BsPokfLWCZEWRgGN4TQ==
@@ -5520,6 +5510,15 @@ cozy-stack-client@^27.21.0:
   integrity sha512-sDJ1k+VkFS+vU4Z2e57MyI1o44yogtO9iYVX1gjmITOlMCcyh8nC4+eBlL6R7uU/oPbdWqAozPvnR8QlwxyZDQ==
   dependencies:
     cozy-flags "2.7.1"
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
+
+cozy-stack-client@^28.2.1:
+  version "28.2.1"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-28.2.1.tgz#f80f03fb859fb3d4224a7ba31024d61862adb64b"
+  integrity sha512-1qafyxmhHsDKycQfxM48BhapyIu2a2QNyhZh9t6/U4TMWDXoejMAVjiMB0YDizh5iwyFszvI9qBZ8hqar35/sw==
+  dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
     qs "^6.7.0"


### PR DESCRIPTION
This version retrieves a feature that allow `cozy-client` to force
HTTPs on fetches if `window.cozy.isSecureProtocol` is `true` (which
should be the case when `cozy-home` is served from ReactNative)

Related PR: cozy/cozy-client#1172