### PR TITLE
fix: Optimization to display the Shortcut icon

### DIFF
--- a/src/components/ShortcutLink.jsx
+++ b/src/components/ShortcutLink.jsx
@@ -10,6 +10,11 @@ import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 export const ShortcutLink = ({ file, desktopSize = 44 }) => {
   const client = useClient()
+  // We only need this call to useFetchShortcut in order to
+  // get the URL of the shortcut. For the rest of the information
+  // like the icon or iconType, we already have the informations
+  // within the file. So let's use these informations instead of
+  // waiting an http request to resolve.
   const { shortcutInfos } = useFetchShortcut(client, file._id)
   const { isMobile } = useBreakpoints()
   const computedSize = isMobile ? 32 : desktopSize
@@ -21,11 +26,8 @@ export const ShortcutLink = ({ file, desktopSize = 44 }) => {
    * If we don't have iconMimeType, we consider that the icon is a binary svg.
    * Otherwise we consider that the icon comes from Iconizer api so it is in base64 directly.
    */
-  const icon = get(shortcutInfos, 'data.attributes.metadata.icon')
-  const iconMimeType = get(
-    shortcutInfos,
-    'data.attributes.metadata.iconMimeType'
-  )
+  const icon = get(file, 'attributes.metadata.icon')
+  const iconMimeType = get(file, 'attributes.metadata.iconMimeType')
 
   return (
     <Link


### PR DESCRIPTION
```
### ✨ Features

* We only need this call to useFetchShortcut in order to get the URL of the shortcut. For the rest of the information like the icon or iconType, we already have the informations within the file. So let's use these informations instead of waiting an http request to resolve.

```
