### PR TITLE
fix: Fix isready status

### DIFF
--- a/src/components/Shortcuts/utils.js
+++ b/src/components/Shortcuts/utils.js
@@ -1,5 +1,14 @@
 export const formatShortcuts = (folders, shortcuts) => {
-  if (!folders || !shortcuts) return undefined
+  // folder null is when the query is not done yet
+  if (folders === null) return undefined
+  // if folders is empty, we return an empty array because
+  // we can't have shortcuts without folders
+  if (folders.length === 0) return []
+
+  // shortcuts null is when the query for the shortcut is not done yet
+  // and since we already checked that folders is not null, we can return undefined
+  // because it means that the query for shortcuts is not done yet
+  if (shortcuts === null) return undefined
   return folders
     .map(folder => ({
       name: folder.attributes.name,

--- a/src/components/Shortcuts/utils.spec.js
+++ b/src/components/Shortcuts/utils.spec.js
@@ -21,6 +21,7 @@ describe('formatShortcuts', () => {
   })
   it('merges with null / empty array', () => {
     expect(formatShortcuts(null, [])).toBeUndefined()
-    expect(formatShortcuts([], null)).toBeUndefined()
+    expect(formatShortcuts([], null)).toEqual([])
+    expect(formatShortcuts(directories, null)).toBeUndefined()
   })
 })


### PR DESCRIPTION
We didn't call hidesplashscreen when a cozy didn't have shortcuts. This was because we didn't check correctly the fact that the data has been loaded or not.

Now we're less naive that the first implementation
