### PR TITLE
feat: Upgrade `cozy-harvest-lib` to 9.26.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cozy-device-helper": "2.2.1",
     "cozy-doctypes": "1.83.8",
     "cozy-flags": "2.10.0",
-    "cozy-harvest-lib": "^9.26.1",
+    "cozy-harvest-lib": "^9.26.6",
     "cozy-intent": "^2.3.0",
     "cozy-keys-lib": "^3.11.2",
     "cozy-logger": "1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5329,12 +5329,12 @@ cozy-doctypes@^1.85.0:
     lodash "^4.17.19"
     prop-types "^15.7.2"
 
-cozy-doctypes@^1.85.1:
-  version "1.85.1"
-  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.85.1.tgz#4e2ea4a9be718b2c9f02d66ae09cecc59bfc93ee"
-  integrity sha512-WG5LLYfqb9D5wiMHwzQFtgi8IX20uMbCqUuM0c04u9nEJx0c/oGdFMtY38zf2hcB8oz+86++tHcceqsPuWTKhQ==
+cozy-doctypes@^1.85.3:
+  version "1.85.3"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.85.3.tgz#9a59856161a4e54af248bec8ed6b1e8752bbbcff"
+  integrity sha512-ISHGpC4tlzcN4P8MzKV3vbsWmx6AfPIZjO60KSHNfHuD1TFfOaAWKQXpg2Eo4KWExImzRXmrs1uMTuYFEdYZTA==
   dependencies:
-    cozy-logger "^1.9.0"
+    cozy-logger "^1.9.1"
     date-fns "^1.30.1"
     es6-promise-pool "^2.5.0"
     lodash "^4.17.19"
@@ -5354,16 +5354,16 @@ cozy-flags@2.7.1:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.26.1:
-  version "9.26.1"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.26.1.tgz#367b2d15fb737a832b81754f05dc9e849e53c29c"
-  integrity sha512-YTDR0rjQdemM5k9yZvWEhcXs1J2PrpHQlliVYirkPmz2Sga9WcpDUIPmtXV9zf7oUWEabOR0/QG0OxeLj5Rbew==
+cozy-harvest-lib@^9.26.6:
+  version "9.26.6"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.26.6.tgz#7fca707bb51fe82f8e82e3edbc915481da366cbe"
+  integrity sha512-zy087g04BiyLO6IBrQFDNsma2kR19A2oKHre6drE6kyRQ2ctHMjSSOXArV5jumykAdy1SP3/mSryG42/WA9hog==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"
     cozy-bi-auth "0.0.25"
-    cozy-doctypes "^1.85.1"
-    cozy-logger "^1.9.0"
+    cozy-doctypes "^1.85.3"
+    cozy-logger "^1.9.1"
     date-fns "^1.30.1"
     final-form "^4.18.5"
     lodash "^4.17.19"
@@ -5434,6 +5434,14 @@ cozy-logger@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.9.0.tgz#e3a2323d9a2945ca10da5c318ff2f63544a54415"
   integrity sha512-x/iFwFuNTbG4lwgeKPv6HtdixY+CcJm47sRd2za09aS1zZMHnN3HX7fFgoSSgEqFhpnIO/PpP2pVqJ4orSCp0g==
+  dependencies:
+    chalk "^2.4.2"
+    json-stringify-safe "5.0.1"
+
+cozy-logger@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.9.1.tgz#d5eb5a007eae6b4612fc6cc5a82fd70fe8c435bb"
+  integrity sha512-9P8A4chfSsdx5P32upo9SDx+ZyQj1RuFuggHd6BgVbcFo7folCulk6TCFRFEekT2fIYHbT2nRDc0RTOdz98lYw==
   dependencies:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"


### PR DESCRIPTION
`cozy-harvest-lib` as been upgraded to to `9.26.6` to retrieve a fix
that automatically close the harvest dialog and display an error
message when trying to open a non-existing connector

Related PR: cozy/cozy-libs#1807