### PR TITLE
fix: improve workflow for native app

### DIFF
--- a/src/components/BackgroundContainer.tsx
+++ b/src/components/BackgroundContainer.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react'
-// @ts-expect-error -- TODO: type useCustomWallpaper
 import useCustomWallpaper from 'hooks/useCustomWallpaper'
 import { useClient } from 'cozy-client'
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,5 @@
+declare module 'cozy-harvest-lib' {
+  export const handleOAuthResponse: () => boolean
+}
+declare module 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+declare module 'cozy-ui/transpiled/react/Spinner'

--- a/src/targets/browser/index.ejs
+++ b/src/targets/browser/index.ejs
@@ -11,12 +11,14 @@
   <meta name="msapplication-TileColor" content="#2b5797">
   <meta name="theme-color" content="#ffffff">
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, viewport-fit=cover">
-  <link rel="preload" href="//{{.Domain}}/assets/fonts/Lato-Bold.immutable.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="//{{.Domain}}/assets/fonts/Lato-Regular.immutable.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="//{{.Domain}}/assets/fonts/Lato-Bold.immutable.woff2" as="font" type="font/woff2"
+    crossorigin>
+  <link rel="preload" href="//{{.Domain}}/assets/fonts/Lato-Regular.immutable.woff2" as="font" type="font/woff2"
+    crossorigin>
   <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
     <link rel="stylesheet" href="<%- file %>">
     <% }); %>
-  <link rel="stylesheet" href="//{{.Domain}}/assets/fonts/fonts.css">
+      <link rel="stylesheet" href="//{{.Domain}}/assets/fonts/fonts.css">
       {{.ThemeCSS}}
       <% if (__STACK_ASSETS__) { %>
         {{.CozyClientJS}}
@@ -30,8 +32,12 @@
     data-cozy-icon-path="{{.IconPath}}" data-cozy-subdomain-type="{{.SubDomain}}"
     data-cozy-default-wallpaper="{{.DefaultWallpaper}}" data-cozy-flags="{{.Flags}}">
     <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
-      <script src="<%- file %>"></script>
-      <% }); %>
+      <% if (process.env.NODE_ENV==='development' ) { %>
+        <script src="<%- file %>?cacheBuster=<%= Date.now() %>"></script>
+        <% } else { %>
+          <script src="<%- file %>"></script>
+          <% } %>
+            <% }); %>
 </body>
 
 </html>

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -1,48 +1,21 @@
-import 'cozy-ui/transpiled/react/stylesheet.css'
-import 'cozy-ui/dist/cozy-ui.utils.min.css'
-
-import 'intro.js-fix-cozy/minified/introjs.min.css'
-import 'styles/index.styl'
-
-import React from 'react'
 import { createRoot } from 'react-dom/client'
-import 'url-search-params-polyfill'
-import { handleOAuthResponse } from 'cozy-harvest-lib'
-import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
-import Spinner from 'cozy-ui/transpiled/react/Spinner'
-import { WebviewIntentProvider } from 'cozy-intent'
 
-import AppWrapper from 'components/AppWrapper'
-import { HashRouter } from 'react-router-dom'
-import { closeApp, openApp } from 'hooks/useOpenApp'
+import { renderApp } from './renderApp'
 
-const container = document.querySelector('[role=application]')
-const root = createRoot(container)
+const onReady = () => {
+  const container = document.querySelector('[role=application]')
+  if (!container) throw new Error('No container found')
+  const root = createRoot(container)
 
-const renderApp = () => {
-  if (handleOAuthResponse()) {
-    root.render(<Spinner size="xxlarge" middle={true} />)
-    return
+  renderApp(root)
+}
+
+export const _main = () => {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', onReady)
+  } else {
+    onReady()
   }
-  const AnimatedWrapper = require('components/AnimatedWrapper').default
-  root.render(
-    <WebviewIntentProvider methods={{ openApp, closeApp }}>
-      <AppWrapper>
-        <BreakpointsProvider>
-          <HashRouter>
-            <AnimatedWrapper />
-          </HashRouter>
-        </BreakpointsProvider>
-      </AppWrapper>
-    </WebviewIntentProvider>
-  )
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  renderApp()
-})
-
-if (module.hot) {
-  renderApp()
-  module.hot.accept()
-}
+if (process.env.NODE_ENV !== 'test') _main()

