### PR TITLE
fix: Don't call /download/Wallpaper 4 times

### DIFF
--- a/src/components/BackgroundContainer.tsx
+++ b/src/components/BackgroundContainer.tsx
@@ -2,8 +2,7 @@ import React, { useEffect, useState } from 'react'
 import useCustomWallpaper from 'hooks/useCustomWallpaper'
 import { useClient } from 'cozy-client'
 import cx from 'classnames'
-import { usePreferedTheme } from 'hooks/usePreferedTheme'
-
+import { useCozyTheme } from 'cozy-ui/transpiled/react/providers/CozyTheme'
 type BackgroundContainerComputedProps = {
   className: string
   style?: { backgroundImage: string }
@@ -28,7 +27,7 @@ export const BackgroundContainer = (): JSX.Element => {
     fetchStatus,
     data: { wallpaperLink }
   } = useCustomWallpaper()
-  const preferedTheme = usePreferedTheme()
+  const theme = useCozyTheme()
   const [backgroundURL, setBackgroundURL] = useState<string | null>(null)
 
   useEffect(() => {
@@ -39,7 +38,7 @@ export const BackgroundContainer = (): JSX.Element => {
   }, [wallpaperLink, fetchStatus, client])
 
   return (
-    <div {...makeProps(backgroundURL, preferedTheme)}>
+    <div {...makeProps(backgroundURL, theme)}>
       <div></div>
       <div></div>
       <div></div>

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -11,6 +11,7 @@ import Alerter from 'cozy-ui/transpiled/react/deprecated/Alerter'
 import IconSprite from 'cozy-ui/transpiled/react/Icon/Sprite'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { Main } from 'cozy-ui/transpiled/react/Layout'
+import { useCozyTheme } from 'cozy-ui/transpiled/react/providers/CozyTheme'
 
 import AddButton from 'components/AddButton/AddButton'
 import Corner from 'components/HeroHeader/Corner'
@@ -26,7 +27,6 @@ import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { BackgroundContainer } from 'components/BackgroundContainer'
 import { FLAG_FAB_BUTTON_ENABLED } from 'components/AddButton/helpers'
 import { MainView } from 'components/MainView'
-import { usePreferedTheme } from 'hooks/usePreferedTheme'
 import { toFlagNames } from './toFlagNames'
 import { Konnector } from 'components/Konnector'
 import DefaultRedirectionSnackbar from 'components/DefaultRedirectionSnackbar/DefaultRedirectionSnackbar'
@@ -54,7 +54,7 @@ const App = ({ accounts, konnectors, triggers }) => {
   const [isReady, setIsReady] = useState(false)
   const [appsReady, setAppsReady] = useState(false)
   const webviewIntent = useWebviewIntent()
-  const preferedTheme = usePreferedTheme()
+  const theme = useCozyTheme()
 
   const { shortcutsDirectories } = useCustomShortcuts()
   useEffect(() => {
@@ -108,10 +108,10 @@ const App = ({ accounts, konnectors, triggers }) => {
 
   useEffect(() => {
     if (isReady && webviewIntent) {
-      webviewIntent.call('setTheme', preferedTheme)
+      webviewIntent.call('setTheme', theme)
       webviewIntent.call('hideSplashScreen')
     }
-  }, [isReady, preferedTheme, webviewIntent])
+  }, [isReady, theme, webviewIntent])
 
   return (
     <>

--- a/src/cozy-ui.d.ts
+++ b/src/cozy-ui.d.ts
@@ -24,6 +24,7 @@ declare module 'cozy-ui/transpiled/react/providers/CozyTheme' {
     className?: string
   }
   export default function CozyTheme(props: CozyThemeProps): JSX.Element
+  export function useCozyTheme(): string
 }
 
 declare module 'cozy-ui/transpiled/react/providers/I18n' {


### PR DESCRIPTION
By reading the theme value, we call the API only twice. We can go further and only call once, maybe I'll do it later if I've enough time.

```
### 🐛 Bug Fixes

* Optim:  Don't call 4 times /download/Wallpaper. Call it only twice
```
