### PR TITLE
feat: Add flag to persist store even in the browser

### DIFF
--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -82,7 +82,7 @@ const configureDefault = (legacyClient, cozyClient, context, options) => {
 }
 
 const configureStore = (legacyClient, cozyClient, context, options = {}) => {
-  return isFlagshipApp()
+  return isFlagshipApp() || flag('home.store.persist')
     ? configureWithPersistor(legacyClient, cozyClient, context, options)
     : configureDefault(legacyClient, cozyClient, context, options)
 }


### PR DESCRIPTION
Added flag('home.store.persist') in order to persist store even in a browser.

ATM, this flag is used only for dev & debug purpose. Don't use it in production.



```
### 🔧 Tech

* We can persist the Home's store in the browser through the flag flag('home.store.persist')
```
