### PR TITLE
feat: Upgrade cozy-harvest-lib to 9.32.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cozy-device-helper": "2.2.1",
     "cozy-doctypes": "1.83.8",
     "cozy-flags": "2.10.0",
-    "cozy-harvest-lib": "^9.29.5",
+    "cozy-harvest-lib": "^9.32.5",
     "cozy-intent": "^2.3.0",
     "cozy-keys-lib": "^4.3.0",
     "cozy-logger": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cozy-intent": "^2.3.0",
     "cozy-keys-lib": "^4.3.0",
     "cozy-logger": "1.8.1",
-    "cozy-realtime": "4.2.2",
+    "cozy-realtime": "4.2.9",
     "cozy-sharing": "4.5.2",
     "cozy-stack-client": "^27.21.0",
     "cozy-ui": "^75.6.1",

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -10,21 +10,24 @@ import ScrollToTopOnMount from 'components/ScrollToTopOnMount'
 import Services from 'components/Services'
 import FooterLogo from 'components/FooterLogo'
 import Shortcuts from 'components/Shortcuts'
+import { CozyConfirmDialogProvider } from 'cozy-harvest-lib'
 
 class Home extends Component {
   render() {
     const { setAppsReady, wrapper } = this.props
     return (
-      <Main className="u-flex-grow-1">
-        <ScrollToTopOnMount target={wrapper} />
-        <Content className="u-flex u-flex-column u-ph-1">
-          <Applications onAppsFetched={setAppsReady} />
-          <Services />
-          <Shortcuts />
-          <FooterLogo />
-        </Content>
-        <Route path="/connected/:konnectorSlug" component={Konnector} />
-      </Main>
+      <CozyConfirmDialogProvider>
+        <Main className="u-flex-grow-1">
+          <ScrollToTopOnMount target={wrapper} />
+          <Content className="u-flex u-flex-column u-ph-1">
+            <Applications onAppsFetched={setAppsReady} />
+            <Services />
+            <Shortcuts />
+            <FooterLogo />
+          </Content>
+          <Route path="/connected/:konnectorSlug" component={Konnector} />
+        </Main>
+      </CozyConfirmDialogProvider>
     )
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5754,6 +5754,13 @@ cozy-device-helper@^1.7.5:
   dependencies:
     lodash "4.17.19"
 
+cozy-device-helper@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-2.6.0.tgz#07d83e6e412244f92bba30a0e04560bf3e1abb79"
+  integrity sha512-9loS2xUnA1szP8z8rBu8ni69zZj95eZKH8OqPTspWeRgUtzCAMlJoXusqEUTgVbj37JrvbYkifyxf3IkCZDXAg==
+  dependencies:
+    lodash "^4.17.19"
+
 cozy-doctypes@1.83.8:
   version "1.83.8"
   resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.83.8.tgz#99ec864059034bd032f6f01e322b57fea130a5d3"
@@ -5886,13 +5893,13 @@ cozy-logger@^1.9.1:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
 
-cozy-realtime@4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-4.2.2.tgz#4284d82cb57b4e758eb3b146d484627b733b6058"
-  integrity sha512-GVdfthFG0uQs2MBTfBRSKrnA6WQfB1Sk76tgU5+2rwwIFpY3BUOUkBFj9FG9r29NCVPi7NzW7cyjhXeD3PBFPg==
+cozy-realtime@4.2.9:
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-4.2.9.tgz#3b8823a1c0e894e3160102d797c238cc85f57bd5"
+  integrity sha512-LMaCNI98W1KCb0DoaqEujbLomS9Nvypn3Drft0b9nq0SZhy5XYktqNT6qyiRe+mEhWyDG0AQA7b0C/lMLYIGYA==
   dependencies:
     "@cozy/minilog" "^1.0.0"
-    cozy-device-helper "^2.2.1"
+    cozy-device-helper "^2.6.0"
 
 cozy-release@1.10.0:
   version "1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5776,10 +5776,10 @@ cozy-doctypes@^1.85.0:
     lodash "^4.17.19"
     prop-types "^15.7.2"
 
-cozy-doctypes@^1.85.4:
-  version "1.85.4"
-  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.85.4.tgz#4c1f42d5bab1f15cc7da6431f820c676f21ba036"
-  integrity sha512-Ofk7PMio5lJ+NM0A0B0G7IBU29AYjP6pzct/3nh1ZJ3/DGmWNWDgnaYKYOkiLYIBcO+nC21Vnn95f02gEl+CUA==
+cozy-doctypes@^1.86.0:
+  version "1.86.0"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.86.0.tgz#017d03262d370ec34004a2d2799d3c1ed17e7cc1"
+  integrity sha512-NLXghupeE0rwnjsHnf/AnMppfhyMKb68wIO+xYg+zHsOKT+RvJQu72mrRw2Mn1Fuk9N2adAvW+WPquXHa6I3QA==
   dependencies:
     cozy-logger "^1.9.1"
     date-fns "^1.30.1"
@@ -5801,15 +5801,15 @@ cozy-flags@2.7.1:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.29.5:
-  version "9.29.5"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.29.5.tgz#82b485b9191510023e9d975f32f3391b62280076"
-  integrity sha512-RMF7UBfDr3Sla9zXngJbjvfFuJZIL0Xk6Hk9u9cc0CuiQzHAkFr0a0ZDf4NH3gQ2gXJ4WaqYjiAhVFvegJkeiA==
+cozy-harvest-lib@^9.32.5:
+  version "9.32.5"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.32.5.tgz#1a6825277adb755f124a7d87adb1b23da71ee897"
+  integrity sha512-4xMLsZZuiTPbQVAhahlbnMfUZth5+yCmM10hFRjjp/LbsrmAJZ6FPc7++Y14QTKrxMP0mc+pKRtDSNc+KimDaA==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"
     cozy-bi-auth "0.0.25"
-    cozy-doctypes "^1.85.4"
+    cozy-doctypes "^1.86.0"
     cozy-logger "^1.9.1"
     date-fns "^1.30.1"
     final-form "^4.18.5"


### PR DESCRIPTION
To get the new CozyConfirmDialogProvider which allows harvest to display a confirm dialog outside of its components tree.