### PR TITLE
fix: Home Style

### DIFF
--- a/src/hooks/usePreferedTheme.ts
+++ b/src/hooks/usePreferedTheme.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useCustomWallpaperContext } from './useCustomWallpaperContext'
+import { useClient } from 'cozy-client'
 
 const getHomeThemeCssVariable = (): string => {
   return getComputedStyle(document.getElementsByTagName('body')[0])
@@ -11,17 +12,21 @@ export const usePreferedTheme = (): string => {
   const {
     data: { wallpaperLink, binaryCustomWallpaper }
   } = useCustomWallpaperContext()
+  const client = useClient()
   const [preferedTheme, setPreferedTheme] = useState('inverted')
-
+  // @ts-expect-error client is not typed
+  const { cozyDefaultWallpaper } = client.getInstanceOptions()
   useEffect(() => {
     const preferedTheme = getHomeThemeCssVariable()
 
-    if (wallpaperLink || binaryCustomWallpaper) {
+    if (
+      (wallpaperLink && wallpaperLink !== cozyDefaultWallpaper) ||
+      binaryCustomWallpaper
+    ) {
       setPreferedTheme('inverted')
     } else {
       setPreferedTheme(preferedTheme || 'inverted')
     }
-  }, [wallpaperLink, binaryCustomWallpaper])
-
+  }, [wallpaperLink, binaryCustomWallpaper, cozyDefaultWallpaper])
   return preferedTheme
 }


### PR DESCRIPTION
Since 5c850137f7a26fa1b35576408cf93f5cfbc4f01e I store the default wallpaper into the wallpaperlink var of the hook.

But I didn't expect that an other hook was relying on this value to determine if it was an inverted theme or not.

So I fix the issue by checking if the current wallpaper is different of the default one.