--- a/src/targets/browser/index.test.jsx
+++ b/src/targets/browser/index.test.jsx
@@ -1,0 +1,56 @@
+import { createRoot } from 'react-dom/client'
+import { renderApp } from './renderApp'
+import { _main } from './index'
+
+jest.mock('react-dom/client', () => ({
+  createRoot: jest.fn()
+}))
+
+jest.mock('./renderApp', () => ({
+  renderApp: jest.fn()
+}))
+
+describe('_main function', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders app when DOMContentLoaded event is fired', () => {
+    const container = document.createElement('div')
+    container.setAttribute('role', 'application')
+    document.body.appendChild(container)
+
+    Object.defineProperty(document, 'readyState', {
+      value: 'loading',
+      writable: true
+    })
+
+    _main()
+
+    expect(createRoot).not.toHaveBeenCalled()
+    expect(renderApp).not.toHaveBeenCalled()
+
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+
+    expect(createRoot).toHaveBeenCalledTimes(1)
+    expect(createRoot).toHaveBeenCalledWith(container)
+    expect(renderApp).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders app immediately when DOM content is already loaded', () => {
+    const container = document.createElement('div')
+    container.setAttribute('role', 'application')
+    document.body.appendChild(container)
+
+    Object.defineProperty(document, 'readyState', {
+      value: 'complete',
+      writable: true
+    })
+
+    _main()
+
+    expect(createRoot).toHaveBeenCalledTimes(1)
+    expect(createRoot).toHaveBeenCalledWith(container)
+    expect(renderApp).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/targets/browser/renderApp.tsx
+++ b/src/targets/browser/renderApp.tsx
@@ -1,0 +1,39 @@
+import 'cozy-ui/transpiled/react/stylesheet.css'
+import 'cozy-ui/dist/cozy-ui.utils.min.css'
+import 'intro.js-fix-cozy/minified/introjs.min.css'
+import 'styles/index.styl'
+import 'url-search-params-polyfill'
+
+import React from 'react'
+import { HashRouter } from 'react-router-dom'
+
+import { handleOAuthResponse } from 'cozy-harvest-lib'
+import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import { WebviewIntentProvider } from 'cozy-intent'
+
+import AppWrapper from 'components/AppWrapper'
+import { closeApp, openApp } from 'hooks/useOpenApp'
+import { Root } from 'react-dom/client'
+
+export const renderApp = (root?: Root): void => {
+  if (handleOAuthResponse()) {
+    root?.render(<Spinner size="xxlarge" middle={true} />)
+    return
+  }
+
+  // eslint-disable-next-line
+  const AnimatedWrapper = require('components/AnimatedWrapper').default as () => JSX.Element
+
+  root?.render(
+    <WebviewIntentProvider methods={{ openApp, closeApp }}>
+      <AppWrapper>
+        <BreakpointsProvider>
+          <HashRouter>
+            <AnimatedWrapper />
+          </HashRouter>
+        </BreakpointsProvider>
+      </AppWrapper>
+    </WebviewIntentProvider>
+  )
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,9 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
+    "paths": {
+      "components/*": ["./src/components/*"],
+      "hooks/*": ["./src/hooks/*"],
+    }
   }
 }


### PR DESCRIPTION
The app was always rendered twice in a row with a 30ms interval
This was because renderApp() was called twice with bad
HMR handling.
HMR update has been disabled for now because it doesn't work correctly.
The whole page will reload just as before when a file is updated.
This will  be fixed in another commit

This will also fix a bug in react-native WebView where the
static assets are never updated.
With the cache busting in dev mode only,
the webview will refetch the files everytime