### PR TITLE
fix: Upgrade harvest to get IntentProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cozy-device-helper": "2.7.0",
     "cozy-doctypes": "1.83.8",
     "cozy-flags": "3.0.1",
-    "cozy-harvest-lib": "^21.0.4",
+    "cozy-harvest-lib": "^22.0.0",
     "cozy-intent": "^2.3.0",
     "cozy-interapp": "^0.9.0",
     "cozy-keys-lib": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5978,10 +5978,10 @@ cozy-flags@3.0.1:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^21.0.4:
-  version "21.0.4"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-21.0.4.tgz#3ac5f788831adb1057b36e84ce5e927f7189f2a6"
-  integrity sha512-kuXjzSBtkyj8t+MfqluY7gDaIcXjYa4qlmCiq61tfJp84C26oYqQmcADMbBYGtbeRtghKLj7NfugrGdq84D6kg==
+cozy-harvest-lib@^22.0.0:
+  version "22.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-22.0.0.tgz#4e35fa3431493365fdd420b6ae2462832bec8c59"
+  integrity sha512-lobbkweUORYM2HZtN9BjnGWQ/e91ukqOrVbUwDFHsXki9NuZ5zNv0oZOpeGXLPsVU2XylbojuqPOAWP3vjJD3g==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
In order to have fully functionnal flow for a konnector installation and configuration from the store.

