### PR TITLE
feat: Implement CSS transitions for apps/connectors open/exit

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,5 +19,8 @@
         ]
       }
     ]
+  },
+  "parserOptions": {
+    "project": "tsconfig.json"
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   testURL: 'http://localhost/',
-  moduleFileExtensions: ['js', 'jsx', 'json', 'styl'],
+  moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json', 'styl'],
   setupFiles: ['<rootDir>/test/jestLib/setup.js'],
   moduleDirectories: ['src', 'node_modules'],
   moduleNameMapper: {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cozy-doctypes": "1.83.8",
     "cozy-flags": "2.8.7",
     "cozy-harvest-lib": "^9.7.0",
-    "cozy-intent": "1.17.1",
+    "cozy-intent": "^2.2.0",
     "cozy-keys-lib": "3.11.1",
     "cozy-logger": "1.8.1",
     "cozy-realtime": "4.0.5",

--- a/src/components/BackgroundContainer.tsx
+++ b/src/components/BackgroundContainer.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+type BackgroundContainerProps = { backgroundURL?: string; children?: void }
+
+type BackgroundContainerComputedProps = {
+  className: string
+  style?: { backgroundImage: string }
+}
+
+const makeProps = (
+  backgroundURL?: string
+): BackgroundContainerComputedProps => ({
+  className: 'background-container',
+  ...(backgroundURL && {
+    style: { backgroundImage: `url(${backgroundURL})` }
+  })
+})
+
+export const BackgroundContainer = ({
+  backgroundURL
+}: BackgroundContainerProps): JSX.Element => (
+  <div {...makeProps(backgroundURL)} />
+)

--- a/src/components/Konnector.jsx
+++ b/src/components/Konnector.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import flow from 'lodash/flow'
@@ -10,11 +10,18 @@ import log from 'cozy-logger'
 import { getKonnector } from 'ducks/konnectors'
 
 import { getTriggersByKonnector } from 'reducers'
+import { closeApp, openApp } from 'hooks/useOpenApp'
 
 export const Konnector = ({ konnector, history, triggers }) => {
   const konnectorWithTriggers = { ...konnector, triggers: { data: triggers } }
   const onDismiss = useCallback(() => history.push('/connected'), [history])
   const slug = konnector?.slug || location.hash.split('/')[2]
+
+  useEffect(() => {
+    openApp()
+
+    return closeApp
+  }, [])
 
   if (!slug) {
     log(

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -23,6 +23,8 @@ import StoreRedirection from 'components/StoreRedirection'
 import { MainView } from 'components/MainView'
 import withCustomWallpaper from 'hoc/withCustomWallpaper'
 import { toFlagNames } from './toFlagNames'
+import { useOpenApp } from 'hooks/useOpenApp'
+import { BackgroundContainer } from 'components/BackgroundContainer'
 
 const IDLE = 'idle'
 const FETCHING_CONTEXT = 'FETCHING_CONTEXT'
@@ -49,6 +51,7 @@ const App = ({
   const [isReady, setIsReady] = useState(false)
   const [backgroundURL, setBackgroundURL] = useState(null)
   const webviewIntent = useWebviewIntent()
+  const { getAppState } = useOpenApp()
 
   useEffect(() => {
     const { cozyDefaultWallpaper } = client.getInstanceOptions()
@@ -98,13 +101,14 @@ const App = ({
 
   return (
     <div
-      className="App u-flex u-flex-column u-w-100 u-miw-100 u-flex-items-center"
+      className={`App ${getAppState} u-flex u-flex-column u-w-100 u-miw-100 u-flex-items-center`}
       style={{
-        backgroundImage: `url(${backgroundURL})`,
         position: 'fixed',
         height: '100%'
       }}
     >
+      <BackgroundContainer backgroundURL={backgroundURL} />
+
       <MainView>
         <Corner />
         <div

--- a/src/hooks/useOpenApp.spec.ts
+++ b/src/hooks/useOpenApp.spec.ts
@@ -1,0 +1,47 @@
+import { renderHook, act } from '@testing-library/react-hooks'
+
+import { useOpenApp, openApp, closeApp, AppState } from './useOpenApp'
+
+test('getAppState should return the correct value in a continuous scenario', () => {
+  const { result } = renderHook(() => useOpenApp())
+  const expectClosed = { getAppState: AppState.Closed }
+  const expectOpen = { getAppState: AppState.Opened }
+
+  expect(result.current).toStrictEqual(expectClosed)
+
+  act(() => {
+    openApp()
+  })
+
+  expect(result.current).toStrictEqual(expectOpen)
+
+  act(() => {
+    openApp()
+  })
+
+  expect(result.current).toStrictEqual(expectOpen)
+
+  act(() => {
+    closeApp()
+  })
+
+  expect(result.current).toStrictEqual(expectClosed)
+
+  act(() => {
+    closeApp()
+  })
+
+  expect(result.current).toStrictEqual(expectClosed)
+
+  act(() => {
+    openApp()
+  })
+
+  expect(result.current).toStrictEqual(expectOpen)
+
+  act(() => {
+    closeApp()
+  })
+
+  expect(result.current).toStrictEqual(expectClosed)
+})

--- a/src/hooks/useOpenApp.ts
+++ b/src/hooks/useOpenApp.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+
+/** Internals */
+
+enum AppAction {
+  CloseApp = 'closeApp',
+  OpenApp = 'openApp'
+}
+
+const openAppEvent = new Event(AppAction.OpenApp)
+
+const closeAppEvent = new Event(AppAction.CloseApp)
+
+/** API */
+
+export enum AppState {
+  Closed = '',
+  Opened = ' App--opened '
+}
+
+export const openApp = (): boolean => window.dispatchEvent(openAppEvent)
+
+export const closeApp = (): boolean => window.dispatchEvent(closeAppEvent)
+
+export const useOpenApp = (): { getAppState: AppState } => {
+  const [state, setState] = useState(AppState.Closed)
+
+  useEffect(() => {
+    window.addEventListener(AppAction.OpenApp, () => setState(AppState.Opened))
+    window.addEventListener(AppAction.CloseApp, () => setState(AppState.Closed))
+  }, [])
+
+  return { getAppState: state }
+}

--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -55,6 +55,17 @@ body
     background-color rgba(0, 0, 0, .32)
     backdrop-filter saturate(124%)
 
++small-screen()
+    .main-view, .background-container
+        transition transform 200ms ease-out
+
+    .App--opened
+        .main-view
+            transform scale(1.3)
+
+        .background-container
+            transform scale(1.1)
+
 .KonnectorErrors
     p
         margin: spacing_values.xs 0

--- a/src/styles/backgroundContainer.styl
+++ b/src/styles/backgroundContainer.styl
@@ -1,0 +1,8 @@
+.background-container
+    background-position center
+    background-repeat no-repeat
+    background-size cover
+    height 100%
+    mix-blend-mode multiply
+    position fixed
+    width 100%

--- a/src/styles/index.styl
+++ b/src/styles/index.styl
@@ -13,9 +13,7 @@
     @require './app.styl'
     @require './hero-header.styl'
     @require './lists.styl'
-
     @require './dialog.styl'
-
     @require './error.styl'
-
     @require './introjs-cozy.styl'
+    @require './backgroundContainer.styl'

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -14,6 +14,7 @@ import { WebviewIntentProvider } from 'cozy-intent'
 import homeConfig from 'config/home.json'
 import AppWrapper from 'components/AppWrapper'
 import PiwikHashRouter from 'lib/PiwikHashRouter'
+import { closeApp, openApp } from 'hooks/useOpenApp'
 
 const renderApp = () => {
   if (handleOAuthResponse()) return
@@ -22,7 +23,7 @@ const renderApp = () => {
     <AppWrapper>
       <BreakpointsProvider>
         <PiwikHashRouter>
-          <WebviewIntentProvider>
+          <WebviewIntentProvider methods={{ openApp, closeApp }}>
             <App {...homeConfig} />
           </WebviewIntentProvider>
         </PiwikHashRouter>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "include": ["./src/**/*"],
+  "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": "./src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "react",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "target": "es5",
+    "strict": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5294,7 +5294,7 @@ cozy-device-helper@^1.7.5:
   dependencies:
     lodash "4.17.19"
 
-cozy-doctypes@1.83.8:
+cozy-doctypes@1.83.8, cozy-doctypes@^1.83.8:
   version "1.83.8"
   resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.83.8.tgz#99ec864059034bd032f6f01e322b57fea130a5d3"
   integrity sha512-S88VzjnfZTHo7Mix7M3qId0YF6gOmL+C0X2LZnQp6F2cEOKa7sOlDiMD18u2kfPwyvlxxM+tQBI9ArEM/Xqkog==
@@ -5311,17 +5311,6 @@ cozy-doctypes@^1.83.5:
   integrity sha512-r4YEMoEuLTwl5iJ//rkxjpylkqAvZVIrUhdIHTtEdiFkJ7Oo4vpNQznzOAqP3Jdw8tfZkWE3rR3TE/wk1Elseg==
   dependencies:
     cozy-logger "^1.8.0"
-    date-fns "^1.30.1"
-    es6-promise-pool "^2.5.0"
-    lodash "^4.17.19"
-    prop-types "^15.7.2"
-
-cozy-doctypes@^1.83.8:
-  version "1.83.8"
-  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.83.8.tgz#99ec864059034bd032f6f01e322b57fea130a5d3"
-  integrity sha512-S88VzjnfZTHo7Mix7M3qId0YF6gOmL+C0X2LZnQp6F2cEOKa7sOlDiMD18u2kfPwyvlxxM+tQBI9ArEM/Xqkog==
-  dependencies:
-    cozy-logger "^1.9.0"
     date-fns "^1.30.1"
     es6-promise-pool "^2.5.0"
     lodash "^4.17.19"
@@ -5360,17 +5349,17 @@ cozy-harvest-lib@^9.7.0:
     react-markdown "^4.2.2"
     uuid "^3.3.2"
 
-cozy-intent@1.17.1:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-1.17.1.tgz#0e246ebf0308a7aaac04c8b2b66bc3ccf7146fae"
-  integrity sha512-oe5T9/igq9VZ99VZpUFR/ZWUg5wAHrccVe6oKjEAhLSFQ8UL2vA4sQdmNerMffTKEYy3bHm98tUGjhU0h8NeTA==
-  dependencies:
-    post-me "0.4.5"
-
 cozy-intent@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-2.0.2.tgz#81330389c7b8cfc1433608a435873b362691931c"
   integrity sha512-E+9WqbYhFiV/KCGFArSJu/jcvdliI58Vfa3ajrJFRV2AsPtej6wN5qfn6Wex53xpdTAZSjLfmYAQLNt0cl6xGw==
+  dependencies:
+    post-me "0.4.5"
+
+cozy-intent@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-2.2.0.tgz#bb32115c48bf239338166b90aaa2171f8295b8d5"
+  integrity sha512-DbThgCn3BkHfbe/zzofbzGuzLtSV/dkbuTV+pFKRDxTp3+qe1QsiFZtBS7ClcjPVP/kYKVTPv2gGnpejIgBx5g==
   dependencies:
     post-me "0.4.5"
 


### PR DESCRIPTION
# Pull Request Description

## Specification

Addresses this [ticket](https://trello.com/c/oxm6FGJG/455-%F0%9F%8E%81-e137-animation-%C3%A0-louverture-des-connecteurs-j).

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Implementation

`cozy-home` has to handle zoom-in/zoom-out animations on demand. This has to be compatible with **App Amirale** but nothing specific will be implemented for that in this PR. 

`cozy-harvest-lib` doesn't need to be upgraded to its latest version before merging, because it handles the fadeIn animation by itself, and `cozy-home` handles its animation alone.

- [x] Public API to trigger the animation
- [x] CSS class zooming in the application, with a transition
- [x] Works in reverse
- [x] Has parallax effect with the page background (if easy enough)

# How Has This Been Tested?

Since we're dealing with CSS animations it is too cumbersome to write tests for it. Testing was only done manually.

- [x] Manual testing in a web browser
- [x] Manual testing in a `WebView`

**Test Configuration**:
* WSL2 (Ubuntu-20.04) on Windows 10 Pro
* Microsoft Edge (Official build)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
