### PR TITLE
feat: Add theme and complex background support to cozy-home  

### DIFF
--- a/.bundlemonrc
+++ b/.bundlemonrc
@@ -8,7 +8,7 @@
     },
     {
       "path": "app/home.<hash>.js",
-      "maxSize": "42 KB"
+      "maxSize": "43 KB"
     },
     {
       "path": "intents-home.<hash>.min.css",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "13.3.0",
     "@testing-library/react-hooks": "8.0.1",
+    "@types/classnames": "2.2.6",
     "@types/react": "18.0.17",
     "@types/react-dom": "18.0.6",
     "babel-jest": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "cozy-sharing": "7.1.0",
     "cozy-stack-client": "^36.2.0",
     "cozy-tsconfig": "1.2.0",
-    "cozy-ui": "^84.1.5",
+    "cozy-ui": "^85.0.0",
     "date-fns": "2.28.0",
     "es-abstract": "1.20.2",
     "form-data": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "cozy-sharing": "7.1.0",
     "cozy-stack-client": "^36.2.0",
     "cozy-tsconfig": "1.2.0",
-    "cozy-ui": "^85.0.0",
+    "cozy-ui": "^85.0.1",
     "date-fns": "2.28.0",
     "es-abstract": "1.20.2",
     "form-data": "2.5.1",

--- a/src/components/AddButton/AddButton.jsx
+++ b/src/components/AddButton/AddButton.jsx
@@ -3,6 +3,7 @@ import React, { useState, useRef } from 'react'
 import flag from 'cozy-flags'
 import { useQuery, isQueryLoading } from 'cozy-client'
 import { getFlagshipMetadata } from 'cozy-device-helper'
+import CozyTheme from 'cozy-ui/transpiled/react/CozyTheme'
 import Fab from 'cozy-ui/transpiled/react/Fab'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { appsConn } from 'queries'
@@ -59,11 +60,13 @@ export const AddButton = () => {
         <Icon icon="plus" />
       </Fab>
       {isOpen && (
-        <ActionsBottomSheet
-          hideMenu={hideMenu}
-          anchorRef={anchorRef}
-          actionsLists={actionsLists}
-        />
+        <CozyTheme variant="normal">
+          <ActionsBottomSheet
+            hideMenu={hideMenu}
+            anchorRef={anchorRef}
+            actionsLists={actionsLists}
+          />
+        </CozyTheme>
       )}
     </>
   )

--- a/src/components/AppWrapper.jsx
+++ b/src/components/AppWrapper.jsx
@@ -8,7 +8,7 @@ import flag from 'cozy-flags'
 import CozyClient, { CozyProvider, RealTimeQueries } from 'cozy-client'
 import CozyDevtools from 'cozy-client/dist/devtools'
 import I18n from 'cozy-ui/transpiled/react/I18n'
-import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
+import CozyTheme from 'cozy-ui/transpiled/react/CozyTheme'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { PersistGate } from 'redux-persist/integration/react'
 
@@ -19,6 +19,8 @@ import {
 import configureStore from 'store/configureStore'
 import homeConfig from 'config/home.json'
 import { RealtimePlugin } from 'cozy-realtime'
+
+import { usePreferedTheme } from 'hooks/usePreferedTheme'
 
 import schema from '../schema'
 import { ConditionalWrapper } from './ConditionalWrapper'
@@ -75,6 +77,19 @@ const Inner = ({ children, lang, context }) => (
   </I18n>
 )
 
+const ThemeProvider = ({ children }) => {
+  const preferedTheme = usePreferedTheme()
+
+  return (
+    <CozyTheme
+      variant={preferedTheme}
+      className="u-flex u-flex-column u-w-100 u-miw-100 u-flex-items-center"
+    >
+      {children}
+    </CozyTheme>
+  )
+}
+
 /**
  * Setups the app context and creates all context providers and wrappers
  * for an app
@@ -86,8 +101,8 @@ const AppWrapper = ({ children }) => {
   return (
     <AppContext.Provider value={appContext}>
       <BreakpointsProvider>
-        <MuiCozyTheme>
-          <CozyProvider client={cozyClient}>
+        <CozyProvider client={cozyClient}>
+          <ThemeProvider>
             <LegacyCozyProvider
               store={store}
               client={cozyClient}
@@ -109,8 +124,8 @@ const AppWrapper = ({ children }) => {
                 </ConditionalWrapper>
               </ReduxProvider>
             </LegacyCozyProvider>
-          </CozyProvider>
-        </MuiCozyTheme>
+          </ThemeProvider>
+        </CozyProvider>
       </BreakpointsProvider>
     </AppContext.Provider>
   )

--- a/src/components/AppWrapper.spec.jsx
+++ b/src/components/AppWrapper.spec.jsx
@@ -32,6 +32,9 @@ jest.mock('redux-persist/integration/react', () => ({
 }))
 const AddButtonMock = () => <></>
 jest.mock('./AddButton/AddButton', () => AddButtonMock)
+jest.mock('hooks/usePreferedTheme', () => ({
+  usePreferedTheme: jest.fn().mockReturnValue('inverted')
+}))
 
 describe('AppWrapper.jsx', () => {
   beforeEach(() => {

--- a/src/components/Applications.jsx
+++ b/src/components/Applications.jsx
@@ -4,7 +4,6 @@ import memoize from 'lodash/memoize'
 import { useQuery } from 'cozy-client'
 import flag from 'cozy-flags'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
-import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import { useI18n } from 'cozy-ui/transpiled/react'
 
 import AppTile from 'components/AppTile'
@@ -69,9 +68,7 @@ export const Applications = ({ onAppsFetched }) => {
 
   return (
     <div className="app-list-wrapper u-m-auto u-w-100">
-      <MuiCozyTheme variant="inverted">
-        <Divider className="u-mv-0" />
-      </MuiCozyTheme>
+      <Divider className="u-mv-0" />
 
       <div className="app-list u-w-100 u-mv-3 u-mv-2-t u-mh-auto u-flex-justify-center">
         {getApplicationsList(data)}

--- a/src/components/BackgroundContainer.tsx
+++ b/src/components/BackgroundContainer.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import useCustomWallpaper from 'hooks/useCustomWallpaper'
 import { useClient } from 'cozy-client'
+import cx from 'classnames'
+import { usePreferedTheme } from 'hooks/usePreferedTheme'
 
 type BackgroundContainerComputedProps = {
   className: string
@@ -8,9 +10,13 @@ type BackgroundContainerComputedProps = {
 }
 
 const makeProps = (
-  backgroundURL: string | null
+  backgroundURL: string | null,
+  preferedTheme: string
 ): BackgroundContainerComputedProps => ({
-  className: 'background-container',
+  className: cx('background-container', {
+    'background-container-darken': preferedTheme === 'inverted',
+    'home-default-partner-background': preferedTheme === 'normal'
+  }),
   ...(backgroundURL && {
     style: { backgroundImage: `url(${backgroundURL})` }
   })
@@ -22,7 +28,7 @@ export const BackgroundContainer = (): JSX.Element => {
     fetchStatus,
     data: { wallpaperLink }
   } = useCustomWallpaper()
-
+  const preferedTheme = usePreferedTheme()
   const [backgroundURL, setBackgroundURL] = useState<string | null>(null)
 
   useEffect(() => {
@@ -31,5 +37,6 @@ export const BackgroundContainer = (): JSX.Element => {
     }
     setBackgroundURL(wallpaperLink || cozyDefaultWallpaper)
   }, [wallpaperLink, fetchStatus, client])
-  return <div {...makeProps(backgroundURL)} />
+
+  return <div {...makeProps(backgroundURL, preferedTheme)} />
 }

--- a/src/components/HeroHeader/CornerButton.jsx
+++ b/src/components/HeroHeader/CornerButton.jsx
@@ -1,9 +1,26 @@
 import React from 'react'
+import cx from 'classnames'
 import Button, { ButtonLink } from 'cozy-ui/transpiled/react/Button'
+import { useCozyTheme } from 'cozy-ui/transpiled/react/CozyTheme'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import { makeStyles } from 'cozy-ui/transpiled/react/styles'
+
+const useStyles = makeStyles(theme => ({
+  cornerButton: {
+    color: theme.palette.text.secondary,
+    '&:hover': {
+      color: theme.palette.text.primary
+    }
+  },
+  cornerButtonInverted: {
+    color: theme.palette.text.primary
+  }
+}))
 
 const CornerButton = props => {
   const { isMobile } = useBreakpoints()
+  const classes = useStyles()
+  const theme = useCozyTheme()
   const { href } = props
   const ButtonComp = href ? ButtonLink : Button
 
@@ -11,7 +28,10 @@ const CornerButton = props => {
     <ButtonComp
       size={isMobile ? 'normal' : 'small'}
       theme="text"
-      className="corner-button"
+      className={cx('corner-button', {
+        [classes.cornerButton]: theme === 'normal',
+        [classes.cornerButtonInverted]: theme === 'inverted'
+      })}
       iconOnly={isMobile}
       extension={isMobile ? 'narrow' : null}
       {...props}

--- a/src/components/HeroHeader/index.jsx
+++ b/src/components/HeroHeader/index.jsx
@@ -1,11 +1,20 @@
 import React from 'react'
 import { useClient } from 'cozy-client'
 import { useInstanceSettings } from 'hooks/useInstanceSettings'
+import cx from 'classnames'
 
+import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+
+const useStyles = makeStyles(theme => ({
+  shadow: {
+    boxShadow: theme.shadows[2]
+  }
+}))
 
 export const HeroHeader = () => {
   const client = useClient()
+  const classes = useStyles()
   const rootURL = client.getStackClient().uri
   const { host } = new URL(rootURL)
 
@@ -16,7 +25,7 @@ export const HeroHeader = () => {
     <header className="hero-header u-pos-relative u-flex u-flex-column u-flex-justify-center u-flex-items-center u-flex-shrink-0 u-bxz">
       <div>
         <img
-          className="hero-avatar u-mb-1 u-mb-half-s"
+          className={cx('hero-avatar u-mb-1 u-mb-half-s', classes.shadow)}
           aria-hidden="true"
           src={`${rootURL}/public/avatar`}
         />

--- a/src/components/HeroHeader/index.jsx
+++ b/src/components/HeroHeader/index.jsx
@@ -3,18 +3,26 @@ import { useClient } from 'cozy-client'
 import { useInstanceSettings } from 'hooks/useInstanceSettings'
 import cx from 'classnames'
 
+import { useCozyTheme } from 'cozy-ui/transpiled/react/CozyTheme'
 import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
 const useStyles = makeStyles(theme => ({
   shadow: {
     boxShadow: theme.shadows[2]
+  },
+  nameInverted: {
+    textShadow: theme.textShadows[1]
+  },
+  hostInverted: {
+    textShadow: theme.textShadows[1]
   }
 }))
 
 export const HeroHeader = () => {
   const client = useClient()
   const classes = useStyles()
+  const theme = useCozyTheme()
   const rootURL = client.getStackClient().uri
   const { host } = new URL(rootURL)
 
@@ -32,11 +40,19 @@ export const HeroHeader = () => {
       </div>
       <Typography
         variant="h1"
-        className="hero-title u-ta-center u-mv-0 u-mh-1 u-primaryContrastTextColor"
+        className={cx(
+          'hero-title u-ta-center u-mv-0 u-mh-1 u-primaryTextColor',
+          { [classes.nameInverted]: theme === 'inverted' }
+        )}
       >
         {publicName}
       </Typography>
-      <Typography className="hero-subtitle u-ta-center u-mv-0 u-mh-1 u-primaryContrastTextColor">
+      <Typography
+        className={cx(
+          'hero-subtitle u-ta-center u-mv-0 u-mh-1 u-primaryTextColor',
+          { [classes.hostInverted]: theme === 'inverted' }
+        )}
+      >
         {host}
       </Typography>
     </header>

--- a/src/components/Konnector.jsx
+++ b/src/components/Konnector.jsx
@@ -9,6 +9,7 @@ import { Routes as HarvestRoutes } from 'cozy-harvest-lib'
 import { closeApp, openApp } from 'hooks/useOpenApp'
 import { getKonnector } from 'ducks/konnectors'
 import { getTriggersByKonnector } from 'reducers'
+import CozyTheme from 'cozy-ui/transpiled/react/CozyTheme'
 
 export const StatelessKonnector = ({ konnector, triggers, slug }) => {
   const navigate = useNavigate()
@@ -37,13 +38,15 @@ export const StatelessKonnector = ({ konnector, triggers, slug }) => {
   }
 
   return (
-    <HarvestRoutes
-      datacardOptions={datacardOptions}
-      konnector={konnectorWithTriggers}
-      konnectorRoot={`/connected/${konnectorSlug}`}
-      konnectorSlug={konnectorSlug}
-      onDismiss={onDismiss}
-    />
+    <CozyTheme variant="normal">
+      <HarvestRoutes
+        datacardOptions={datacardOptions}
+        konnector={konnectorWithTriggers}
+        konnectorRoot={`/connected/${konnectorSlug}`}
+        konnectorSlug={konnectorSlug}
+        onDismiss={onDismiss}
+      />
+    </CozyTheme>
   )
 }
 

--- a/src/components/KonnectorErrors.jsx
+++ b/src/components/KonnectorErrors.jsx
@@ -14,7 +14,6 @@ import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
 import Infos from 'cozy-ui/transpiled/react/Infos'
 import InfosCarrousel from 'cozy-ui/transpiled/react/InfosCarrousel'
-import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { Media, Bd } from 'cozy-ui/transpiled/react/Media'
@@ -189,9 +188,7 @@ export const KonnectorErrors = ({
       </InfosCarrousel>
     </div>
   ) : (
-    <MuiCozyTheme variant="inverted">
-      <Divider className="u-mv-0" />
-    </MuiCozyTheme>
+    <Divider className="u-mv-0" />
   )
 }
 

--- a/src/components/Shortcuts/ShortcutsView.jsx
+++ b/src/components/Shortcuts/ShortcutsView.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
-import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 
 import { ShortcutLink } from 'components/ShortcutLink'
 
@@ -13,9 +12,7 @@ export const ShortcutsView = ({ shortcutsDirectories }) => {
           key={directory.name}
           className="shortcuts-list-wrapper u-m-auto u-w-100"
         >
-          <MuiCozyTheme variant="inverted">
-            <Divider className="u-mv-0">{directory.name}</Divider>
-          </MuiCozyTheme>
+          <Divider className="u-mv-0">{directory.name}</Divider>
           <div className="shortcuts-list u-w-100 u-mv-3 u-mv-2-t u-mh-auto u-flex-justify-center">
             {directory.shortcuts.map(shortcut => (
               <ShortcutLink key={shortcut.name} file={shortcut} />

--- a/src/components/Shortcuts/__snapshots__/ShortcutsView.spec.jsx.snap
+++ b/src/components/Shortcuts/__snapshots__/ShortcutsView.spec.jsx.snap
@@ -9,7 +9,7 @@ Object {
         class="shortcuts-list-wrapper u-m-auto u-w-100"
       >
         <p
-          class="MuiTypography-root-1 styles__divider___-oC9I u-mv-0 MuiTypography-body2-2 MuiTypography-colorTextPrimary-26"
+          class="MuiTypography-root styles__divider___-oC9I u-mv-0 MuiTypography-body2 MuiTypography-colorTextPrimary"
         >
           List title
         </p>
@@ -23,43 +23,47 @@ Object {
             target="_blank"
           >
             <div
-              class="makeStyles-tileWrapper-35"
+              class="makeStyles-tileWrapper-7"
               data-testid="square-app-icon"
             >
-              <span
-                class="MuiBadge-root"
+              <div
+                class="palette__CozyTheme--normal___3UmMb"
               >
                 <span
-                  class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-33"
-                  style="background-color: rgb(53, 206, 104);"
+                  class="MuiBadge-root-9"
                 >
-                  <h2
-                    class="MuiTypography-root makeStyles-letter-32 MuiTypography-h2 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
-                  >
-                    L
-                  </h2>
                   <span
-                    class="MuiBadge-badge badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular"
-                  />
-                </span>
-                <span
-                  class="MuiBadge-badge Component-qualifier-36 MuiBadge-anchorOriginBottomRightRectangular"
-                >
-                  <svg
-                    class="styles__icon___23x3R"
-                    height="10"
-                    viewBox="0 0 16 16"
-                    width="10"
+                    class="MuiBadge-root-9 styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-5"
+                    style="background-color: rgb(53, 206, 104);"
                   >
-                    <path
-                      d="M9 0v2h3.5L6 8.5 7.5 10 14 3.5V7h2V1.003A.996.996 0 0014.997 0H9zM7 2V0H1.003A1 1 0 000 1v14c0 .552.445 1 1 1h14c.552 0 1-.438 1-1.003V9h-2v5H2V2h5z"
-                      fill-rule="evenodd"
+                    <h2
+                      class="MuiTypography-root-32 makeStyles-letter-4 MuiTypography-h2-38 MuiTypography-colorTextPrimary-57 MuiTypography-alignCenter-48"
+                    >
+                      L
+                    </h2>
+                    <span
+                      class="MuiBadge-badge-10 badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular-16"
                     />
-                  </svg>
+                  </span>
+                  <span
+                    class="MuiBadge-badge-10 Component-qualifier-8 MuiBadge-anchorOriginBottomRightRectangular-18"
+                  >
+                    <svg
+                      class="styles__icon___23x3R"
+                      height="10"
+                      viewBox="0 0 16 16"
+                      width="10"
+                    >
+                      <path
+                        d="M9 0v2h3.5L6 8.5 7.5 10 14 3.5V7h2V1.003A.996.996 0 0014.997 0H9zM7 2V0H1.003A1 1 0 000 1v14c0 .552.445 1 1 1h14c.552 0 1-.438 1-1.003V9h-2v5H2V2h5z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
                 </span>
-              </span>
+              </div>
               <h6
-                class="MuiTypography-root makeStyles-name-31 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
+                class="MuiTypography-root makeStyles-name-1 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
               >
                 List item
               </h6>
@@ -74,7 +78,7 @@ Object {
       class="shortcuts-list-wrapper u-m-auto u-w-100"
     >
       <p
-        class="MuiTypography-root-1 styles__divider___-oC9I u-mv-0 MuiTypography-body2-2 MuiTypography-colorTextPrimary-26"
+        class="MuiTypography-root styles__divider___-oC9I u-mv-0 MuiTypography-body2 MuiTypography-colorTextPrimary"
       >
         List title
       </p>
@@ -88,43 +92,47 @@ Object {
           target="_blank"
         >
           <div
-            class="makeStyles-tileWrapper-35"
+            class="makeStyles-tileWrapper-7"
             data-testid="square-app-icon"
           >
-            <span
-              class="MuiBadge-root"
+            <div
+              class="palette__CozyTheme--normal___3UmMb"
             >
               <span
-                class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-33"
-                style="background-color: rgb(53, 206, 104);"
+                class="MuiBadge-root-9"
               >
-                <h2
-                  class="MuiTypography-root makeStyles-letter-32 MuiTypography-h2 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
-                >
-                  L
-                </h2>
                 <span
-                  class="MuiBadge-badge badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular"
-                />
-              </span>
-              <span
-                class="MuiBadge-badge Component-qualifier-36 MuiBadge-anchorOriginBottomRightRectangular"
-              >
-                <svg
-                  class="styles__icon___23x3R"
-                  height="10"
-                  viewBox="0 0 16 16"
-                  width="10"
+                  class="MuiBadge-root-9 styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-5"
+                  style="background-color: rgb(53, 206, 104);"
                 >
-                  <path
-                    d="M9 0v2h3.5L6 8.5 7.5 10 14 3.5V7h2V1.003A.996.996 0 0014.997 0H9zM7 2V0H1.003A1 1 0 000 1v14c0 .552.445 1 1 1h14c.552 0 1-.438 1-1.003V9h-2v5H2V2h5z"
-                    fill-rule="evenodd"
+                  <h2
+                    class="MuiTypography-root-32 makeStyles-letter-4 MuiTypography-h2-38 MuiTypography-colorTextPrimary-57 MuiTypography-alignCenter-48"
+                  >
+                    L
+                  </h2>
+                  <span
+                    class="MuiBadge-badge-10 badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular-16"
                   />
-                </svg>
+                </span>
+                <span
+                  class="MuiBadge-badge-10 Component-qualifier-8 MuiBadge-anchorOriginBottomRightRectangular-18"
+                >
+                  <svg
+                    class="styles__icon___23x3R"
+                    height="10"
+                    viewBox="0 0 16 16"
+                    width="10"
+                  >
+                    <path
+                      d="M9 0v2h3.5L6 8.5 7.5 10 14 3.5V7h2V1.003A.996.996 0 0014.997 0H9zM7 2V0H1.003A1 1 0 000 1v14c0 .552.445 1 1 1h14c.552 0 1-.438 1-1.003V9h-2v5H2V2h5z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
               </span>
-            </span>
+            </div>
             <h6
-              class="MuiTypography-root makeStyles-name-31 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
+              class="MuiTypography-root makeStyles-name-1 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
             >
               List item
             </h6>
@@ -196,7 +204,7 @@ Object {
         class="shortcuts-list-wrapper u-m-auto u-w-100"
       >
         <p
-          class="MuiTypography-root-37 styles__divider___-oC9I u-mv-0 MuiTypography-body2-38 MuiTypography-colorTextPrimary-62"
+          class="MuiTypography-root styles__divider___-oC9I u-mv-0 MuiTypography-body2 MuiTypography-colorTextPrimary"
         >
           a
         </p>
@@ -210,43 +218,47 @@ Object {
             target="_blank"
           >
             <div
-              class="makeStyles-tileWrapper-71"
+              class="makeStyles-tileWrapper-68"
               data-testid="square-app-icon"
             >
-              <span
-                class="MuiBadge-root"
+              <div
+                class="palette__CozyTheme--normal___3UmMb"
               >
                 <span
-                  class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-69"
-                  style="background-color: rgb(252, 109, 0);"
+                  class="MuiBadge-root-70"
                 >
-                  <h2
-                    class="MuiTypography-root makeStyles-letter-68 MuiTypography-h2 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
-                  >
-                    B
-                  </h2>
                   <span
-                    class="MuiBadge-badge badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular"
-                  />
-                </span>
-                <span
-                  class="MuiBadge-badge Component-qualifier-72 MuiBadge-anchorOriginBottomRightRectangular"
-                >
-                  <svg
-                    class="styles__icon___23x3R"
-                    height="10"
-                    viewBox="0 0 16 16"
-                    width="10"
+                    class="MuiBadge-root-70 styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-66"
+                    style="background-color: rgb(252, 109, 0);"
                   >
-                    <path
-                      d="M9 0v2h3.5L6 8.5 7.5 10 14 3.5V7h2V1.003A.996.996 0 0014.997 0H9zM7 2V0H1.003A1 1 0 000 1v14c0 .552.445 1 1 1h14c.552 0 1-.438 1-1.003V9h-2v5H2V2h5z"
-                      fill-rule="evenodd"
+                    <h2
+                      class="MuiTypography-root-93 makeStyles-letter-65 MuiTypography-h2-99 MuiTypography-colorTextPrimary-118 MuiTypography-alignCenter-109"
+                    >
+                      B
+                    </h2>
+                    <span
+                      class="MuiBadge-badge-71 badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular-77"
                     />
-                  </svg>
+                  </span>
+                  <span
+                    class="MuiBadge-badge-71 Component-qualifier-69 MuiBadge-anchorOriginBottomRightRectangular-79"
+                  >
+                    <svg
+                      class="styles__icon___23x3R"
+                      height="10"
+                      viewBox="0 0 16 16"
+                      width="10"
+                    >
+                      <path
+                        d="M9 0v2h3.5L6 8.5 7.5 10 14 3.5V7h2V1.003A.996.996 0 0014.997 0H9zM7 2V0H1.003A1 1 0 000 1v14c0 .552.445 1 1 1h14c.552 0 1-.438 1-1.003V9h-2v5H2V2h5z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
                 </span>
-              </span>
+              </div>
               <h6
-                class="MuiTypography-root makeStyles-name-67 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
+                class="MuiTypography-root makeStyles-name-62 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
               >
                 b
               </h6>
@@ -258,7 +270,7 @@ Object {
         class="shortcuts-list-wrapper u-m-auto u-w-100"
       >
         <p
-          class="MuiTypography-root-73 styles__divider___-oC9I u-mv-0 MuiTypography-body2-74 MuiTypography-colorTextPrimary-98"
+          class="MuiTypography-root styles__divider___-oC9I u-mv-0 MuiTypography-body2 MuiTypography-colorTextPrimary"
         >
           c
         </p>
@@ -272,43 +284,47 @@ Object {
             target="_blank"
           >
             <div
-              class="makeStyles-tileWrapper-71"
+              class="makeStyles-tileWrapper-68"
               data-testid="square-app-icon"
             >
-              <span
-                class="MuiBadge-root"
+              <div
+                class="palette__CozyTheme--normal___3UmMb"
               >
                 <span
-                  class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-69"
-                  style="background-color: rgb(255, 150, 47);"
+                  class="MuiBadge-root-124"
                 >
-                  <h2
-                    class="MuiTypography-root makeStyles-letter-68 MuiTypography-h2 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
-                  >
-                    D
-                  </h2>
                   <span
-                    class="MuiBadge-badge badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular"
-                  />
-                </span>
-                <span
-                  class="MuiBadge-badge Component-qualifier-72 MuiBadge-anchorOriginBottomRightRectangular"
-                >
-                  <svg
-                    class="styles__icon___23x3R"
-                    height="10"
-                    viewBox="0 0 16 16"
-                    width="10"
+                    class="MuiBadge-root-124 styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-66"
+                    style="background-color: rgb(255, 150, 47);"
                   >
-                    <path
-                      d="M9 0v2h3.5L6 8.5 7.5 10 14 3.5V7h2V1.003A.996.996 0 0014.997 0H9zM7 2V0H1.003A1 1 0 000 1v14c0 .552.445 1 1 1h14c.552 0 1-.438 1-1.003V9h-2v5H2V2h5z"
-                      fill-rule="evenodd"
+                    <h2
+                      class="MuiTypography-root-147 makeStyles-letter-65 MuiTypography-h2-153 MuiTypography-colorTextPrimary-172 MuiTypography-alignCenter-163"
+                    >
+                      D
+                    </h2>
+                    <span
+                      class="MuiBadge-badge-125 badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular-131"
                     />
-                  </svg>
+                  </span>
+                  <span
+                    class="MuiBadge-badge-125 Component-qualifier-123 MuiBadge-anchorOriginBottomRightRectangular-133"
+                  >
+                    <svg
+                      class="styles__icon___23x3R"
+                      height="10"
+                      viewBox="0 0 16 16"
+                      width="10"
+                    >
+                      <path
+                        d="M9 0v2h3.5L6 8.5 7.5 10 14 3.5V7h2V1.003A.996.996 0 0014.997 0H9zM7 2V0H1.003A1 1 0 000 1v14c0 .552.445 1 1 1h14c.552 0 1-.438 1-1.003V9h-2v5H2V2h5z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
                 </span>
-              </span>
+              </div>
               <h6
-                class="MuiTypography-root makeStyles-name-67 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
+                class="MuiTypography-root makeStyles-name-62 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
               >
                 d
               </h6>
@@ -323,7 +339,7 @@ Object {
       class="shortcuts-list-wrapper u-m-auto u-w-100"
     >
       <p
-        class="MuiTypography-root-37 styles__divider___-oC9I u-mv-0 MuiTypography-body2-38 MuiTypography-colorTextPrimary-62"
+        class="MuiTypography-root styles__divider___-oC9I u-mv-0 MuiTypography-body2 MuiTypography-colorTextPrimary"
       >
         a
       </p>
@@ -337,43 +353,47 @@ Object {
           target="_blank"
         >
           <div
-            class="makeStyles-tileWrapper-71"
+            class="makeStyles-tileWrapper-68"
             data-testid="square-app-icon"
           >
-            <span
-              class="MuiBadge-root"
+            <div
+              class="palette__CozyTheme--normal___3UmMb"
             >
               <span
-                class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-69"
-                style="background-color: rgb(252, 109, 0);"
+                class="MuiBadge-root-70"
               >
-                <h2
-                  class="MuiTypography-root makeStyles-letter-68 MuiTypography-h2 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
-                >
-                  B
-                </h2>
                 <span
-                  class="MuiBadge-badge badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular"
-                />
-              </span>
-              <span
-                class="MuiBadge-badge Component-qualifier-72 MuiBadge-anchorOriginBottomRightRectangular"
-              >
-                <svg
-                  class="styles__icon___23x3R"
-                  height="10"
-                  viewBox="0 0 16 16"
-                  width="10"
+                  class="MuiBadge-root-70 styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-66"
+                  style="background-color: rgb(252, 109, 0);"
                 >
-                  <path
-                    d="M9 0v2h3.5L6 8.5 7.5 10 14 3.5V7h2V1.003A.996.996 0 0014.997 0H9zM7 2V0H1.003A1 1 0 000 1v14c0 .552.445 1 1 1h14c.552 0 1-.438 1-1.003V9h-2v5H2V2h5z"
-                    fill-rule="evenodd"
+                  <h2
+                    class="MuiTypography-root-93 makeStyles-letter-65 MuiTypography-h2-99 MuiTypography-colorTextPrimary-118 MuiTypography-alignCenter-109"
+                  >
+                    B
+                  </h2>
+                  <span
+                    class="MuiBadge-badge-71 badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular-77"
                   />
-                </svg>
+                </span>
+                <span
+                  class="MuiBadge-badge-71 Component-qualifier-69 MuiBadge-anchorOriginBottomRightRectangular-79"
+                >
+                  <svg
+                    class="styles__icon___23x3R"
+                    height="10"
+                    viewBox="0 0 16 16"
+                    width="10"
+                  >
+                    <path
+                      d="M9 0v2h3.5L6 8.5 7.5 10 14 3.5V7h2V1.003A.996.996 0 0014.997 0H9zM7 2V0H1.003A1 1 0 000 1v14c0 .552.445 1 1 1h14c.552 0 1-.438 1-1.003V9h-2v5H2V2h5z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
               </span>
-            </span>
+            </div>
             <h6
-              class="MuiTypography-root makeStyles-name-67 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
+              class="MuiTypography-root makeStyles-name-62 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
             >
               b
             </h6>
@@ -385,7 +405,7 @@ Object {
       class="shortcuts-list-wrapper u-m-auto u-w-100"
     >
       <p
-        class="MuiTypography-root-73 styles__divider___-oC9I u-mv-0 MuiTypography-body2-74 MuiTypography-colorTextPrimary-98"
+        class="MuiTypography-root styles__divider___-oC9I u-mv-0 MuiTypography-body2 MuiTypography-colorTextPrimary"
       >
         c
       </p>
@@ -399,43 +419,47 @@ Object {
           target="_blank"
         >
           <div
-            class="makeStyles-tileWrapper-71"
+            class="makeStyles-tileWrapper-68"
             data-testid="square-app-icon"
           >
-            <span
-              class="MuiBadge-root"
+            <div
+              class="palette__CozyTheme--normal___3UmMb"
             >
               <span
-                class="MuiBadge-root styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-69"
-                style="background-color: rgb(255, 150, 47);"
+                class="MuiBadge-root-124"
               >
-                <h2
-                  class="MuiTypography-root makeStyles-letter-68 MuiTypography-h2 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
-                >
-                  D
-                </h2>
                 <span
-                  class="MuiBadge-badge badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular"
-                />
-              </span>
-              <span
-                class="MuiBadge-badge Component-qualifier-72 MuiBadge-anchorOriginBottomRightRectangular"
-              >
-                <svg
-                  class="styles__icon___23x3R"
-                  height="10"
-                  viewBox="0 0 16 16"
-                  width="10"
+                  class="MuiBadge-root-124 styles__SquareAppIcon-wrapper___2SEuM makeStyles-shadow-66"
+                  style="background-color: rgb(255, 150, 47);"
                 >
-                  <path
-                    d="M9 0v2h3.5L6 8.5 7.5 10 14 3.5V7h2V1.003A.996.996 0 0014.997 0H9zM7 2V0H1.003A1 1 0 000 1v14c0 .552.445 1 1 1h14c.552 0 1-.438 1-1.003V9h-2v5H2V2h5z"
-                    fill-rule="evenodd"
+                  <h2
+                    class="MuiTypography-root-147 makeStyles-letter-65 MuiTypography-h2-153 MuiTypography-colorTextPrimary-172 MuiTypography-alignCenter-163"
+                  >
+                    D
+                  </h2>
+                  <span
+                    class="MuiBadge-badge-125 badgeSizeLarge MuiBadge-anchorOriginTopRightRectangular-131"
                   />
-                </svg>
+                </span>
+                <span
+                  class="MuiBadge-badge-125 Component-qualifier-123 MuiBadge-anchorOriginBottomRightRectangular-133"
+                >
+                  <svg
+                    class="styles__icon___23x3R"
+                    height="10"
+                    viewBox="0 0 16 16"
+                    width="10"
+                  >
+                    <path
+                      d="M9 0v2h3.5L6 8.5 7.5 10 14 3.5V7h2V1.003A.996.996 0 0014.997 0H9zM7 2V0H1.003A1 1 0 000 1v14c0 .552.445 1 1 1h14c.552 0 1-.438 1-1.003V9h-2v5H2V2h5z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
               </span>
-            </span>
+            </div>
             <h6
-              class="MuiTypography-root makeStyles-name-67 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
+              class="MuiTypography-root makeStyles-name-62 u-spacellipsis MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter"
             >
               d
             </h6>

--- a/src/hooks/usePreferedTheme.ts
+++ b/src/hooks/usePreferedTheme.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react'
+import useCustomWallpaper from 'hooks/useCustomWallpaper'
+import { useClient } from 'cozy-client'
+
+const getHomeThemeCssVariable = (): string => {
+  return getComputedStyle(
+    document.getElementsByTagName('body')[0]
+  ).getPropertyValue('--home-theme')
+}
+
+export const usePreferedTheme = (): string => {
+  const client = useClient()
+  const {
+    fetchStatus,
+    data: { wallpaperLink }
+  } = useCustomWallpaper()
+  const [preferedTheme, setPreferedTheme] = useState('inverted')
+
+  useEffect(() => {
+    const preferedTheme = getHomeThemeCssVariable()
+
+    if (wallpaperLink) {
+      setPreferedTheme('inverted')
+    } else {
+      setPreferedTheme(preferedTheme || 'inverted')
+    }
+  }, [wallpaperLink, fetchStatus, client])
+
+  return preferedTheme
+}

--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -36,7 +36,6 @@ body
         z-index var(--zIndex-nav)
         margin rem(12) 2rem rem(-44) 0
         .corner-button
-            color: var(--white)
             +small-screen()
                 height 3rem
                 width 3rem

--- a/src/styles/backgroundContainer.styl
+++ b/src/styles/backgroundContainer.styl
@@ -3,6 +3,12 @@
     background-repeat no-repeat
     background-size cover
     height 100vh
-    mix-blend-mode multiply
     position fixed
     width 100%
+
+.background-container-darken
+    mix-blend-mode multiply
+
+.home-default-partner-background
+    background-repeat repeat
+    background-size initial

--- a/src/styles/hero-header.styl
+++ b/src/styles/hero-header.styl
@@ -12,8 +12,8 @@ whiteOnWhiteShadow = drop-shadow(0 1px 1px rgba(50, 54, 63, .32)) drop-shadow(0 
         width 8rem
         height 8rem
         border-radius 50%
+        background white
         border 2px solid var(--white)
-        box-shadow 0 2px 16px 0 textShadowHeavy
 
         +small-screen()
             width 4.5rem

--- a/src/styles/hero-header.styl
+++ b/src/styles/hero-header.styl
@@ -1,8 +1,6 @@
 @require 'settings/breakpoints.styl'
 @require 'settings/palette.styl'
 
-whiteOnWhiteShadow = drop-shadow(0 1px 1px rgba(50, 54, 63, .32)) drop-shadow(0 2px 8px rgba(50, 54, 63, .08)) drop-shadow(0 1px 4px rgba(50, 54, 63, .16))
-
 .hero-header
     padding 3rem 4rem
     +small-screen()
@@ -24,7 +22,6 @@ whiteOnWhiteShadow = drop-shadow(0 1px 1px rgba(50, 54, 63, .32)) drop-shadow(0 
         letter-spacing rem(-.8)
         line-height rem(52)
         max-width 50rem
-        filter whiteOnWhiteShadow
 
         +small-screen()
             font-size 2rem
@@ -33,7 +30,6 @@ whiteOnWhiteShadow = drop-shadow(0 1px 1px rgba(50, 54, 63, .32)) drop-shadow(0 
     .hero-subtitle
         line-height rem(21)
         max-width 50rem
-        filter whiteOnWhiteShadow
 
         +small-screen()
             font-size rem(12)

--- a/yarn.lock
+++ b/yarn.lock
@@ -6006,10 +6006,10 @@ cozy-tsconfig@1.2.0:
   resolved "https://registry.yarnpkg.com/cozy-tsconfig/-/cozy-tsconfig-1.2.0.tgz#17e61f960f139fae4d26cbac2254b9ab632b269e"
   integrity sha512-TRHnY9goF3FzVlUbP7BcHxuN2XAA4AmppT4fHHZmTKaSwYTByVR1Al+riFMDbce94kJZ1wzl9WNLWQuqzGZ6Cw==
 
-cozy-ui@^84.1.5:
-  version "84.1.5"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-84.1.5.tgz#87ddeb82fffb4c7046139c8d35989ee298b96624"
-  integrity sha512-4YRS4oKTKR23KZYz9U7fXnWvyNa/ao7W51En6zVqRMShkaKS9TZt7jpSxpOvSNro7rut/OnrcCjXj0rt0tpX3A==
+cozy-ui@^85.0.0:
+  version "85.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-85.0.0.tgz#235114641a82f23fe89f2d2aa0f2536e940d62be"
+  integrity sha512-b/b5Nt2fxwthsGmguSmrP/6/YSvYaDSQY97OTHY4sP+PnIq9WoBfU+6xvxYtjmjL4K5XWTiGVAZF9avQnkUixQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3400,6 +3400,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/classnames@2.2.6":
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.6.tgz#dbe8a666156d556ed018e15a4c65f08937c3f628"
+  integrity sha512-XHcYvVdbtAxVstjKxuULYqYaWIzHR15yr1pZj4fnGChuBVJlIAp9StJna0ZJNSgxPh4Nac2FL4JM3M11Tm6fqQ==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6006,10 +6006,10 @@ cozy-tsconfig@1.2.0:
   resolved "https://registry.yarnpkg.com/cozy-tsconfig/-/cozy-tsconfig-1.2.0.tgz#17e61f960f139fae4d26cbac2254b9ab632b269e"
   integrity sha512-TRHnY9goF3FzVlUbP7BcHxuN2XAA4AmppT4fHHZmTKaSwYTByVR1Al+riFMDbce94kJZ1wzl9WNLWQuqzGZ6Cw==
 
-cozy-ui@^85.0.0:
-  version "85.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-85.0.0.tgz#235114641a82f23fe89f2d2aa0f2536e940d62be"
-  integrity sha512-b/b5Nt2fxwthsGmguSmrP/6/YSvYaDSQY97OTHY4sP+PnIq9WoBfU+6xvxYtjmjL4K5XWTiGVAZF9avQnkUixQ==
+cozy-ui@^85.0.1:
+  version "85.0.1"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-85.0.1.tgz#cc7950a2e306b555c0bcf13339536750a3859124"
+  integrity sha512-0g4/brnlIeW/+3pSD5ceruNnUxsgq3sK6bF48Al2sI7WhOQGSG0840B9NxC0lOfQ2onWdcB+5cxuUuNNUTXuYg==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"


### PR DESCRIPTION
## CSS Theme choice

We want our partners to be able to chose there preferred theme (normal or inverted)

To allow this we add support to a `--home-theme` CSS variable that can be declared on the custom CSS from dynamic assets

When present, we apply this value into the application's wide theme

But there is an exception: if the user added a custom wallpaper to their cozy, then we enforce an inverted theme for better contrast

## Background customization support

We also want our partners to be able to have more control on the displayed background

In combination with the new `--home-theme` variable a partner can customize the Cozy's background by targeting
`home-default-partner-background` css class on the custom CSS from dynamic assets. However this can only be done when choosing the `normal` theme

To ease background customization, the background's blend mode is deactivated when `--home-theme` is set to `normal`. But the partner can add it back in the `home-default-partner-background` css class

Note that the `background` props should be forced using `!important` CSS flag or the Cozy's JPG background will be prioritized instead

Note that if the user sets their own custom background, then the `home-default-partner-background` css class will be ignored as for the `--home-theme` value. The background's blend mode will also be reapplied

## Make the app compatible with both normal and inverted themes

Most of those PR's commits are to make the home compatible with both normal and inverted theme so it adapts to the partner's customization choices

Default home theme is now inverted

___

### TODO

- [x] Upgrade cozy-ui when https://github.com/cozy/cozy-ui/pull/2430 is merged