### PR TITLE
feat: Disable creation of office document in mobile

### DIFF
--- a/.bundlemonrc
+++ b/.bundlemonrc
@@ -8,7 +8,7 @@
     },
     {
       "path": "app/home.<hash>.js",
-      "maxSize": "40 KB"
+      "maxSize": "41 KB"
     },
     {
       "path": "intents-home.<hash>.min.css",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "cozy-client": "^35.6.0",
     "cozy-device-helper": "2.7.0",
     "cozy-doctypes": "1.83.8",
-    "cozy-flags": "2.10.0",
+    "cozy-flags": "2.12.0",
     "cozy-harvest-lib": "^13.8.0",
     "cozy-intent": "^2.3.0",
     "cozy-keys-lib": "^4.3.0",

--- a/src/components/AddButton/ActionsBottomSheet.jsx
+++ b/src/components/AddButton/ActionsBottomSheet.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react'
 
-import { useClient } from 'cozy-client'
+import { useClient, generateWebLink } from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import BottomSheet, {
   BottomSheetItem
@@ -13,7 +13,7 @@ import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
-import AppLinker, { generateWebLink } from 'cozy-ui/transpiled/react/AppLinker'
+import AppLinker from 'cozy-ui/transpiled/react/AppLinker'
 
 export const ActionsBottomSheet = ({ anchorRef, hideMenu, actionsLists }) => {
   const { t } = useI18n()
@@ -32,8 +32,9 @@ export const ActionsBottomSheet = ({ anchorRef, hideMenu, actionsLists }) => {
         {actionsLists.map((actionsList, index) => {
           const listContent = actionsList.map(action => {
             const url = generateWebLink({
+              pathname: '/',
               cozyUrl,
-              nativePath: action.path,
+              hash: action.path,
               slug: action.slug,
               subDomainType
             })

--- a/src/components/AddButton/helpers.js
+++ b/src/components/AddButton/helpers.js
@@ -106,13 +106,25 @@ export const DEFAULT_ACTIONS = [
   }
 ]
 
+export function hasActionFlagCorrectValue({ name, value, operator }) {
+  const flagValue = flag(name) === null ? 'null' : flag(name).toString()
+  return operator === '$ne' ? flagValue !== value : flagValue === value
+}
+
 export const filterAvailableActions = actions => {
-  return actions.filter(action =>
-    action.flag
-      ? flag(action.flag.name) &&
-        flag(action.flag.name).toString() === action.flag.value
-      : true
-  )
+  return actions.filter(action => {
+    const actionFlag = action.flag
+
+    if (actionFlag) {
+      if (Array.isArray(actionFlag)) {
+        return actionFlag.every(hasActionFlagCorrectValue)
+      } else {
+        return hasActionFlagCorrectValue(actionFlag)
+      }
+    }
+
+    return true
+  })
 }
 
 export const reworkActions = (actions, apps) => {

--- a/src/components/AddButton/helpers.js
+++ b/src/components/AddButton/helpers.js
@@ -22,10 +22,17 @@ export const DEFAULT_ACTIONS = [
       fr: 'Document texte',
       en: 'Text document'
     },
-    flag: {
-      name: 'drive.onlyoffice.enabled',
-      value: 'true'
-    }
+    flag: [
+      {
+        name: 'drive.office.enabled',
+        value: 'true'
+      },
+      {
+        name: 'drive.office.disableMobileEditing',
+        value: 'true',
+        operator: '$ne'
+      }
+    ]
   },
   {
     slug: 'drive',
@@ -35,10 +42,17 @@ export const DEFAULT_ACTIONS = [
       fr: 'Feuille de calcul',
       en: 'Spreadsheet'
     },
-    flag: {
-      name: 'drive.onlyoffice.enabled',
-      value: 'true'
-    }
+    flag: [
+      {
+        name: 'drive.office.enabled',
+        value: 'true'
+      },
+      {
+        name: 'drive.office.disableMobileEditing',
+        value: 'true',
+        operator: '$ne'
+      }
+    ]
   },
   {
     slug: 'drive',
@@ -48,10 +62,17 @@ export const DEFAULT_ACTIONS = [
       fr: 'Présentation',
       en: 'Presentation'
     },
-    flag: {
-      name: 'drive.onlyoffice.enabled',
-      value: 'true'
-    }
+    flag: [
+      {
+        name: 'drive.office.enabled',
+        value: 'true'
+      },
+      {
+        name: 'drive.office.disableMobileEditing',
+        value: 'true',
+        operator: '$ne'
+      }
+    ]
   },
   {
     divider: true

--- a/src/components/AddButton/helpers.spec.js
+++ b/src/components/AddButton/helpers.spec.js
@@ -1,0 +1,85 @@
+import { hasActionFlagCorrectValue, filterAvailableActions } from './helpers'
+import flag from 'cozy-flags'
+
+jest.mock('cozy-flags')
+
+describe('hasActionFlagCorrectValue', () => {
+  it('should check equality by default', () => {
+    flag.mockImplementation(() => true)
+
+    expect(
+      hasActionFlagCorrectValue({
+        name: 'test',
+        value: 'true'
+      })
+    ).toBe(true)
+  })
+
+  it('should check difference if operator is $ne', () => {
+    flag.mockImplementation(() => 'value1')
+
+    expect(
+      hasActionFlagCorrectValue({
+        name: 'test',
+        value: 'value2',
+        operator: '$ne'
+      })
+    ).toBe(true)
+  })
+
+  it('should return true if flag and correct value is null', () => {
+    flag.mockImplementation(() => null)
+
+    expect(
+      hasActionFlagCorrectValue({
+        name: 'test',
+        value: 'null'
+      })
+    ).toBe(true)
+  })
+})
+
+describe('filterAvailableActions', () => {
+  it('should manage flag array or single object', () => {
+    flag.mockImplementation(() => true)
+
+    const actions = [
+      {
+        slug: 'slug1',
+        flag: [
+          {
+            name: 'flag1',
+            value: 'true'
+          },
+          {
+            name: 'flag2',
+            value: 'true'
+          }
+        ]
+      },
+      {
+        slug: 'slug2',
+        flag: {
+          name: 'flag1',
+          value: 'false'
+        }
+      }
+    ]
+
+    expect(filterAvailableActions(actions)).toStrictEqual([
+      {
+        slug: 'slug1',
+        flag: [
+          {
+            name: 'flag1',
+            value: 'true'
+          },
+          {
+            name: 'flag2',
+            value: 'true'
+          }
+        ]
+      }
+    ])
+  })
+})

--- a/src/components/AddServiceTile.jsx
+++ b/src/components/AddServiceTile.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { useClient } from 'cozy-client'
-import AppLinker, { generateWebLink } from 'cozy-ui/transpiled/react/AppLinker'
+import { useClient, generateWebLink } from 'cozy-client'
+import AppLinker from 'cozy-ui/transpiled/react/AppLinker'
 
 import SquareAppIcon from 'cozy-ui/transpiled/react/SquareAppIcon'
 
@@ -16,9 +16,10 @@ const AddServiceTile = ({ label }) => {
       app={{ slug: 'store' }}
       nativePath={nativePath}
       href={generateWebLink({
+        pathname: '/',
         cozyUrl: cozyURL.origin,
         slug,
-        nativePath,
+        hash: nativePath,
         subDomainType
       })}
     >

--- a/src/components/CandidateCategoryTile.jsx
+++ b/src/components/CandidateCategoryTile.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Grid from 'cozy-ui/transpiled/react/MuiCozyTheme/Grid'
-import AppLinker, { generateWebLink } from 'cozy-ui/transpiled/react/AppLinker'
-import { useClient } from 'cozy-client'
+import AppLinker from 'cozy-ui/transpiled/react/AppLinker'
+import { useClient, generateWebLink } from 'cozy-client'
 import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
 import { useI18n } from 'cozy-ui/transpiled/react'
 import SquareAppIcon from 'cozy-ui/transpiled/react/SquareAppIcon'
@@ -24,9 +24,10 @@ const CandidateCategoryTile = ({ slugs, category }) => {
       app={{ slug: app }}
       nativePath={nativePath}
       href={generateWebLink({
+        pathname: '/',
         cozyUrl: cozyURL.origin,
         slug: app,
-        nativePath,
+        hash: nativePath,
         subDomainType
       })}
     >

--- a/src/components/FallbackCandidateServiceTile.jsx
+++ b/src/components/FallbackCandidateServiceTile.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import get from 'lodash/get'
-import AppLinker, { generateWebLink } from 'cozy-ui/transpiled/react/AppLinker'
-import { useClient } from 'cozy-client'
+import AppLinker from 'cozy-ui/transpiled/react/AppLinker'
+import { useClient, generateWebLink } from 'cozy-client'
 import useRegistryInformation from 'hooks/useRegistryInformation'
 import SquareAppIcon from 'cozy-ui/transpiled/react/SquareAppIcon'
 
@@ -22,9 +22,10 @@ const FallbackCandidateServiceTile = ({ slug }) => {
       app={{ slug: app }}
       nativePath={nativePath}
       href={generateWebLink({
+        pathname: '/',
         cozyUrl: cozyURL.origin,
         slug: app,
-        nativePath,
+        hash: nativePath,
         subDomainType
       })}
     >

--- a/yarn.lock
+++ b/yarn.lock
@@ -5796,10 +5796,10 @@ cozy-doctypes@^1.88.1:
     lodash "^4.17.19"
     prop-types "^15.7.2"
 
-cozy-flags@2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.10.0.tgz#d99e16db5a9fe1c1a64af97829a7a7d5055ce75f"
-  integrity sha512-DGc9RLcTTF3sibrZQ8kjj83KP7OFGlgJNR2sHLv7vSbrZqSLR0C+JwzltFtSAjpFp9vMEMKQjUp03mFowrAkZA==
+cozy-flags@2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.12.0.tgz#bc3d689db9c91389c28f053223142d4684573ef1"
+  integrity sha512-s0et8aWChaqY4rMKkNKDACflU2h5s6s9UVU1guU3Il9GqktSPrhvMo+ntHLnQb2l+yLL6xV1S6/rK0qniR1q0A==
   dependencies:
     microee "^0.0.6"
 


### PR DESCRIPTION
```
### ✨ Features

* Disable creation of office document in mobile with the flag `drive.office.disableMobileEditing`
```

**Notes:**
Need to use the flag `drive.office` with `enabled: true` property inside to show the link to office creation

**Related PRs:**
- https://github.com/cozy/cozy-libs/pull/2065