### PR TITLE
fix: Normal theme for Logout Modal

### DIFF
--- a/src/components/HeroHeader/LogoutModal.tsx
+++ b/src/components/HeroHeader/LogoutModal.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { Button } from 'cozy-ui/transpiled/react/Button'
 import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import CozyTheme from 'cozy-ui/transpiled/react/CozyTheme'
 
 export const LogoutDialog = (props: {
   open: boolean
@@ -12,25 +13,27 @@ export const LogoutDialog = (props: {
   const { t } = useI18n()
 
   return (
-    <ConfirmDialog
-      actions={
-        <>
-          <Button
-            theme="secondary"
-            label={t('logout_dialog.cancel')}
-            onClick={props.onCancel}
-          />
-          <Button
-            theme="primary"
-            label={t('logout_dialog.confirm')}
-            onClick={props.onConfirm}
-          />
-        </>
-      }
-      content={t('logout_dialog.content')}
-      onClose={props.onCancel}
-      open={props.open}
-      title={t('logout_dialog.title')}
-    />
+    <CozyTheme variant="normal" className={'u-pos-absolute'}>
+      <ConfirmDialog
+        actions={
+          <>
+            <Button
+              theme="secondary"
+              label={t('logout_dialog.cancel')}
+              onClick={props.onCancel}
+            />
+            <Button
+              theme="primary"
+              label={t('logout_dialog.confirm')}
+              onClick={props.onConfirm}
+            />
+          </>
+        }
+        content={t('logout_dialog.content')}
+        onClose={props.onCancel}
+        open={props.open}
+        title={t('logout_dialog.title')}
+      />
+    </CozyTheme>
   )
 }

--- a/src/cozy-ui.d.ts
+++ b/src/cozy-ui.d.ts
@@ -17,6 +17,15 @@ declare module 'cozy-ui/transpiled/react/CozyDialogs' {
   export { ConfirmDialog, ConfirmDialogProps }
 }
 
+declare module 'cozy-ui/transpiled/react/CozyTheme' {
+  interface CozyThemeProps {
+    variant?: 'normal' | 'inverted'
+    children?: JSX.Element
+    className?: string
+  }
+  export default function CozyTheme(props: CozyThemeProps): JSX.Element
+}
+
 declare module 'cozy-ui/transpiled/react/I18n' {
   export const useI18n: () => { t: (key: string) => string }
 }


### PR DESCRIPTION
Cozy Home can have normal or inverted theme now,
so we need to specify the theme we want when we
open a modal.

In this case, let's force the Normal theme.



```

### 🐛 Bug Fixes

* Logout modal on flagship app now have the right color

```
