### PR TITLE
fix: render null if konnector not in registry

### DIFF
--- a/src/components/FallbackCandidateServiceTile.jsx
+++ b/src/components/FallbackCandidateServiceTile.jsx
@@ -17,7 +17,14 @@ const FallbackCandidateServiceTile = ({ slug }) => {
     ? get(registryData, 'latest_version.manifest.name', slug)
     : ''
 
-  return (
+  /**
+   * If there is no registry data it is better to render nothing because we won't have any link to the Konnector, despite having its slug.
+   * This is because failing to get the data most likely means that the Service is not available on the current registry (404 Not Found).
+   *
+   * It is not a problem if the Service is not available on the registry, but it is a problem if we try to link to it.
+   * Here it would display an AppLinker with a grey cube, an unformatted slug as a name and no working link.
+   */
+  return registryData ? (
     <AppLinker
       app={{ slug: app }}
       nativePath={nativePath}
@@ -40,7 +47,7 @@ const FallbackCandidateServiceTile = ({ slug }) => {
         </a>
       )}
     </AppLinker>
-  )
+  ) : null
 }
 
 FallbackCandidateServiceTile.propTypes = {


### PR DESCRIPTION
If there is no registry data it is better to render nothing
because we won't have any link to the Konnector,
despite having its slug.
This is because failing to get the data most likely means
that the Service is not available
on the current registry (404 Not Found).
It is not a problem if the Service is not available on the registry,
but it is a problem if we try to link to it.
Here it would display an AppLinker with a grey cube,
an unformatted slug as a name and no working link.