### PR TITLE
feat: Reload data on focus

### DIFF
--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -28,7 +28,7 @@ import { MainView } from 'components/MainView'
 import { toFlagNames } from './toFlagNames'
 import { Konnector } from 'components/Konnector'
 import DefaultRedirectionSnackbar from 'components/DefaultRedirectionSnackbar/DefaultRedirectionSnackbar'
-
+import ReloadFocus from './ReloadFocus'
 const IDLE = 'idle'
 const FETCHING_CONTEXT = 'FETCHING_CONTEXT'
 
@@ -102,7 +102,7 @@ const App = ({ accounts, konnectors, triggers }) => {
   return (
     <>
       <BackgroundContainer />
-
+      <ReloadFocus />
       <MainView>
         <Corner />
         <div

--- a/src/containers/ReloadFocus.jsx
+++ b/src/containers/ReloadFocus.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { fetchAccounts } from 'ducks/accounts'
+import { fetchKonnectors } from 'ducks/konnectors'
+import { fetchTriggers } from 'ducks/triggers'
+import { withClient, Q } from 'cozy-client'
+class RealoadFocus extends React.Component {
+  static contextTypes = {
+    store: PropTypes.object
+  }
+  componentDidMount() {
+    const dispatch = this.context.store.dispatch
+    const client = this.props.client
+    window.addEventListener('focus', () => {
+      dispatch(fetchAccounts())
+      dispatch(fetchKonnectors())
+      dispatch(fetchTriggers())
+      client.query(Q('io.cozy.jobs'))
+      client.query(Q('io.cozy.apps'))
+    })
+  }
+
+  render() {
+    return null
+  }
+}
+
+export default withClient(RealoadFocus)


### PR DESCRIPTION
Since we heavily rely on relatime to update the redux store, we can miss a message when the app is in background or else. It can result to open Harvest with outdated information and it will then display an error.

Here, we refresh triggers, accounts and konnectors when the focus is there.

This code will be removed once the migration to cozy-client is done.

