### PR TITLE
fix: Open connector even if not present in local state

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cozy-device-helper": "2.2.1",
     "cozy-doctypes": "1.83.8",
     "cozy-flags": "2.10.0",
-    "cozy-harvest-lib": "^9.23.4",
+    "cozy-harvest-lib": "^9.24.0",
     "cozy-intent": "^2.3.0",
     "cozy-keys-lib": "^3.11.2",
     "cozy-logger": "1.8.1",

--- a/src/components/Konnector.jsx
+++ b/src/components/Konnector.jsx
@@ -12,8 +12,11 @@ import { getKonnector } from 'ducks/konnectors'
 import { getTriggersByKonnector } from 'reducers'
 import { closeApp, openApp } from 'hooks/useOpenApp'
 
-export const Konnector = ({ konnector, history, triggers }) => {
-  const konnectorWithTriggers = { ...konnector, triggers: { data: triggers } }
+export const Konnector = ({ konnector, history, match, triggers }) => {
+  const { konnectorSlug } = match ? match.params : {}
+  const konnectorWithTriggers = konnector
+    ? { ...konnector, triggers: { data: triggers } }
+    : undefined
   const onDismiss = useCallback(() => history.push('/connected'), [history])
   const slug = konnector?.slug || location.hash.split('/')[2]
 
@@ -38,6 +41,7 @@ export const Konnector = ({ konnector, history, triggers }) => {
     <HarvestRoutes
       konnectorRoot={`/connected/${slug}`}
       konnector={konnectorWithTriggers}
+      konnectorSlug={konnectorSlug}
       onDismiss={onDismiss}
       datacardOptions={datacardOptions}
     />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5323,10 +5323,10 @@ cozy-flags@2.7.1:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.23.4:
-  version "9.23.4"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.23.4.tgz#c0e2339e7bcb872a3e053b94b206b34fff285362"
-  integrity sha512-Gia5ta3LIagKpx7SKqIuE74U6x5mrkFwMcKQPWf5PH4uF0j3p7HKeRUyoQFhPDOwzynO7dHdVgqgaWPWOh/2CA==
+cozy-harvest-lib@^9.24.0:
+  version "9.24.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.24.0.tgz#10d9f0e1e9676f0640a3da451a9b22f7d919bfa4"
+  integrity sha512-rPUZA6xe6cENiezQnxHmjiRR8qLd5fHvc64niyKBHfC9wsAhRkhmIyQbBPOBAICHXQs1ofeWitQrH5E6iHGPuA==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
In flagship app, if RealTime is not active on `cozy-home` and the app
asks `cozy-home` to display a newly installed connector, then the
connector wouldn't be present in the local state and so
`cozy-harvest-lib` would throw an error

With new implementation, we set `konnectorSlug` so `cozy-harvest-lib`
can retrieve the connector from `cozy-stack` if it is not present in
local state

Related PR: cozy/cozy-libs#1740

____

TODO:

- [x] Upgrade cozy-harvest-lib after https://github.com/cozy/cozy-libs/pull/1740 is merged