### PR TITLE
feat: send home theme to webview when ready

### DIFF
--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -25,6 +25,7 @@ import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { BackgroundContainer } from 'components/BackgroundContainer'
 import { FLAG_FAB_BUTTON_ENABLED } from 'components/AddButton/helpers'
 import { MainView } from 'components/MainView'
+import { usePreferedTheme } from 'hooks/usePreferedTheme'
 import { toFlagNames } from './toFlagNames'
 import { Konnector } from 'components/Konnector'
 import DefaultRedirectionSnackbar from 'components/DefaultRedirectionSnackbar/DefaultRedirectionSnackbar'
@@ -49,6 +50,7 @@ const App = ({ accounts, konnectors, triggers }) => {
   const [isReady, setIsReady] = useState(false)
   const [appsReady, setAppsReady] = useState(false)
   const webviewIntent = useWebviewIntent()
+  const preferedTheme = usePreferedTheme()
 
   useEffect(() => {
     setIsFetching(
@@ -96,8 +98,11 @@ const App = ({ accounts, konnectors, triggers }) => {
   }, [appsReady, hasError, isFetching, status])
 
   useEffect(() => {
-    isReady && webviewIntent?.call('hideSplashScreen')
-  }, [isReady, webviewIntent])
+    if (isReady && webviewIntent) {
+      webviewIntent.call('setTheme', preferedTheme)
+      webviewIntent.call('hideSplashScreen')
+    }
+  }, [isReady, preferedTheme, webviewIntent])
 
   return (
     <>


### PR DESCRIPTION
When the Home is ready and asks for a hide splashscreen,
We will now also send the value of the preferred theme
to the native app,
so it can handle OS icon color in a better way.