### PR TITLE
Update cozy-ui from 98.1.1 to 100.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/cozy/cozy-home#readme",
   "dependencies": {
     "@cozy/minilog": "1.0.0",
-    "cozy-client": "^45.0.1",
+    "cozy-client": "^45.1.0",
     "cozy-device-helper": "2.7.0",
     "cozy-doctypes": "1.83.8",
     "cozy-flags": "3.0.1",
@@ -45,7 +45,7 @@
     "cozy-logger": "1.10.0",
     "cozy-realtime": "4.2.9",
     "cozy-sharing": "10.0.0",
-    "cozy-stack-client": "^42.0.1",
+    "cozy-stack-client": "^45.0.1",
     "cozy-tsconfig": "1.2.0",
     "cozy-ui": "^100.0.0",
     "date-fns": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "cozy-sharing": "10.0.0",
     "cozy-stack-client": "^42.0.1",
     "cozy-tsconfig": "1.2.0",
-    "cozy-ui": "^98.1.1",
+    "cozy-ui": "^100.0.0",
     "date-fns": "2.28.0",
     "es-abstract": "1.20.2",
     "form-data": "2.5.1",

--- a/src/components/Shortcuts/__snapshots__/ShortcutsView.spec.jsx.snap
+++ b/src/components/Shortcuts/__snapshots__/ShortcutsView.spec.jsx.snap
@@ -27,7 +27,7 @@ Object {
               data-testid="square-app-icon"
             >
               <div
-                class="CozyTheme--normal"
+                class="CozyTheme--normal u-dc"
               >
                 <span
                   class="MuiBadge-root-9"
@@ -96,7 +96,7 @@ Object {
             data-testid="square-app-icon"
           >
             <div
-              class="CozyTheme--normal"
+              class="CozyTheme--normal u-dc"
             >
               <span
                 class="MuiBadge-root-9"
@@ -222,7 +222,7 @@ Object {
               data-testid="square-app-icon"
             >
               <div
-                class="CozyTheme--normal"
+                class="CozyTheme--normal u-dc"
               >
                 <span
                   class="MuiBadge-root-70"
@@ -288,7 +288,7 @@ Object {
               data-testid="square-app-icon"
             >
               <div
-                class="CozyTheme--normal"
+                class="CozyTheme--normal u-dc"
               >
                 <span
                   class="MuiBadge-root-124"
@@ -357,7 +357,7 @@ Object {
             data-testid="square-app-icon"
           >
             <div
-              class="CozyTheme--normal"
+              class="CozyTheme--normal u-dc"
             >
               <span
                 class="MuiBadge-root-70"
@@ -423,7 +423,7 @@ Object {
             data-testid="square-app-icon"
           >
             <div
-              class="CozyTheme--normal"
+              class="CozyTheme--normal u-dc"
             >
               <span
                 class="MuiBadge-root-124"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6203,10 +6203,10 @@ cozy-tsconfig@1.2.0:
   resolved "https://registry.yarnpkg.com/cozy-tsconfig/-/cozy-tsconfig-1.2.0.tgz#17e61f960f139fae4d26cbac2254b9ab632b269e"
   integrity sha512-TRHnY9goF3FzVlUbP7BcHxuN2XAA4AmppT4fHHZmTKaSwYTByVR1Al+riFMDbce94kJZ1wzl9WNLWQuqzGZ6Cw==
 
-cozy-ui@^98.1.1:
-  version "98.1.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-98.1.1.tgz#d069cb1de0a7912052d5bbbecfd3a2efe4f5fcce"
-  integrity sha512-Ne+KjAwMH96FEEymsXrJUjuRDYzm1BynCeG/iz9ht4qvy0XTKFi+m54wxL2g5yUljevgGScayWJhnc5sHWUNzw==
+cozy-ui@^100.0.0:
+  version "100.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-100.0.0.tgz#fc4b46556d96771e174f2393f6138f147ca1f7d3"
+  integrity sha512-k4QtKYRh4BiFERrTbvVFfoEHdJ60GS25BGgeSaxn3QiNCYcw8PTK8wu6mTXhJYQN94NwzNvTf+T6SZog+wzlVQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"
@@ -11978,9 +11978,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5917,10 +5917,10 @@ cozy-client-js@0.20.0:
     pouchdb-browser "7.0.0"
     pouchdb-find "7.0.0"
 
-cozy-client@^45.0.1:
-  version "45.0.1"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-45.0.1.tgz#5bf462dfddc2858f0968b9d5e69f170a61375318"
-  integrity sha512-S1rMjKlPkui5CBLWNRY2iNLGTpKVLmM4JodX36A1GTpA1PkDTsYr+HTfxBvVbNcedOW4/CyDel6Uo4MyuOJ1JQ==
+cozy-client@^45.1.0:
+  version "45.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-45.1.0.tgz#5755bc4d766c467da98a043a6e16657bfffb41b2"
+  integrity sha512-acQwXj6dNFT9rv06SfzHu3bYprjZzK0tkvRX14MpYRMRoIho5G4uLEB44BLEZ0+6i141e3LjMsfQj1BN3pMk5w==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
@@ -6179,15 +6179,6 @@ cozy-sharing@10.0.0:
     react-autosuggest "^10.1.0"
     react-tooltip "^3.11.1"
     snarkdown "^2.0.0"
-
-cozy-stack-client@^42.0.1:
-  version "42.0.1"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-42.0.1.tgz#db23bfada9201a6053bae1e8f956bae737bb4f9d"
-  integrity sha512-C1CNj2coI60z76RpufgSjocv/HltYBZwXux1f1mvGI76ZQr3S9xRyh5NXP2sAXtRApQT5jjPNVI1W1m5NvyGYA==
-  dependencies:
-    detect-node "^2.0.4"
-    mime "^2.4.0"
-    qs "^6.7.0"
 
 cozy-stack-client@^45.0.1:
   version "45.0.1"
@@ -11978,9 +11969,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
This update allows us to anticipate the arrival of IAP in the paywall.

```
### 🔧 Tech

* Update cozy-ui from 98.1.1 to 100.0.0
* Update cozy-client from 45.0.1 to 45.1.0
```