### PR TITLE
fix: Use `RemoveScroll` to prevent OS pull-to-refresh on Flagship app

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-inspector": "5.1.1",
     "react-markdown": "4.3.1",
     "react-redux": "7.2.6",
+    "react-remove-scroll": "^2.5.5",
     "react-router-dom": "4.3.1",
     "react-swipeable-views": "0.14.0",
     "redux": "4.2.0",

--- a/src/components/AnimatedWrapper.jsx
+++ b/src/components/AnimatedWrapper.jsx
@@ -1,20 +1,38 @@
 import React from 'react'
+import { isFlagshipApp } from 'cozy-device-helper'
 import homeConfig from 'config/home.json'
 import { useOpenApp } from 'hooks/useOpenApp'
+import { RemoveScroll } from 'react-remove-scroll'
 
 import App from 'containers/App'
+
+const RemoveScrollOnFlaghsip = ({ children }) => {
+  if (isFlagshipApp()) {
+    return <RemoveScroll forwardProps>{children}</RemoveScroll>
+  }
+
+  return children
+}
+
 const AnimatedWrapper = () => {
   const { getAppState } = useOpenApp()
-  return (
-    <div
-      className={`App ${getAppState} u-flex u-flex-column u-w-100 u-miw-100 u-flex-items-center`}
-      style={{
+
+  const mainStyle = isFlagshipApp()
+    ? {
         position: 'fixed',
         height: '100%'
-      }}
-    >
-      <App {...homeConfig} />
-    </div>
+      }
+    : {}
+
+  return (
+    <RemoveScrollOnFlaghsip>
+      <div
+        className={`App ${getAppState} u-flex u-flex-column u-w-100 u-miw-100 u-flex-items-center`}
+        style={mainStyle}
+      >
+        <App {...homeConfig} />
+      </div>
+    </RemoveScrollOnFlaghsip>
   )
 }
 

--- a/src/containers/App.spec.jsx
+++ b/src/containers/App.spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { isFlagshipApp } from 'cozy-device-helper'
 import { render } from '@testing-library/react'
 import App from '../components/AnimatedWrapper'
 import AppLike from 'test/AppLike'
@@ -22,6 +23,12 @@ jest.mock('lib/redux-cozy-client', () => ({
   }
 }))
 
+jest.mock('cozy-device-helper', () => ({
+  isFlagshipApp: jest.fn(),
+  isAndroidApp: jest.fn(),
+  isIOS: jest.fn()
+}))
+
 // eslint-disable-next-line react/display-name
 jest.mock('components/HeroHeader', () => () => <div data-testid="HeroHeader" />)
 // jest.mock('components/Home', () => () => <div />)
