### PR TITLE
fix: Call isReady

### DIFF
--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -71,9 +71,10 @@ const App = ({ accounts, konnectors, triggers }) => {
   const homeShortcutsDirConn = mkHomeCustomShorcutsDirConn({
     currentFolderId: magicHomeFolderId
   })
+  const canHaveShortcuts = !!magicHomeFolderId
   const { data: folders } = useQuery(homeShortcutsDirConn.query, {
     ...homeShortcutsDirConn.options,
-    enabled: !!magicHomeFolderId
+    enabled: canHaveShortcuts
   })
   const customHomeShortcutsConn = mkHomeCustomShorcutsConn(
     folders && folders.map(folder => folder._id)
@@ -85,8 +86,9 @@ const App = ({ accounts, konnectors, triggers }) => {
       enabled: Boolean(folders && folders.length > 0)
     }
   )
-
-  const shortcutsDirectories = formatShortcuts(folders, customHomeShortcuts)
+  const shortcutsDirectories = canHaveShortcuts
+    ? formatShortcuts(folders, customHomeShortcuts)
+    : null
   const context = useQuery(contextQuery.definition, contextQuery.options)
 
   useEffect(() => {


### PR DESCRIPTION
In a previous attempt fda23d869ecd63ef6805ec171d911c78ee9d3928 I managed to try to fix the call to hideSplashScreen.

I fixed the call when the user had a magicFolder but without custom shortcuts. But missed the case where the user doesn't have a magic folder.

This is a TMP fix. I need to think about a better fix and mainly a way to add a few UT to that method.
