### PR TITLE
fix: Use `trim()` on `usePreferedTheme`

### DIFF
--- a/src/hooks/usePreferedTheme.ts
+++ b/src/hooks/usePreferedTheme.ts
@@ -3,9 +3,9 @@ import useCustomWallpaper from 'hooks/useCustomWallpaper'
 import { useClient } from 'cozy-client'
 
 const getHomeThemeCssVariable = (): string => {
-  return getComputedStyle(
-    document.getElementsByTagName('body')[0]
-  ).getPropertyValue('--home-theme')
+  return getComputedStyle(document.getElementsByTagName('body')[0])
+    .getPropertyValue('--home-theme')
+    .trim()
 }
 
 export const usePreferedTheme = (): string => {


### PR DESCRIPTION
In some environments `getComputedStyle().getPropertyValue()` would return a result with a leading space

In this scenario we retrieve ` normal` instead of `normal`

So we want to `trim()` the result

Note that `getComputedStyle().getPropertyValue()` always return a string even if the property does not exist. In that cas the string is empty. So we don't need to check for nullity


> **Note**
> This commit is a cherry pick from a fix done in the release branch and is a fix for https://github.com/cozy/cozy-home/pull/1939 also included in the 1.52.0 release
> Therefore this PR has no release note
