### PR TITLE
feat: Add a context to store the custom Wallpaper

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "es-abstract": "1.20.2",
     "form-data": "2.5.1",
     "leaflet": "1.7.1",
+    "localforage": "^1.10.0",
     "lodash": "4.17.21",
     "moment": "2.29.4",
     "papaparse": "5.3.1",

--- a/src/components/AppWrapper.jsx
+++ b/src/components/AppWrapper.jsx
@@ -18,6 +18,7 @@ import { usePreferedTheme } from 'hooks/usePreferedTheme'
 
 import schema from '../schema'
 import { ConditionalWrapper } from './ConditionalWrapper'
+import { CustomWallPaperProvider } from 'hooks/useCustomWallpaperContext'
 const dictRequire = lang => require(`locales/${lang}.json`)
 
 export const AppContext = createContext()
@@ -91,22 +92,24 @@ const AppWrapper = ({ children }) => {
     <AppContext.Provider value={appContext}>
       <BreakpointsProvider>
         <CozyProvider client={cozyClient}>
-          <ThemeProvider>
-            <ReduxProvider store={store}>
-              <ConditionalWrapper
-                condition={persistor}
-                wrapper={children => (
-                  <PersistGate loading={null} persistor={persistor}>
+          <CustomWallPaperProvider>
+            <ThemeProvider>
+              <ReduxProvider store={store}>
+                <ConditionalWrapper
+                  condition={persistor}
+                  wrapper={children => (
+                    <PersistGate loading={null} persistor={persistor}>
+                      {children}
+                    </PersistGate>
+                  )}
+                >
+                  <Inner lang={lang} context={context}>
                     {children}
-                  </PersistGate>
-                )}
-              >
-                <Inner lang={lang} context={context}>
-                  {children}
-                </Inner>
-              </ConditionalWrapper>
-            </ReduxProvider>
-          </ThemeProvider>
+                  </Inner>
+                </ConditionalWrapper>
+              </ReduxProvider>
+            </ThemeProvider>
+          </CustomWallPaperProvider>
         </CozyProvider>
       </BreakpointsProvider>
     </AppContext.Provider>

--- a/src/components/AppWrapper.spec.jsx
+++ b/src/components/AppWrapper.spec.jsx
@@ -4,8 +4,17 @@
 import AppWrapper, { setupAppContext } from './AppWrapper'
 import { render } from '@testing-library/react'
 import React from 'react'
+import AppLike from 'test/AppLike'
+import { CustomWallPaperProvider } from 'hooks/useCustomWallpaperContext'
+import { act } from 'react-dom/test-utils'
 
-const mockClient = { registerPlugin: jest.fn(), setStore: jest.fn() }
+const mockClient = {
+  registerPlugin: jest.fn(),
+  setStore: jest.fn(),
+  getInstanceOptions: () => ({
+    cozyDefaultWallpaper: 'defaultWallpaper'
+  })
+}
 
 jest.mock('cozy-client', () => ({
   __esModule: true,
@@ -13,7 +22,8 @@ jest.mock('cozy-client', () => ({
   RealTimeQueries: ({ doctype }) => (
     <div data-testid="RealTimeQueries">{doctype}</div>
   ),
-  default: () => mockClient
+  default: () => mockClient,
+  useClient: () => mockClient
 }))
 
 jest.mock('store/configureStore', () => () => ({
@@ -58,24 +68,36 @@ describe('AppWrapper.jsx', () => {
   })
 
   describe('AppWrapper', () => {
-    it('should render children', () => {
+    it('should render children', async () => {
       // Given
       window.__DEVELOPMENT__ = 'defined'
-
+      // act(() => {
       // When
-      const { getByText } = render(<AppWrapper>children</AppWrapper>)
+      const { getByText } = render(
+        <AppLike>
+          <CustomWallPaperProvider>
+            <AppWrapper>children</AppWrapper>
+          </CustomWallPaperProvider>
+        </AppLike>
+      )
+      await act(async () => {})
 
       // Then
       expect(getByText('children')).toBeTruthy()
+      // })
     })
 
-    it('should contain RealTimeQueries', () => {
+    it('should contain RealTimeQueries', async () => {
       // Given
       window.__DEVELOPMENT__ = 'defined'
 
       // When
-      const { getAllByTestId } = render(<AppWrapper>children</AppWrapper>)
-
+      const { getAllByTestId } = render(
+        <AppWrapper>
+          <CustomWallPaperProvider>children </CustomWallPaperProvider>
+        </AppWrapper>
+      )
+      await act(async () => {})
       // Then
       expect(getAllByTestId('RealTimeQueries')).toBeTruthy()
     })

--- a/src/components/BackgroundContainer.tsx
+++ b/src/components/BackgroundContainer.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react'
-import useCustomWallpaper from 'hooks/useCustomWallpaper'
 import { useClient } from 'cozy-client'
 import cx from 'classnames'
 import { useCozyTheme } from 'cozy-ui/transpiled/react/providers/CozyTheme'
+import { useCustomWallpaperContext } from 'hooks/useCustomWallpaperContext'
 type BackgroundContainerComputedProps = {
   className: string
   style?: { backgroundImage: string }
@@ -10,35 +10,30 @@ type BackgroundContainerComputedProps = {
 
 const makeProps = (
   backgroundURL: string | null,
-  preferedTheme: string
+  preferedTheme: string,
+  binaryCustomWallpaper: string | null
 ): BackgroundContainerComputedProps => ({
   className: cx('background-container', {
     'background-container-darken': preferedTheme === 'inverted',
     'home-default-partner-background': preferedTheme === 'normal'
   }),
-  ...(backgroundURL && {
-    style: { backgroundImage: `url(${backgroundURL})` }
-  })
+  ...(binaryCustomWallpaper && {
+    style: { backgroundImage: `url(${binaryCustomWallpaper})` }
+  }),
+  ...(!binaryCustomWallpaper &&
+    backgroundURL && {
+      style: { backgroundImage: `url(${backgroundURL})` }
+    })
 })
 
 export const BackgroundContainer = (): JSX.Element => {
-  const client = useClient()
   const {
-    fetchStatus,
-    data: { wallpaperLink }
-  } = useCustomWallpaper()
+    data: { wallpaperLink, binaryCustomWallpaper }
+  } = useCustomWallpaperContext()
   const theme = useCozyTheme()
-  const [backgroundURL, setBackgroundURL] = useState<string | null>(null)
-
-  useEffect(() => {
-    const { cozyDefaultWallpaper } = client?.getInstanceOptions() as {
-      cozyDefaultWallpaper: string
-    }
-    setBackgroundURL(wallpaperLink || cozyDefaultWallpaper)
-  }, [wallpaperLink, fetchStatus, client])
 
   return (
-    <div {...makeProps(backgroundURL, theme)}>
+    <div {...makeProps(wallpaperLink, theme, binaryCustomWallpaper)}>
       <div></div>
       <div></div>
       <div></div>

--- a/src/containers/App.spec.jsx
+++ b/src/containers/App.spec.jsx
@@ -3,6 +3,9 @@ import { isFlagshipApp } from 'cozy-device-helper'
 import { render } from '@testing-library/react'
 import App from '../components/AnimatedWrapper'
 import AppLike from 'test/AppLike'
+import { CustomWallPaperProvider } from 'hooks/useCustomWallpaperContext'
+import { act } from 'react-dom/test-utils'
+import CozyTheme from 'cozy-ui/transpiled/react/providers/CozyTheme'
 
 // eslint-disable-next-line react/display-name
 jest.mock('components/HeroHeader', () => () => <div data-testid="HeroHeader" />)
@@ -39,17 +42,21 @@ jest.mock('react-router', () => ({
 }))
 
 describe('App', () => {
-  it('should keep backgroundImage fixed on Flagship app scroll', () => {
+  it('should keep backgroundImage fixed on Flagship app scroll', async () => {
     // Given
     isFlagshipApp.mockReturnValue(true)
 
     // When
     const { container } = render(
       <AppLike>
-        <App />
+        <CozyTheme>
+          <CustomWallPaperProvider>
+            <App />
+          </CustomWallPaperProvider>
+        </CozyTheme>
       </AppLike>
     )
-
+    await act(async () => {})
     // Then
     expect(
       container
@@ -60,17 +67,21 @@ describe('App', () => {
     ).toEqual('position: fixed; height: 100%;')
   })
 
-  it(`should not keep backgroundImage fixed on mobile's browser scroll`, () => {
+  it(`should not keep backgroundImage fixed on mobile's browser scroll`, async () => {
     // Given
     isFlagshipApp.mockReturnValue(false)
 
     // When
     const { container } = render(
       <AppLike>
-        <App />
+        <CozyTheme>
+          <CustomWallPaperProvider>
+            <App />
+          </CustomWallPaperProvider>
+        </CozyTheme>
       </AppLike>
     )
-
+    await act(async () => {})
     // Then
     expect(
       container

--- a/src/hooks/useCustomWallpaper.jsx
+++ b/src/hooks/useCustomWallpaper.jsx
@@ -1,22 +1,47 @@
 import { useState, useEffect } from 'react'
 import homeConfig from 'config/home.json'
 import { useClient } from 'cozy-client'
+import localForage from 'localforage'
 
 const useCustomWallpaper = () => {
   const client = useClient()
   const [wallpaperLink, setWallpaperLink] = useState(null)
   const [fetchStatus, setFetchStatus] = useState('idle')
-
+  const [binaryCustomWallpaper, setBinaryCustomWallpaper] = useState(null)
   useEffect(() => {
     const fetchData = async () => {
+      // happy path, in order to avoid a flash of the default wallpaper
+      if (localStorage.getItem('hasCustomWallpaper') !== 'true') {
+        const { cozyDefaultWallpaper } = client.getInstanceOptions()
+        setWallpaperLink(cozyDefaultWallpaper)
+      }
       try {
         setFetchStatus('loading')
+        const binary = await localForage.getItem('customWallpaper')
+        if (binary) {
+          setBinaryCustomWallpaper(binary)
+        }
         const response = await client
           .collection('io.cozy.files')
           .getDownloadLinkByPath(homeConfig.customWallpaperPath)
         setWallpaperLink(response)
         setFetchStatus('loaded')
+        const fetchBinary = await fetch(response)
+        const blob = await fetchBinary.blob()
+        const reader = new FileReader()
+        reader.readAsDataURL(blob)
+        reader.onloadend = async () => {
+          const base64data = reader.result
+          setBinaryCustomWallpaper(base64data)
+          await localForage.setItem('customWallpaper', base64data)
+          localStorage.setItem('hasCustomWallpaper', true)
+        }
       } catch (error) {
+        await localForage.removeItem('customWallpaper')
+        localStorage.setItem('hasCustomWallpaper', false)
+        const { cozyDefaultWallpaper } = client.getInstanceOptions()
+        setWallpaperLink(cozyDefaultWallpaper)
+        setBinaryCustomWallpaper(null)
         setFetchStatus('failed')
       }
     }
@@ -24,7 +49,7 @@ const useCustomWallpaper = () => {
   }, [client])
 
   return {
-    data: { wallpaperLink },
+    data: { wallpaperLink, binaryCustomWallpaper },
     fetchStatus
   }
 }

--- a/src/hooks/useCustomWallpaperContext.tsx
+++ b/src/hooks/useCustomWallpaperContext.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import useCustomWallpaper from './useCustomWallpaper'
+
+const CustomWallPaperContext = React.createContext<
+  CustomWallPaperContextInterface | undefined
+>(undefined)
+
+interface CustomWallPaperContextInterfaceData {
+  wallpaperLink: string | null
+  binaryCustomWallpaper: string | null
+}
+interface CustomWallPaperContextInterface {
+  data: CustomWallPaperContextInterfaceData
+  fetchStatus: string
+}
+export const CustomWallPaperProvider = ({
+  children
+}: {
+  children: JSX.Element
+}): JSX.Element => {
+  const data = useCustomWallpaper() as CustomWallPaperContextInterface
+  return (
+    <CustomWallPaperContext.Provider value={data}>
+      {children}
+    </CustomWallPaperContext.Provider>
+  )
+}
+
+export const useCustomWallpaperContext =
+  (): CustomWallPaperContextInterface => {
+    const context = React.useContext(CustomWallPaperContext)
+    if (context === undefined) {
+      throw new Error(
+        'useCustomWallpaperContext must be used within a CustomWallpaperProvider'
+      )
+    }
+    return context
+  }

--- a/src/hooks/usePreferedTheme.ts
+++ b/src/hooks/usePreferedTheme.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import useCustomWallpaper from 'hooks/useCustomWallpaper'
+import { useCustomWallpaperContext } from './useCustomWallpaperContext'
 
 const getHomeThemeCssVariable = (): string => {
   return getComputedStyle(document.getElementsByTagName('body')[0])
@@ -9,19 +9,19 @@ const getHomeThemeCssVariable = (): string => {
 
 export const usePreferedTheme = (): string => {
   const {
-    data: { wallpaperLink }
-  } = useCustomWallpaper()
+    data: { wallpaperLink, binaryCustomWallpaper }
+  } = useCustomWallpaperContext()
   const [preferedTheme, setPreferedTheme] = useState('inverted')
 
   useEffect(() => {
     const preferedTheme = getHomeThemeCssVariable()
 
-    if (wallpaperLink) {
+    if (wallpaperLink || binaryCustomWallpaper) {
       setPreferedTheme('inverted')
     } else {
       setPreferedTheme(preferedTheme || 'inverted')
     }
-  }, [wallpaperLink])
+  }, [wallpaperLink, binaryCustomWallpaper])
 
   return preferedTheme
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9140,6 +9140,11 @@ image-size@^0.5.1:
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
   integrity sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
@@ -11154,6 +11159,13 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==
+  dependencies:
+    immediate "~3.0.5"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -11286,6 +11298,13 @@ loader-utils@^2.0.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^2.1.2"
+
+localforage@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
+  integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
We already reduce the number of request to wallpaper, but here we go further and make only one call (see https://github.com/cozy/cozy-home/pull/2020 for the first iteration).

Also, we store 2 things :
- within the localStorage : the fact that we have a custom wallpaper or not, in order to have a quick path to know what to do
- within the localforage, the binary of the wallpaper. I decided to store it within localforage, because localstorage has a limite to 5 or 10MB depending on the browser. And since a wallpaper can be huge... like that "no limit".

Maybe the next iteration will be to call "hidesplashscreen" only if the wallpaper is fully loaded.



```
### ✨ Features

* Store the binary of the customwallpaper in the localStorage

### 🐛 Bug Fixes

* Call only once the API to get the wallpaper (instead of 2 times) 
```
