### PR TITLE
fix: Improve spacing in Connector title block

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cozy-device-helper": "^2.2.0",
     "cozy-doctypes": "1.83.8",
     "cozy-flags": "2.8.7",
-    "cozy-harvest-lib": "^9.8.0",
+    "cozy-harvest-lib": "^9.8.1",
     "cozy-intent": "^2.2.0",
     "cozy-keys-lib": "3.11.1",
     "cozy-logger": "1.8.1",

--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -66,6 +66,18 @@ body
         .background-container
             transform scale(1.1)
 
+    /*
+    * @HACK
+    * The <Dialog /> `cozy-ui` component used by Harvest has a flaw in its design
+    * In small screens, it will display (probably by error) the modal title in a padding '12 16 16 48' setting
+    * This is highly undesired and unfortunately we can't add class or any styling props to this part of <Dialog />
+    * At the time of this commit, the simplest way to handle the issue is to override `.dialogTitleWithBack` class
+    * This way we can apply our desired design in a limited scope: only Home, only Mobile
+    * Issue created: https://github.com/cozy/cozy-ui/issues/2165
+    */
+    .dialogTitleWithBack
+        padding spacing_values.xl spacing_values.m spacing_values.m !important // @stylint ignore
+
 .KonnectorErrors
     p
         margin: spacing_values.xs 0

--- a/yarn.lock
+++ b/yarn.lock
@@ -5330,10 +5330,10 @@ cozy-flags@2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.8.0:
-  version "9.8.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.8.0.tgz#3904c0ff81dc0e89fb807b48da828d17ff37e561"
-  integrity sha512-tb84+ks7B5umtbA4rqidgy1vjkosaTjgtHvFfO+oKwwJILILzMu98aWlde+0drmAPLaqaL9fbNb8oS+wyPg/4w==
+cozy-harvest-lib@^9.8.1:
+  version "9.8.1"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.8.1.tgz#0768a5da54e3859634c6e1ef9cacb7f65d6a81a8"
+  integrity sha512-0R2q07DKQTRtwxby0PFCOLfNsdCAndS6f4oYRc8j3Rnmr/Jg1VFWTXB1znyKHORxM/rIQNicPXZyrijwvW69mg==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
The `<Dialog />` `cozy-ui` component used by *Harvest* has a flaw in its design
In small screens, it will display (probably by error) the modal title in a `padding: 12px 16px 16px 48px` setting
This is highly undesired and unfortunately we can't add class or any styling props to this part of `<Dialog />`
At the time of this commit, the simplest way to handle the issue is to override the `.dialogTitleWithBack` class
This way we can apply our desired design in a limited scope: only *Home*, only *Mobile*
Issue created [here](https://github.com/cozy/cozy-ui/issues/2165)