### PR TITLE
feat: Preload fonts before CSS is fetched

### DIFF
--- a/src/targets/browser/index.ejs
+++ b/src/targets/browser/index.ejs
@@ -11,6 +11,8 @@
   <meta name="msapplication-TileColor" content="#2b5797">
   <meta name="theme-color" content="#ffffff">
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, viewport-fit=cover">
+  <link rel="preload" href="/assets/fonts/Lato-Bold.immutable.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Lato-Regular.immutable.woff2" as="font" type="font/woff2" crossorigin>
   <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
     <link rel="stylesheet" href="<%- file %>">
     <% }); %>


### PR DESCRIPTION
This should allow faster display of the custom fonts,
that way we don't have to fallback while waiting