### PR TITLE
fix: Remove chrome highlight on AppTile touch

### DIFF
--- a/src/styles/lists.styl
+++ b/src/styles/lists.styl
@@ -36,6 +36,7 @@
 
     a
         text-decoration none
+        -webkit-tap-highlight-color transparent // https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-tap-highlight-color
 
 .app-list-wrapper, .services-list-wrapper, .shortcuts-list-wrapper, .failure-wrapper
     max-width 50rem


### PR DESCRIPTION
Adding a CSS property to make it transparent
instead of default Chrome blue
