### PR TITLE
feat: Add some empty div in BackgroundContainer to allow customizations

### DIFF
--- a/src/components/BackgroundContainer.tsx
+++ b/src/components/BackgroundContainer.tsx
@@ -38,5 +38,11 @@ export const BackgroundContainer = (): JSX.Element => {
     setBackgroundURL(wallpaperLink || cozyDefaultWallpaper)
   }, [wallpaperLink, fetchStatus, client])
 
-  return <div {...makeProps(backgroundURL, preferedTheme)} />
+  return (
+    <div {...makeProps(backgroundURL, preferedTheme)}>
+      <div></div>
+      <div></div>
+      <div></div>
+    </div>
+  )
 }


### PR DESCRIPTION
For one of our partners customizations we want an animated background

This background animation need some supplementary divs so we can do it in CSS

Those divs are empty and contains no classes so they won't impact generic Cozies

But we can easily target them in a custom Theme CSS stylesheet by targeting `.home-default-partner-background div:nth-child(n)`



```
### ✨ Features

* Improve UI customization capabilities for our partners

```
