### PR TITLE
fix: Make SettingsButton work again

### DIFF
--- a/src/components/HeroHeader/SettingsButton.jsx
+++ b/src/components/HeroHeader/SettingsButton.jsx
@@ -10,9 +10,8 @@ import CornerButton from './CornerButton'
 
 const { applications } = models
 
-const SettingsButton = ({ settingsAppQuery: { data } }) => {
+const SettingsButton = ({ settingsAppQuery: { data: app } }) => {
   const { lang } = useI18n()
-  const app = get(data, '[0]')
   const appHref = get(app, 'links.related')
   const slug = get(app, 'slug')
   const displayName = applications.getAppDisplayName(app, lang)


### PR DESCRIPTION
The SettingsButton was never displayed because the `settingsAppQuery` query would return the app object instead of an array

Related commit: 6e59f08f8dc55f6bedb888e22acde49ce275169a