### PR TITLE
fix: Define the indexFields for the magicfolder query

### DIFF
--- a/src/queries.js
+++ b/src/queries.js
@@ -19,7 +19,9 @@ export const suggestedKonnectorsConn = {
 
 export const mkHomeMagicFolderConn = t => {
   return {
-    query: Q('io.cozy.files').where({ path: t('home_config_magic_folder') }),
+    query: Q('io.cozy.files')
+      .where({ path: t('home_config_magic_folder') })
+      .indexFields(['path']),
     as: 'home/io.cozy.files/path=magic-folder',
     fetchPolicy: defaultFetchPolicy
   }


### PR DESCRIPTION
Like that we remove the warning:
```
cozy-stack-client warn Selector fields should be manually indexed to prevent unexpected behaviour
```



```
### 🔧 Tech

* Remove cozy-stack-client warning about indexFields
```
