### PR TITLE
fix: Help button should target blank everywhere

### DIFF
--- a/src/components/HeroHeader/HelpButton.tsx
+++ b/src/components/HeroHeader/HelpButton.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import HelpIcon from 'cozy-ui/transpiled/react/Icons/Help'
-import { isFlagshipApp } from 'cozy-device-helper'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import CornerButton from './CornerButton'
@@ -11,12 +10,11 @@ const HelpButton = (): JSX.Element => {
 
   return (
     <CornerButton
-      label={t('help')}
       href={t('help_link')}
       icon={HelpIcon}
-      {...(isFlagshipApp()
-        ? { target: '_blank', rel: 'noopener noreferrer' }
-        : {})}
+      label={t('help')}
+      rel="noopener noreferrer"
+      target="_blank"
     />
   )
 }

--- a/src/cozy-ui.d.ts
+++ b/src/cozy-ui.d.ts
@@ -25,4 +25,8 @@ declare module 'cozy-ui/transpiled/react/Button' {
   export const Button: (props: React.PropsWithChildren) => JSX.Element
 }
 
-declare module 'cozy-ui/transpiled/react/Icons/Help' {}
+declare module 'cozy-ui/transpiled/react/Icons/Help' {
+  export default function HelpIcon(
+    props?: Omit<React.SVGAttributes<SVGElement>, 'children'>
+  ): JSX.Element
+}


### PR DESCRIPTION
After review, the help button should open a new tab no matter the env.
Also added better typings blueprint for cozy-ui icons in def file.