### PR TITLE
chore: Don't run CI for branches if not master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: node_js
 node_js:
   - 16
   - 20
+branches:
+  only:
+    - master
+     # detect also tag like x.y.z or x.y.z-beta.n as travis consider them to be branches
+    - /^\d+\.\d+\.\d+(\-beta.\d+)?$/
 env:
   global:
     - MATTERMOST_CHANNEL='{"dev":"app---home","beta":"app---home,publication","stable":"app---home,publication"}'


### PR DESCRIPTION
Travis is configured to run on branches and PRs. The problem is that the CI is triggered at force push for all branches even if there is no associated PR, and for those with PRs the CI is therefore triggered twice.