@@ -36,8 +43,9 @@ jest.mock('react-router-dom', () => ({
 }))
 
 describe('App', () => {
-  it('should keep backgroundImage fixed on mobile scroll', () => {
+  it('should keep backgroundImage fixed on Flagship app scroll', () => {
     // Given
+    isFlagshipApp.mockReturnValue(true)
 
     // When
     const { container } = render(
@@ -54,5 +62,26 @@ describe('App', () => {
         )
         .getAttribute('style')
     ).toEqual('position: fixed; height: 100%;')
+  })
+
+  it(`should not keep backgroundImage fixed on mobile's browser scroll`, () => {
+    // Given
+    isFlagshipApp.mockReturnValue(false)
+
+    // When
+    const { container } = render(
+      <AppLike>
+        <App />
+      </AppLike>
+    )
+
+    // Then
+    expect(
+      container
+        .querySelector(
+          '.App.u-flex.u-flex-column.u-w-100.u-miw-100.u-flex-items-center'
+        )
+        .getAttribute('style')
+    ).toBeNull()
   })
 })

--- a/src/styles/backgroundContainer.styl
+++ b/src/styles/backgroundContainer.styl
@@ -2,7 +2,7 @@
     background-position center
     background-repeat no-repeat
     background-size cover
-    height 100%
+    height 100vh
     mix-blend-mode multiply
     position fixed
     width 100%

--- a/yarn.lock
+++ b/yarn.lock
@@ -6525,6 +6525,11 @@ detect-node-es@^1.0.0:
   resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.0.0.tgz#c0318b9e539a5256ca780dd9575c9345af05b8ed"
   integrity sha512-S4AHriUkTX9FoFvL4G8hXDcx6t3gp2HpfCza3Q0v6S78gul2hKWifLQbeW+ZF89+hSm2ZIc/uF3J97ZgytgTRg==
 
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
+
 detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
@@ -13604,6 +13609,14 @@ react-remove-scroll-bar@^2.1.0:
     react-style-singleton "^2.1.0"
     tslib "^1.0.0"
 
+react-remove-scroll-bar@^2.3.3:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz#53e272d7a5cb8242990c7f144c44d8bd8ab5afd9"
+  integrity sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==
+  dependencies:
+    react-style-singleton "^2.2.1"
+    tslib "^2.0.0"
+
 react-remove-scroll@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.4.1.tgz#e0af6126621083a5064591d367291a81b2d107f5"
@@ -13614,6 +13627,17 @@ react-remove-scroll@^2.4.0:
     tslib "^1.0.0"
     use-callback-ref "^1.2.3"
     use-sidecar "^1.0.1"
+
+react-remove-scroll@^2.5.5:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz#1e31a1260df08887a8a0e46d09271b52b3a37e77"
+  integrity sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==
+  dependencies:
+    react-remove-scroll-bar "^2.3.3"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
 
 react-router-dom@4.3.1:
   version "4.3.1"
@@ -13682,6 +13706,15 @@ react-style-singleton@^2.1.0:
     get-nonce "^1.0.0"
     invariant "^2.2.4"
     tslib "^1.0.0"
+
+react-style-singleton@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.1.tgz#f99e420492b2d8f34d38308ff660b60d0b1205b4"
+  integrity sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==
+  dependencies:
+    get-nonce "^1.0.0"
+    invariant "^2.2.4"
+    tslib "^2.0.0"
 
 react-swipeable-views-core@^0.13.7:
   version "0.13.7"
@@ -15959,6 +15992,11 @@ tslib@^1.0.0, tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.0.0, tslib@^2.1.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -16338,6 +16376,13 @@ use-callback-ref@^1.2.3:
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.4.tgz#d86d1577bfd0b955b6e04aaf5971025f406bea3c"
   integrity sha512-rXpsyvOnqdScyied4Uglsp14qzag1JIemLeTWGKbwpotWht57hbP78aNT+Q4wdFKQfQibbUX4fb6Qb4y11aVOQ==
 
+use-callback-ref@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.0.tgz#772199899b9c9a50526fedc4993fc7fa1f7e32d5"
+  integrity sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==
+  dependencies:
+    tslib "^2.0.0"
+
 use-deep-compare-effect@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz#ef0ce3b3271edb801da1ec23bf0754ef4189d0c6"
@@ -16358,6 +16403,14 @@ use-sidecar@^1.0.1:
   dependencies:
     detect-node-es "^1.0.0"
     tslib "^1.9.3"
+
+use-sidecar@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.2.tgz#2f43126ba2d7d7e117aa5855e5d8f0276dfe73c2"
+  integrity sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
In #1730 we attempted to fix the background's position so it would not
show a white area on top of the app when trying to pull-to-refresh from
our Flagship app

This had 2 side effects

The first one is that pull-to-refresh was not possible anymore on iOS
Safari and also the address bar would not hide anymore when scrolling

To prevent this we chose to apply the custom CSS only when the app is
hosted by our Flagship app

The second side effect is that trying to trigger the pull-to-refresh
gesture would freeze the UI for a few seconds. This is a common issue
with `position: fixed` divs

To prevent this, we wrapped the `main` div with `<RemoveScroll />`
plugin that would completely lock the scroll of the HTML body and only
allow the `main` div to scroll. However the `position: fixed` is still
needed si the `main` div would have the correct height and enable
scroll


```
### ✨ Features

*

### 🐛 Bug Fixes

* Fix interaction freeze that may happen when scrolling the app from iOS

### 🔧 Tech

*
```

___

Related PRs:
- https://github.com/cozy/cozy-home/pull/1730
- https://github.com/cozy/cozy-home/pull/1721
- https://github.com/cozy/cozy-home/pull/1851
