### PR TITLE
feat: Define the maximum number of accounts allowed to connect using konnectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cozy-device-helper": "2.7.0",
     "cozy-doctypes": "1.83.8",
     "cozy-flags": "3.0.1",
-    "cozy-harvest-lib": "^13.20.0",
+    "cozy-harvest-lib": "^14.0.0",
     "cozy-intent": "^2.3.0",
     "cozy-keys-lib": "^4.3.0",
     "cozy-logger": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "cozy-client": "^36.2.0",
     "cozy-device-helper": "2.7.0",
     "cozy-doctypes": "1.83.8",
-    "cozy-flags": "2.12.0",
+    "cozy-flags": "3.0.1",
     "cozy-harvest-lib": "^13.20.0",
     "cozy-intent": "^2.3.0",
     "cozy-keys-lib": "^4.3.0",

--- a/src/components/AppTile.jsx
+++ b/src/components/AppTile.jsx
@@ -12,11 +12,11 @@ const { applications } = models
 
 // AppTileWrapper is responsible for fetching the app's information
 // if the app state changes from 'installing' to 'ready'
-const AppTileWrapper = ({ app, lang }) => {
+const AppTileWrapper = ({ app }) => {
   const client = useClient()
   const [appInfo, setAppInfo] = useState(app.state === 'ready' ? app : null)
   const prevState = useRef(app.state)
-  const { t } = useI18n()
+  const { t, lang } = useI18n()
 
   // If app state changes from 'installing' to 'ready', fetch app info
   useEffect(() => {

--- a/src/components/AppWrapper.jsx
+++ b/src/components/AppWrapper.jsx
@@ -73,6 +73,7 @@ const Inner = ({ children, lang, context }) => (
     {children}
     <RealTimeQueries doctype="io.cozy.apps" />
     <RealTimeQueries doctype="io.cozy.jobs" />
+    <RealTimeQueries doctype="io.cozy.triggers" />
     {process.env.NODE_ENV !== 'production' ? <CozyDevtools /> : null}
   </I18n>
 )

--- a/src/components/KonnectorInstall.jsx
+++ b/src/components/KonnectorInstall.jsx
@@ -48,7 +48,8 @@ export class KonnectorInstall extends Component {
       successMessage,
       successMessages,
       successButtonLabel,
-      t
+      t,
+      onCancel
     } = this.props
 
     const { trigger, success } = this.state
@@ -81,6 +82,7 @@ export class KonnectorInstall extends Component {
             onLoginSuccess={this.handleLoginSuccess}
             onSuccess={this.handleSuccess}
             vaultClosable={false}
+            onClose={onCancel}
           />
         </div>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5809,10 +5809,10 @@ cozy-doctypes@^1.88.6:
     lodash "^4.17.19"
     prop-types "^15.7.2"
 
-cozy-flags@2.12.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.12.0.tgz#bc3d689db9c91389c28f053223142d4684573ef1"
-  integrity sha512-s0et8aWChaqY4rMKkNKDACflU2h5s6s9UVU1guU3Il9GqktSPrhvMo+ntHLnQb2l+yLL6xV1S6/rK0qniR1q0A==
+cozy-flags@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-3.0.1.tgz#ffb0f3e57f6e3d631f8fa420e866f0eacddd222a"
+  integrity sha512-+uvrrzchRxg2+M0a9uoCEJCLDLwe1DdmTgXlu56zFagqMQGCxgLSHLL7MrP/8cjt9LjgzVdqO4Mg+mDtAIqc/g==
   dependencies:
     microee "^0.0.6"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5816,10 +5816,10 @@ cozy-flags@3.0.1:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^13.20.0:
-  version "13.20.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-13.20.0.tgz#9b226aed7af78fda72f8c90081a1aba38c986f43"
-  integrity sha512-8pdD40GeKB5Tzy+Hxbf2pApgw7LJ0F8TBh3V5rnvPNOErcE0TdTt/ufAV3Lldrw//vDCskiqNeeB4VK3CJu0fg==
+cozy-harvest-lib@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-14.0.0.tgz#0ccfb586776caf43803c1b8e2a8a4ca2e43e138d"
+  integrity sha512-0gzG37Sx7VH1fMSIfGfIuMUixMda7fXY41TegyjnmpbRyj50pynjwSusE25RpreOfj5CAwd4nk8Hy+fGaJoWrw==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
```
### ✨ Features

* Define the maximum number of accounts allowed to connect using konnectors with the flag `harvest.accounts: {"max": 10, "maxByKonnector": {"default": 3}`

### 🔧 Tech

* Update cozy-flag from 2.12.0 to 3.0.1
* Update cozy-harvest from 13.20.0 to 14.0.0
```

**Related PRs:** 

* https://github.com/cozy/cozy-ui/pull/2452
* https://github.com/cozy/cozy-libs/pull/2190