### PR TITLE
fix: Ugrade harvest to 9.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Display InAppBrowser in flagship app for OAuth connectors
 * cozy-harvest-lib 9.2.1 : Add BI connection creation via BI webview  [PR](https://github.com/cozy/cozy-libs/pull/1570)
 * cozy-harvest-lib 9.7.0 : Add contract activation/deactivation via BI webview  [PR](https://github.com/cozy/cozy-libs/pull/1627)
+* cozy-harvest-lib 9.8.0 : Add reconnect to bi Webviews  [PR](https://github.com/cozy/cozy-libs/pull/1656)
 
 ## 🐛 Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cozy-device-helper": "2.0.0",
     "cozy-doctypes": "1.83.8",
     "cozy-flags": "2.8.7",
-    "cozy-harvest-lib": "^9.7.0",
+    "cozy-harvest-lib": "^9.8.0",
     "cozy-intent": "^2.2.0",
     "cozy-keys-lib": "3.11.1",
     "cozy-logger": "1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5330,10 +5330,10 @@ cozy-flags@2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.7.0:
-  version "9.7.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.7.0.tgz#33809fc78fae96d557b007519deaf1d153443eee"
-  integrity sha512-mnENsXO+JaiLtyQIMLJZAAo/TM15ILUBSPnrlBknyAkqcmjUbQTnM/17gwjavU3zRvH61/KSOpl3S1MpDdu8LQ==
+cozy-harvest-lib@^9.8.0:
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.8.0.tgz#3904c0ff81dc0e89fb807b48da828d17ff37e561"
+  integrity sha512-tb84+ks7B5umtbA4rqidgy1vjkosaTjgtHvFfO+oKwwJILILzMu98aWlde+0drmAPLaqaL9fbNb8oS+wyPg/4w==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
To get BI reconnection via webviews


#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on supported browsers, including responsive mode
* [X] Localized in english and french
* [X] All changes have test coverage
* [X] Updated README & CHANGELOG, if necessary

