### PR TITLE
fix: Assume instanceSettings can be undefined

### DIFF
--- a/src/components/MoveModal.jsx
+++ b/src/components/MoveModal.jsx
@@ -13,7 +13,7 @@ export const MoveModal = () => {
   const { t } = useI18n()
   const { data: instanceSettings } = useInstanceSettings(client)
 
-  const movedFrom = instanceSettings['moved_from']
+  const movedFrom = instanceSettings?.['moved_from']
   const [hasBeenClosed, setClosed] = useState(false)
   const displayModal = Boolean(movedFrom && !hasBeenClosed)
 


### PR DESCRIPTION
It was believed that instanceSettings would at last be an empty object.
But an occurence can make it appear as undefined.
As a preventive measure, assume it can be undefined.
Then later we have to find out why it's undefined in the first place