### PR TITLE
[VO-427] feat: Upgrade cozy-ui cozy-ui to 103.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cozy-sharing": "10.1.4",
     "cozy-stack-client": "^45.0.1",
     "cozy-tsconfig": "1.2.0",
-    "cozy-ui": "^100.0.0",
+    "cozy-ui": "^103.6.2",
     "date-fns": "2.28.0",
     "es-abstract": "1.20.2",
     "form-data": "2.5.1",

--- a/src/components/BackgroundContainer.tsx
+++ b/src/components/BackgroundContainer.tsx
@@ -33,7 +33,7 @@ export const BackgroundContainer = (): JSX.Element => {
   const theme = useCozyTheme()
 
   return (
-    <div {...makeProps(wallpaperLink, theme, binaryCustomWallpaper)}>
+    <div {...makeProps(wallpaperLink, theme.variant, binaryCustomWallpaper)}>
       <div></div>
       <div></div>
       <div></div>

--- a/src/components/HeroHeader/CornerButton.jsx
+++ b/src/components/HeroHeader/CornerButton.jsx
@@ -29,8 +29,8 @@ const CornerButton = props => {
       size={isMobile ? 'normal' : 'small'}
       theme="text"
       className={cx('corner-button', {
-        [classes.cornerButton]: theme === 'normal',
-        [classes.cornerButtonInverted]: theme === 'inverted'
+        [classes.cornerButton]: theme.variant === 'normal',
+        [classes.cornerButtonInverted]: theme.variant === 'inverted'
       })}
       iconOnly={isMobile}
       extension={isMobile ? 'narrow' : null}

--- a/src/components/HeroHeader/index.jsx
+++ b/src/components/HeroHeader/index.jsx
@@ -42,7 +42,7 @@ export const HeroHeader = () => {
         variant="h1"
         className={cx(
           'hero-title u-ta-center u-mv-0 u-mh-1 u-primaryTextColor',
-          { [classes.nameInverted]: theme === 'inverted' }
+          { [classes.nameInverted]: theme.variant === 'inverted' }
         )}
       >
         {publicName}
@@ -50,7 +50,7 @@ export const HeroHeader = () => {
       <Typography
         className={cx(
           'hero-subtitle u-ta-center u-mv-0 u-mh-1 u-primaryTextColor',
-          { [classes.hostInverted]: theme === 'inverted' }
+          { [classes.hostInverted]: theme.variant === 'inverted' }
         )}
       >
         {host}

--- a/src/components/Services.spec.jsx
+++ b/src/components/Services.spec.jsx
@@ -21,6 +21,7 @@ jest.mock('components/KonnectorTile', () => ({ konnector }) => (
 jest.mock('hooks/useRegistryInformation', () => (client, slug) => slug)
 
 jest.mock('cozy-ui/transpiled/react/utils/color', () => ({
+  createNodeWithThemeCssVars: () => null, // Fix error: "TypeError: (0 , _color.createNodeWithThemeCssVars) is not a function"
   getCssVariableValue: () => '#fff',
   getInvertedCssVariableValue: () => '#fff'
 }))

--- a/src/components/Shortcuts/__snapshots__/ShortcutsView.spec.jsx.snap
+++ b/src/components/Shortcuts/__snapshots__/ShortcutsView.spec.jsx.snap
@@ -6,7 +6,7 @@ Object {
   "baseElement": <body>
     <div>
       <div
-        class="CozyTheme--normal u-dc"
+        class="CozyTheme--light-normal u-dc"
       >
         <div
           class="shortcuts-list-wrapper u-m-auto u-w-100"
@@ -30,7 +30,7 @@ Object {
                 data-testid="square-app-icon"
               >
                 <div
-                  class="CozyTheme--normal u-dc"
+                  class="CozyTheme--light-normal u-dc"
                 >
                   <span
                     class="MuiBadge-root-9"
@@ -79,7 +79,7 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="CozyTheme--normal u-dc"
+      class="CozyTheme--light-normal u-dc"
     >
       <div
         class="shortcuts-list-wrapper u-m-auto u-w-100"
@@ -103,7 +103,7 @@ Object {
               data-testid="square-app-icon"
             >
               <div
-                class="CozyTheme--normal u-dc"
+                class="CozyTheme--light-normal u-dc"
               >
                 <span
                   class="MuiBadge-root-9"
@@ -209,7 +209,7 @@ Object {
   "baseElement": <body>
     <div>
       <div
-        class="CozyTheme--normal u-dc"
+        class="CozyTheme--light-normal u-dc"
       >
         <div
           class="shortcuts-list-wrapper u-m-auto u-w-100"
@@ -233,7 +233,7 @@ Object {
                 data-testid="square-app-icon"
               >
                 <div
-                  class="CozyTheme--normal u-dc"
+                  class="CozyTheme--light-normal u-dc"
                 >
                   <span
                     class="MuiBadge-root-70"
@@ -299,7 +299,7 @@ Object {
                 data-testid="square-app-icon"
               >
                 <div
-                  class="CozyTheme--normal u-dc"
+                  class="CozyTheme--light-normal u-dc"
                 >
                   <span
                     class="MuiBadge-root-124"
@@ -348,7 +348,7 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="CozyTheme--normal u-dc"
+      class="CozyTheme--light-normal u-dc"
     >
       <div
         class="shortcuts-list-wrapper u-m-auto u-w-100"
@@ -372,7 +372,7 @@ Object {
               data-testid="square-app-icon"
             >
               <div
-                class="CozyTheme--normal u-dc"
+                class="CozyTheme--light-normal u-dc"
               >
                 <span
                   class="MuiBadge-root-70"
@@ -438,7 +438,7 @@ Object {
               data-testid="square-app-icon"
             >
               <div
-                class="CozyTheme--normal u-dc"
+                class="CozyTheme--light-normal u-dc"
               >
                 <span
                   class="MuiBadge-root-124"
@@ -541,7 +541,7 @@ Object {
 exports[`Shortcuts Should display nothing if nothing was found 1`] = `
 <div>
   <div
-    class="CozyTheme--normal u-dc"
+    class="CozyTheme--light-normal u-dc"
   />
 </div>
 `;

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -119,7 +119,7 @@ const App = ({ accounts, konnectors, triggers }) => {
 
   useEffect(() => {
     if (isReady && webviewIntent) {
-      webviewIntent.call('setTheme', theme)
+      webviewIntent.call('setTheme', theme.variant)
       webviewIntent.call('hideSplashScreen')
     }
     if (isReady && !webviewIntent && __SIMULATE_FLAGSHIP__) {

--- a/src/cozy-ui.d.ts
+++ b/src/cozy-ui.d.ts
@@ -23,8 +23,12 @@ declare module 'cozy-ui/transpiled/react/providers/CozyTheme' {
     children?: JSX.Element
     className?: string
   }
+  interface CozyTheme {
+    type: string
+    variant: string
+  }
   export default function CozyTheme(props: CozyThemeProps): JSX.Element
-  export function useCozyTheme(): string
+  export function useCozyTheme(): CozyTheme
 }
 
 declare module 'cozy-ui/transpiled/react/providers/I18n' {

--- a/src/targets/browser/index.ejs
+++ b/src/targets/browser/index.ejs
@@ -10,6 +10,7 @@
   <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
   <meta name="msapplication-TileColor" content="#2b5797">
   <meta name="theme-color" content="#ffffff">
+  <meta name="color-scheme" content="only light" />
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, viewport-fit=cover">
   <link rel="preload" href="//{{.Domain}}/assets/fonts/Lato-Bold.immutable.woff2" as="font" type="font/woff2"
     crossorigin>

--- a/src/targets/intents/index.ejs
+++ b/src/targets/intents/index.ejs
@@ -6,6 +6,7 @@
 {{.Favicon}}
 <meta name="msapplication-TileColor" content="#2b5797">
 <meta name="theme-color" content="#ffffff">
+<meta name="color-scheme" content="only light" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="preload" href="//{{.Domain}}/assets/fonts/Lato-Bold.immutable.woff2" as="font" type="font/woff2"
     crossorigin>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3295,6 +3295,20 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@pdf-lib/standard-fonts@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz#8ba691c4421f71662ed07c9a0294b44528af2d7f"
+  integrity sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==
+  dependencies:
+    pako "^1.0.6"
+
+"@pdf-lib/upng@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@pdf-lib/upng/-/upng-1.0.1.tgz#7dc9c636271aca007a9df4deaf2dd7e7960280cb"
+  integrity sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==
+  dependencies:
+    pako "^1.0.10"
+
 "@popperjs/core@^2.4.4":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.4.tgz#11d5db19bd178936ec89cd84519c4de439574398"
@@ -5800,11 +5814,6 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-text-to-clipboard@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.0.tgz#0202b2d9bdae30a49a53f898626dcc3b49ad960b"
-  integrity sha512-RnJFp1XR/LOBDckxTib5Qjr/PMfkatD0MUCQgdpqS8MdKiNUzBjAQBEN6oUy+jW7LI93BBG3DtMB2KOOKpGs2Q==
-
 copy-text-to-clipboard@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-2.2.0.tgz#329dd6daf8c42034c763ace567418401764579ae"
@@ -6166,10 +6175,10 @@ cozy-tsconfig@1.2.0:
   resolved "https://registry.yarnpkg.com/cozy-tsconfig/-/cozy-tsconfig-1.2.0.tgz#17e61f960f139fae4d26cbac2254b9ab632b269e"
   integrity sha512-TRHnY9goF3FzVlUbP7BcHxuN2XAA4AmppT4fHHZmTKaSwYTByVR1Al+riFMDbce94kJZ1wzl9WNLWQuqzGZ6Cw==
 
-cozy-ui@^100.0.0:
-  version "100.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-100.0.0.tgz#fc4b46556d96771e174f2393f6138f147ca1f7d3"
-  integrity sha512-k4QtKYRh4BiFERrTbvVFfoEHdJ60GS25BGgeSaxn3QiNCYcw8PTK8wu6mTXhJYQN94NwzNvTf+T6SZog+wzlVQ==
+cozy-ui@^103.6.2:
+  version "103.6.2"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-103.6.2.tgz#6867e06082aec4c82b2ccd2a626540f22e774984"
+  integrity sha512-cSc6mQj3L81Opux3GpJwJ5mh+c6895vZywr8uFK/xY08yijIMHruivb/HFCAOM34ypQEEpIsmyxxbld+sUT8iQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"
@@ -6178,7 +6187,6 @@ cozy-ui@^100.0.0:
     bundlemon "^1.3.2"
     chart.js "3.7.1"
     classnames "^2.2.5"
-    copy-text-to-clipboard "3.2.0"
     cozy-interapp "^0.5.4"
     date-fns "^1.28.5"
     filesize "8.0.7"
@@ -6188,9 +6196,11 @@ cozy-ui@^100.0.0:
     mui-bottom-sheet "https://github.com/cozy/mui-bottom-sheet.git#v1.0.9"
     node-polyglot "^2.2.2"
     normalize.css "^8.0.0"
+    pdf-lib "1.17.1"
     piwik-react-router "0.12.1"
     react-chartjs-2 "4.1.0"
     react-markdown "^4.0.8"
+    react-middle-ellipsis "1.2.2"
     react-pdf "^5.7.2"
     react-popper "^2.2.3"
     react-remove-scroll "^2.4.0"
@@ -11942,9 +11952,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"
@@ -12643,6 +12653,11 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+pako@^1.0.10, pako@^1.0.11, pako@^1.0.6:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 pako@~1.0.5:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
@@ -12838,6 +12853,16 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+pdf-lib@1.17.1:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/pdf-lib/-/pdf-lib-1.17.1.tgz#9e7dd21261a0c1fb17992580885b39e7d08f451f"
+  integrity sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==
+  dependencies:
+    "@pdf-lib/standard-fonts" "^1.0.0"
+    "@pdf-lib/upng" "^1.0.1"
+    pako "^1.0.11"
+    tslib "^1.11.1"
 
 pdfjs-dist@2.12.313:
   version "2.12.313"
@@ -13612,6 +13637,11 @@ react-markdown@^4.0.8, react-markdown@^4.2.2:
     unified "^6.1.5"
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
+
+react-middle-ellipsis@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/react-middle-ellipsis/-/react-middle-ellipsis-1.2.2.tgz#e1676fe2fbc864ea7e2fc25bedc53db2635bb2a9"
+  integrity sha512-tTsyS/hOjT3C5WjpueAx1/WsYUVnNlUnDRCKSffGT1ns7b0NbSi6FGVVPDLTxn207B0sVjNTbMnk1HFGWd5hzA==
 
 react-pdf@^5.7.2:
   version "5.7.2"


### PR DESCRIPTION
`cozy-ui` has been upgraded to `103.6.2` to retrieve the new Theme variants support (light and dark)

The code changes are for handling the `cozy-ui 101.0.0` breaking changes

One of the changes consist to force the light theme as there are no specs yet for this theme support on cozy-home

Related PR: cozy/cozy-ui#2540



```
### ✨ Features

* 

### 🐛 Bug Fixes

*

### 🔧 Tech

* Upgrade cozy-ui to latest (103.6.2)
```
