### PR TITLE
fix: Display IconBinary for shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "homepage": "https://github.com/cozy/cozy-home#readme",
   "dependencies": {
     "@cozy/minilog": "1.0.0",
-    "@material-ui/core": "4.12.3",
     "@material-ui/lab": "4.0.0-alpha.60",
     "cozy-client": "^30.0.0",
     "cozy-device-helper": "2.2.1",
@@ -47,7 +46,7 @@
     "cozy-realtime": "4.0.5",
     "cozy-sharing": "4.1.0",
     "cozy-stack-client": "^27.21.0",
-    "cozy-ui": "^68.5.1",
+    "cozy-ui": "^70.2.2",
     "date-fns": "2.28.0",
     "form-data": "2.5.1",
     "intro.js-fix-cozy": "2.9.5",

--- a/src/components/ShortcutLink.jsx
+++ b/src/components/ShortcutLink.jsx
@@ -6,14 +6,17 @@ import { CozyFile } from 'cozy-doctypes'
 
 import SquareAppIcon from 'cozy-ui/transpiled/react/SquareAppIcon'
 import Link from 'cozy-ui/transpiled/react/Link'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
-export const ShortcutLink = ({ file }) => {
+export const ShortcutLink = ({ file, desktopSize = 32 }) => {
   const client = useClient()
   const { shortcutInfos } = useFetchShortcut(client, file._id)
+  const { isMobile } = useBreakpoints()
+  const computedSize = isMobile ? 32 : desktopSize
 
   const { filename } = CozyFile.splitFilename(file)
   const url = get(shortcutInfos, 'data.attributes.url', '#')
-
+  const iconBinary = get(shortcutInfos, 'data.attributes.metadata.icon')
   return (
     <Link
       underline="none"
@@ -22,7 +25,22 @@ export const ShortcutLink = ({ file }) => {
       rel="noopener noreferrer"
       className="scale-hover"
     >
-      <SquareAppIcon name={filename} variant="shortcut" />
+      {iconBinary ? (
+        <SquareAppIcon
+          name={filename}
+          variant="shortcut"
+          IconContent={
+            <img
+              src={`data:image/svg+xml;base64,${window.btoa(iconBinary)}`}
+              width={computedSize}
+              height={computedSize}
+              alt={filename}
+            />
+          }
+        />
+      ) : (
+        <SquareAppIcon name={filename} variant="shortcut" />
+      )}
     </Link>
   )
 }

--- a/src/components/Shortcuts/__snapshots__/ShortcutsView.spec.jsx.snap
+++ b/src/components/Shortcuts/__snapshots__/ShortcutsView.spec.jsx.snap
@@ -34,7 +34,7 @@ Object {
                   style="background-color: rgb(53, 206, 104);"
                 >
                   <h2
-                    class="MuiTypography-root makeStyles-letter-32 MuiTypography-h2 MuiTypography-alignCenter"
+                    class="MuiTypography-root makeStyles-letter-32 MuiTypography-h2 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
                   >
                     L
                   </h2>
@@ -59,7 +59,7 @@ Object {
                 </span>
               </span>
               <h6
-                class="MuiTypography-root makeStyles-name-31 u-spacellipsis MuiTypography-h6 MuiTypography-alignCenter"
+                class="MuiTypography-root makeStyles-name-31 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
               >
                 List item
               </h6>
@@ -99,7 +99,7 @@ Object {
                 style="background-color: rgb(53, 206, 104);"
               >
                 <h2
-                  class="MuiTypography-root makeStyles-letter-32 MuiTypography-h2 MuiTypography-alignCenter"
+                  class="MuiTypography-root makeStyles-letter-32 MuiTypography-h2 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
                 >
                   L
                 </h2>
@@ -124,7 +124,7 @@ Object {
               </span>
             </span>
             <h6
-              class="MuiTypography-root makeStyles-name-31 u-spacellipsis MuiTypography-h6 MuiTypography-alignCenter"
+              class="MuiTypography-root makeStyles-name-31 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
             >
               List item
             </h6>
@@ -221,7 +221,7 @@ Object {
                   style="background-color: rgb(252, 109, 0);"
                 >
                   <h2
-                    class="MuiTypography-root makeStyles-letter-68 MuiTypography-h2 MuiTypography-alignCenter"
+                    class="MuiTypography-root makeStyles-letter-68 MuiTypography-h2 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
                   >
                     B
                   </h2>
@@ -246,7 +246,7 @@ Object {
                 </span>
               </span>
               <h6
-                class="MuiTypography-root makeStyles-name-67 u-spacellipsis MuiTypography-h6 MuiTypography-alignCenter"
+                class="MuiTypography-root makeStyles-name-67 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
               >
                 b
               </h6>
@@ -283,7 +283,7 @@ Object {
                   style="background-color: rgb(255, 150, 47);"
                 >
                   <h2
-                    class="MuiTypography-root makeStyles-letter-68 MuiTypography-h2 MuiTypography-alignCenter"
+                    class="MuiTypography-root makeStyles-letter-68 MuiTypography-h2 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
                   >
                     D
                   </h2>
@@ -308,7 +308,7 @@ Object {
                 </span>
               </span>
               <h6
-                class="MuiTypography-root makeStyles-name-67 u-spacellipsis MuiTypography-h6 MuiTypography-alignCenter"
+                class="MuiTypography-root makeStyles-name-67 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
               >
                 d
               </h6>
@@ -348,7 +348,7 @@ Object {
                 style="background-color: rgb(252, 109, 0);"
               >
                 <h2
-                  class="MuiTypography-root makeStyles-letter-68 MuiTypography-h2 MuiTypography-alignCenter"
+                  class="MuiTypography-root makeStyles-letter-68 MuiTypography-h2 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
                 >
                   B
                 </h2>
@@ -373,7 +373,7 @@ Object {
               </span>
             </span>
             <h6
-              class="MuiTypography-root makeStyles-name-67 u-spacellipsis MuiTypography-h6 MuiTypography-alignCenter"
+              class="MuiTypography-root makeStyles-name-67 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
             >
               b
             </h6>
@@ -410,7 +410,7 @@ Object {
                 style="background-color: rgb(255, 150, 47);"
               >
                 <h2
-                  class="MuiTypography-root makeStyles-letter-68 MuiTypography-h2 MuiTypography-alignCenter"
+                  class="MuiTypography-root makeStyles-letter-68 MuiTypography-h2 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
                 >
                   D
                 </h2>
@@ -435,7 +435,7 @@ Object {
               </span>
             </span>
             <h6
-              class="MuiTypography-root makeStyles-name-67 u-spacellipsis MuiTypography-h6 MuiTypography-alignCenter"
+              class="MuiTypography-root makeStyles-name-67 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
             >
               d
             </h6>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5531,12 +5531,13 @@ cozy-stack-client@^30.0.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-ui@^68.5.1:
-  version "68.5.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-68.5.1.tgz#4f4b6cb8a70a53fa1347c3b3e037c747351c6df8"
-  integrity sha512-PhxDn+g7WujewEoKrrbm9T1FKrwJXttAsh+h16l01HqrdaytgRoBAtZc54kw8Rd3sERu4vod0AYbygoiY1+wlg==
+cozy-ui@^70.2.2:
+  version "70.2.2"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-70.2.2.tgz#b932a454eb821d233e3f8a543f42c5d1ff27bc5d"
+  integrity sha512-ttUUuROs8B4NQSgXf+IFTUlE9lhNi9Bhgiy2jDtocP0YhZNotgvdwb869NPCZHQdWWQRQa8/BSDGn2U8SX61jQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
+    "@material-ui/core" "4.12.3"
     "@popperjs/core" "^2.4.4"
     bundlemon "^1.3.2"
     chart.js "3.7.1"
@@ -10899,7 +10900,6 @@ msgpack5@^4.0.2:
 
 "mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
   version "1.0.6"
-  uid "494c40416ecde95732c864f9b921e7e545075aa5"
   resolved "https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"


### PR DESCRIPTION
We lose the ability to display the binary of a shortcut. Let's add it again.

Needs https://github.com/cozy/cozy-ui/pull/2190 