### PR TITLE
fix: convert date before getting lastSync

### DIFF
--- a/src/ducks/connections/index.js
+++ b/src/ducks/connections/index.js
@@ -327,6 +327,28 @@ export const getFirstUserError = (state, konnectorSlug) => {
   return firstTriggerHavingUserError ? firstTriggerHavingUserError.error : null
 }
 
+/**
+ * Converts the input date string to a valid ISO 8601 format if needed.
+ *
+ * This function checks if the input date string is in the extended ISO 8601 format
+ * and trims the fractional seconds part to 6 digits if it has more than 6 digits.
+ * This is done to avoid deprecation warnings from Moment.js regarding
+ * non-standard date formats, as Moment.js expects a maximum of 6 digits for
+ * fractional seconds in the ISO 8601 format.
+ *
+ * @param {string} dateStr - The input date string
+ * @returns {string|null} - The converted date string in a valid ISO 8601 format, or null if input is falsy
+ */
+const convertDateFormat = dateStr => {
+  if (!dateStr) return null
+  const iso8601Pattern =
+    /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{1,6}(?:\+|-)\d{2}:\d{2}/
+  if (iso8601Pattern.test(dateStr)) {
+    return dateStr.slice(0, 23) + dateStr.slice(23)
+  }
+  return dateStr
+}
+
 export const getLastSyncDate = (state, konnectorSlug) => {
   const lastExecutions =
     !!state.konnectors &&
@@ -335,8 +357,8 @@ export const getLastSyncDate = (state, konnectorSlug) => {
     Object.values(state.konnectors[konnectorSlug].triggers)
       .map(trigger => trigger.lastSyncDate)
       .sort((dateA, dateB) => {
-        const momentA = moment.utc(dateA)
-        const momentB = moment.utc(dateB)
+        const momentA = moment.utc(convertDateFormat(dateA))
+        const momentB = moment.utc(convertDateFormat(dateB))
         return momentA.isAfter(momentB) ? -1 : momentA.isBefore(momentB) ? 1 : 0
       })
   return lastExecutions.length && lastExecutions[0]


### PR DESCRIPTION
This will check if the input date string is in the extended ISO 8601 format
 and trims the fractional seconds part to 6 digits if it has more than 6 digits.
 This is done to avoid deprecation warnings from Moment.js regarding
 non-standard date formats, as Moment.js expects a maximum of 6 digits for
 fractional seconds in the ISO 8601 format.
