### PR TITLE
fix: Cosmetic improvements

### DIFF
--- a/src/components/HeroHeader/index.jsx
+++ b/src/components/HeroHeader/index.jsx
@@ -25,7 +25,7 @@ export const HeroHeader = () => {
         variant="h1"
         className="hero-title u-ta-center u-mv-0 u-mh-1 u-primaryContrastTextColor"
       >
-        {publicName}
+        {publicName || '&nbsp;'}
       </Typography>
       <Typography className="hero-subtitle u-ta-center u-mv-0 u-mh-1 u-primaryContrastTextColor">
         {host}

--- a/src/components/Shortcuts/ShortcutsView.jsx
+++ b/src/components/Shortcuts/ShortcutsView.jsx
@@ -1,19 +1,12 @@
 import React from 'react'
 
-import { Spinner } from 'cozy-ui/transpiled/react'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 
 import { ShortcutLink } from 'components/ShortcutLink'
 
 export const ShortcutsView = ({ shortcutsDirectories }) => {
-  return !shortcutsDirectories ? (
-    shortcutsDirectories === null ? null : (
-      <div className="u-flex u-flex-justify-center">
-        <Spinner size="xxlarge" role="progressbar" />
-      </div>
-    )
-  ) : (
+  return !shortcutsDirectories ? null : (
     <>
       {shortcutsDirectories.map(directory => (
         <div

--- a/src/components/Shortcuts/ShortcutsView.spec.jsx
+++ b/src/components/Shortcuts/ShortcutsView.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { render, screen } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
 
 import { ShortcutsView } from './ShortcutsView'
@@ -8,18 +8,6 @@ import AppLike from 'test/AppLike'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 
 describe('Shortcuts', () => {
-  it('Should display a spinner on first render', () => {
-    render(
-      <AppLike>
-        <MuiCozyTheme>
-          <ShortcutsView />
-        </MuiCozyTheme>
-      </AppLike>
-    )
-
-    expect(screen.getByRole('progressbar')).toBeInTheDocument()
-  })
-
   it('Should display nothing if nothing was found', () => {
     const { container } = render(
       <AppLike>


### PR DESCRIPTION
Added a nbsp in hero-title so it
does always have correct placeholder height

Deleted Spinner for shortcuts loading.
Displaying nothing instead