### PR TITLE
fix: Request the shortcutsDirectory at the top level

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Outlet } from 'react-router-dom'
 
 import { CozyConfirmDialogProvider } from 'cozy-harvest-lib'
@@ -9,24 +9,20 @@ import ScrollToTopOnMount from 'components/ScrollToTopOnMount'
 import Services from 'components/Services'
 import Shortcuts from 'components/Shortcuts'
 
-class Home extends Component {
-  render() {
-    const { setAppsReady, wrapper } = this.props
-
-    return (
-      <CozyConfirmDialogProvider>
-        <Main className="u-flex-grow-1">
-          <ScrollToTopOnMount target={wrapper} />
-          <Content className="u-flex u-flex-column u-ph-1">
-            <Applications onAppsFetched={setAppsReady} />
-            <Services />
-            <Shortcuts />
-          </Content>
-        </Main>
-        <Outlet />
-      </CozyConfirmDialogProvider>
-    )
-  }
+const Home = ({ setAppsReady, wrapper, shortcutsDirectories }) => {
+  return (
+    <CozyConfirmDialogProvider>
+      <Main className="u-flex-grow-1">
+        <ScrollToTopOnMount target={wrapper} />
+        <Content className="u-flex u-flex-column u-ph-1">
+          <Applications onAppsFetched={setAppsReady} />
+          <Services />
+          <Shortcuts shortcutsDirectories={shortcutsDirectories} />
+        </Content>
+      </Main>
+      <Outlet />
+    </CozyConfirmDialogProvider>
+  )
 }
 
 export default Home

--- a/src/components/Shortcuts/index.jsx
+++ b/src/components/Shortcuts/index.jsx
@@ -1,8 +1,9 @@
 import React from 'react'
 
-import useCustomShortcuts from './useCustomShortcuts'
 import { ShortcutsView } from './ShortcutsView'
 
-export const Shortcuts = () => <ShortcutsView {...useCustomShortcuts()} />
+export const Shortcuts = ({ shortcutsDirectories }) => (
+  <ShortcutsView shortcutsDirectories={shortcutsDirectories} />
+)
 
 export default Shortcuts

--- a/src/components/Shortcuts/useCustomShortcuts.js
+++ b/src/components/Shortcuts/useCustomShortcuts.js
@@ -14,7 +14,7 @@ import { formatShortcuts } from './utils'
 export const useCustomShortcuts = () => {
   const client = useClient()
   const { t } = useI18n()
-  const [shortcutsDirectories, setDirectories] = useState()
+  const [shortcutsDirectories, setDirectories] = useState(undefined)
   const abort = () => setDirectories(null)
 
   useEffect(() => {

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -32,6 +32,7 @@ import { Konnector } from 'components/Konnector'
 import DefaultRedirectionSnackbar from 'components/DefaultRedirectionSnackbar/DefaultRedirectionSnackbar'
 import ReloadFocus from './ReloadFocus'
 import FooterLogo from 'components/FooterLogo/FooterLogo'
+import useCustomShortcuts from 'components/Shortcuts/useCustomShortcuts'
 
 const IDLE = 'idle'
 const FETCHING_CONTEXT = 'FETCHING_CONTEXT'
@@ -55,6 +56,7 @@ const App = ({ accounts, konnectors, triggers }) => {
   const webviewIntent = useWebviewIntent()
   const preferedTheme = usePreferedTheme()
 
+  const { shortcutsDirectories } = useCustomShortcuts()
   useEffect(() => {
     setIsFetching(
       [accounts, konnectors, triggers].some(collection =>
@@ -96,9 +98,13 @@ const App = ({ accounts, konnectors, triggers }) => {
 
   useEffect(() => {
     setIsReady(
-      appsReady && !hasError && !isFetching && !(status === FETCHING_CONTEXT)
+      appsReady &&
+        !hasError &&
+        !isFetching &&
+        !(status === FETCHING_CONTEXT) &&
+        shortcutsDirectories !== undefined
     )
-  }, [appsReady, hasError, isFetching, status])
+  }, [appsReady, hasError, isFetching, status, shortcutsDirectories])
 
   useEffect(() => {
     if (isReady && webviewIntent) {
@@ -140,6 +146,7 @@ const App = ({ accounts, konnectors, triggers }) => {
                     <Home
                       wrapper={contentWrapper}
                       setAppsReady={() => setAppsReady(true)}
+                      shortcutsDirectories={shortcutsDirectories}
                     />
                   }
                 >


### PR DESCRIPTION
Like that, we can wait this request to be done in order to hide the splashscreen.

Before this fix, we were sending too soon the message, and on an application with a lot of shortcut, the result for the user was not good.

Here we wait for all the info to be fetched before setting the isReady



```

### 🐛 Bug Fixes

* Send the isReady event only after fetched jobs, accounts, apps, konnectors AND shortcuts
```
