### PR TITLE
[SCR-346] feat: Add sourceAccountNormalizer service

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -162,6 +162,11 @@
       "type": "node",
       "file": "services/cliskTimeout/home.js",
       "comment": "This service must be called programmatically from the flagship app. It stopps the given job with a context deadline exceeded error"
+    },
+    "sourceAccountIdentifierNormalizer": {
+      "type": "node",
+      "file": "services/sourceAccountIdentifierNormalizer/home.js",
+      "comment": "This service must be called manually"
     }
   }
 }

--- a/src/targets/services/sourceAccountIdentifierNormalizer.js
+++ b/src/targets/services/sourceAccountIdentifierNormalizer.js
@@ -1,0 +1,185 @@
+/*
+ * This service updates identity, bills and accounts with proper sourceAccountIdentifier in
+ * cozyMetadata.sourceAccountIdentifier when possible
+ *
+ */
+import CozyClient, { Q, models } from 'cozy-client'
+import logger from 'cozy-logger'
+import polyfillFetch from './polyfillFetch'
+
+const log = logger.namespace('sourceAccountIdentifierNormalizer')
+
+polyfillFetch()
+
+const main = async () => {
+  const client = CozyClient.fromEnv()
+
+  await Promise.all([
+    normalizeIdentities(client),
+    normalizeBills(client),
+    normalizeAccounts(client)
+  ])
+}
+;(async () => {
+  try {
+    await main()
+  } catch (error) {
+    log('critical', error.message)
+  }
+})()
+
+async function createBillsFilesMap({ client, bills }) {
+  const billsInvoicesIds = bills.map(bill => {
+    return bill.invoice?.split(':').pop()
+  })
+  const files = await client.queryAll(
+    Q('io.cozy.files').getByIds(billsInvoicesIds)
+  )
+  return files.reduce((map, file) => {
+    map.set(file._id, file)
+    return map
+  }, new Map())
+}
+
+async function createBillsAndFilesAccountsMap({
+  client,
+  bills,
+  billsFilesMap
+}) {
+  const billsAndFilesAccountIds = [
+    ...bills.map(bill => bill?.cozyMetadata?.sourceAccount).filter(Boolean),
+    ...Array.from(billsFilesMap.values())
+      .map(file => file?.cozyMetadata?.sourceAccount)
+      .filter(Boolean)
+  ]
+  const billsAndFilesAccounts = await client.queryAll(
+    Q('io.cozy.accounts').getByIds(billsAndFilesAccountIds)
+  )
+  return billsAndFilesAccounts.reduce((map, account) => {
+    map.set(account._id, account)
+    return map
+  }, new Map())
+}
+
+export async function normalizeIdentities(client) {
+  const identities = await client.queryAll(
+    Q('io.cozy.identities').partialIndex({
+      'cozyMetadata.sourceAccountIdentifier': { $exists: false },
+      identifier: { $exists: true }
+    })
+  )
+
+  const normalizedIdentities = identities
+    .map(identity => ({
+      ...identity,
+      cozyMetadata: {
+        ...identity.cozyMetadata,
+        sourceAccountIdentifier: identity.identifier
+      }
+    }))
+    .filter(Boolean)
+
+  if (normalizedIdentities.length > 0) {
+    await client.saveAll(normalizedIdentities)
+  }
+  log('info', `Normalized ${normalizedIdentities.length}/${identities.length}`)
+}
+
+export async function normalizeBills(client) {
+  const bills = await client.queryAll(
+    Q('io.cozy.bills').partialIndex({
+      'cozyMetadata.sourceAccountIdentifier': { $exists: false }
+    })
+  )
+
+  const billsFilesMap = await createBillsFilesMap({ client, bills })
+  const billsAndFilesAccountsMap = await createBillsAndFilesAccountsMap({
+    client,
+    bills,
+    billsFilesMap
+  })
+
+  const normalizedBills = bills
+    .map(bill => {
+      let sourceAccountIdentifier = null
+      if (bill.sourceAccountIdentifier) {
+        sourceAccountIdentifier = bill.sourceAccountIdentifier
+      } else if (bill.cozyMetadata?.sourceAccount) {
+        const account = billsAndFilesAccountsMap.get(
+          bill.cozyMetadata.sourceAccount
+        )
+        if (account) {
+          if (account.cozyMetadata?.sourceAccountIdentifier) {
+            sourceAccountIdentifier =
+              account.cozyMetadata.sourceAccountIdentifier
+          } else {
+            const accountName = models.account.getAccountName(account)
+            sourceAccountIdentifier =
+              accountName !== account._id ? accountName : null
+          }
+        }
+      } else if (!sourceAccountIdentifier && bill.invoice) {
+        const fileId = bill.invoice?.split(':').pop()
+        const file = billsFilesMap.get(fileId)
+        if (file?.cozyMetadata?.sourceAccountIdentifier) {
+          sourceAccountIdentifier = file.cozyMetadata.sourceAccountIdentifier
+        } else if (file.cozyMetadata?.sourceAccount) {
+          const account = billsAndFilesAccountsMap.get(
+            file.cozyMetadata.sourceAccount
+          )
+          if (account) {
+            if (account.cozyMetadata?.sourceAccountIdentifier) {
+              sourceAccountIdentifier =
+                account.cozyMetadata.sourceAccountIdentifier
+            } else {
+              const accountName = models.account.getAccountName(account)
+              sourceAccountIdentifier =
+                accountName !== account._id ? accountName : null
+            }
+          }
+        }
+      }
+      if (!sourceAccountIdentifier) {
+        return false
+      }
+      return {
+        ...bill,
+        cozyMetadata: { ...bill.cozyMetadata, sourceAccountIdentifier }
+      }
+    })
+    .filter(Boolean)
+
+  log('info', `Normalized ${normalizedBills.length}/${bills.length}`)
+  if (normalizedBills.length > 0) {
+    await client.saveAll(normalizedBills)
+  }
+}
+
+export async function normalizeAccounts(client) {
+  const accounts = await client.queryAll(
+    Q('io.cozy.accounts').partialIndex({
+      'cozyMetadata.sourceAccountIdentifier': { $exists: false }
+    })
+  )
+
+  const normalizedAccounts = accounts
+    .map(account => {
+      const accountName = models.account.getAccountName(account)
+      const sourceAccountIdentifier =
+        accountName !== account._id ? accountName : null
+      if (!sourceAccountIdentifier) {
+        return false
+      }
+
+      return {
+        ...account,
+        cozyMetadata: { ...account.cozyMetadata, sourceAccountIdentifier }
+      }
+    })
+    .filter(Boolean)
+
+  log('info', `Normalized ${normalizedAccounts.length}/${accounts.length}`)
+  if (normalizedAccounts.length > 0) {
+    await client.saveAll(normalizedAccounts)
+  }
+}

--- a/src/targets/services/sourceAccountIdentifierNormalizer.spec.js
+++ b/src/targets/services/sourceAccountIdentifierNormalizer.spec.js
@@ -1,0 +1,306 @@
+import {
+  normalizeIdentities,
+  normalizeBills
+} from './sourceAccountIdentifierNormalizer'
+
+describe('normalizeIdentities', () => {
+  it('should normalize identities with the identifier attribute', async () => {
+    const client = {
+      queryAll: jest.fn().mockImplementationOnce(() => [
+        {
+          _id: 'identityid',
+          _type: 'io.cozy.identities',
+          identifier: 'testidentifier',
+          cozyMetadata: {
+            createdByApp: 'testapp'
+          }
+        }
+      ]),
+      saveAll: jest.fn()
+    }
+    await normalizeIdentities(client)
+    expect(client.saveAll).toHaveBeenCalledWith([
+      {
+        _id: 'identityid',
+        _type: 'io.cozy.identities',
+        identifier: 'testidentifier',
+        cozyMetadata: {
+          createdByApp: 'testapp',
+          sourceAccountIdentifier: 'testidentifier'
+        }
+      }
+    ])
+  })
+})
+
+describe('normalizeBills', () => {
+  it('should normalize bills with sourceAccountIdentifier attribute', async () => {
+    const client = {
+      queryAll: jest.fn().mockImplementation(async query => {
+        if (query.doctype === 'io.cozy.bills') {
+          return [
+            {
+              _id: 'billid',
+              _type: 'io.cozy.bills',
+              sourceAccountIdentifier: 'testbillidentifier',
+              cozyMetadata: {
+                createdByApp: 'testapp'
+              }
+            }
+          ]
+        } else if (query.doctype === 'io.cozy.accounts') {
+          return []
+        } else if (query.doctype === 'io.cozy.files') {
+          return []
+        }
+      }),
+      saveAll: jest.fn()
+    }
+    await normalizeBills(client)
+    expect(client.saveAll).toHaveBeenCalledWith([
+      {
+        _id: 'billid',
+        _type: 'io.cozy.bills',
+        sourceAccountIdentifier: 'testbillidentifier',
+        cozyMetadata: {
+          createdByApp: 'testapp',
+          sourceAccountIdentifier: 'testbillidentifier'
+        }
+      }
+    ])
+  })
+  it('should normalize bills with sourceAccount refering to accounts with sourceAccountIdentifier', async () => {
+    const client = {
+      queryAll: jest.fn().mockImplementation(async query => {
+        if (query.doctype === 'io.cozy.bills') {
+          return [
+            {
+              _id: 'billid',
+              _type: 'io.cozy.bills',
+              cozyMetadata: {
+                createdByApp: 'testapp',
+                sourceAccount: 'testaccountid'
+              }
+            }
+          ]
+        } else if (query.doctype === 'io.cozy.accounts') {
+          return [
+            {
+              _id: 'testaccountid',
+              _type: 'io.cozy.accounts',
+              cozyMetadata: {
+                sourceAccountIdentifier: 'accountSourceAccountIdentifier'
+              }
+            }
+          ]
+        } else if (query.doctype === 'io.cozy.files') {
+          return []
+        }
+      }),
+      saveAll: jest.fn()
+    }
+    await normalizeBills(client)
+    expect(client.saveAll).toHaveBeenCalledWith([
+      {
+        _id: 'billid',
+        _type: 'io.cozy.bills',
+        cozyMetadata: {
+          createdByApp: 'testapp',
+          sourceAccount: 'testaccountid',
+          sourceAccountIdentifier: 'accountSourceAccountIdentifier'
+        }
+      }
+    ])
+  })
+  it('should normalize bills with sourceAccount refering to accounts with account name or login', async () => {
+    const client = {
+      queryAll: jest.fn().mockImplementation(async query => {
+        if (query.doctype === 'io.cozy.bills') {
+          return [
+            {
+              _id: 'billid',
+              _type: 'io.cozy.bills',
+              cozyMetadata: {
+                createdByApp: 'testapp',
+                sourceAccount: 'testaccountid'
+              }
+            }
+          ]
+        } else if (query.doctype === 'io.cozy.accounts') {
+          return [
+            {
+              _id: 'testaccountid',
+              _type: 'io.cozy.accounts',
+              auth: {
+                accountName: 'testaccountname'
+              }
+            }
+          ]
+        } else if (query.doctype === 'io.cozy.files') {
+          return []
+        }
+      }),
+      saveAll: jest.fn()
+    }
+    await normalizeBills(client)
+    expect(client.saveAll).toHaveBeenCalledWith([
+      {
+        _id: 'billid',
+        _type: 'io.cozy.bills',
+        cozyMetadata: {
+          createdByApp: 'testapp',
+          sourceAccount: 'testaccountid',
+          sourceAccountIdentifier: 'testaccountname'
+        }
+      }
+    ])
+  })
+  it('should normalize bills with invoice refering to files with sourceAccountIdentifier metadata', async () => {
+    const client = {
+      queryAll: jest.fn().mockImplementation(async query => {
+        if (query.doctype === 'io.cozy.bills') {
+          return [
+            {
+              _id: 'billid',
+              _type: 'io.cozy.bills',
+              invoice: 'io.cozy.files:testfileid',
+              cozyMetadata: {
+                createdByApp: 'testapp'
+              }
+            }
+          ]
+        } else if (query.doctype === 'io.cozy.accounts') {
+          return []
+        } else if (query.doctype === 'io.cozy.files') {
+          return [
+            {
+              _id: 'testfileid',
+              _type: 'io.cozy.files',
+              cozyMetadata: {
+                sourceAccountIdentifier: 'testfilesourceaccountidentifier'
+              }
+            }
+          ]
+        }
+      }),
+      saveAll: jest.fn()
+    }
+    await normalizeBills(client)
+    expect(client.saveAll).toHaveBeenCalledWith([
+      {
+        _id: 'billid',
+        _type: 'io.cozy.bills',
+        invoice: 'io.cozy.files:testfileid',
+        cozyMetadata: {
+          createdByApp: 'testapp',
+          sourceAccountIdentifier: 'testfilesourceaccountidentifier'
+        }
+      }
+    ])
+  })
+  it('should normalize bills with invoice refering to files with sourceAccount refering to account with sourceAccountIdentifier in auth', async () => {
+    const client = {
+      queryAll: jest.fn().mockImplementation(async query => {
+        if (query.doctype === 'io.cozy.bills') {
+          return [
+            {
+              _id: 'billid',
+              _type: 'io.cozy.bills',
+              invoice: 'io.cozy.files:testfileid',
+              cozyMetadata: {
+                createdByApp: 'testapp'
+              }
+            }
+          ]
+        } else if (query.doctype === 'io.cozy.accounts') {
+          return [
+            {
+              _id: 'testaccountid',
+              _type: 'io.cozy.accounts',
+              auth: {
+                accountName: 'testaccountname'
+              }
+            }
+          ]
+        } else if (query.doctype === 'io.cozy.files') {
+          return [
+            {
+              _id: 'testfileid',
+              _type: 'io.cozy.files',
+              cozyMetadata: {
+                sourceAccount: 'testaccountid'
+              }
+            }
+          ]
+        }
+      }),
+      saveAll: jest.fn()
+    }
+    await normalizeBills(client)
+    expect(client.saveAll).toHaveBeenCalledWith([
+      {
+        _id: 'billid',
+        _type: 'io.cozy.bills',
+        invoice: 'io.cozy.files:testfileid',
+        cozyMetadata: {
+          createdByApp: 'testapp',
+          sourceAccountIdentifier: 'testaccountname'
+        }
+      }
+    ])
+  })
+  it('should normalize bills with invoice refering to files with sourceAccount refering to account with sourceAccountIdentifier in cozyMetadata', async () => {
+    const client = {
+      queryAll: jest.fn().mockImplementation(async query => {
+        if (query.doctype === 'io.cozy.bills') {
+          return [
+            {
+              _id: 'billid',
+              _type: 'io.cozy.bills',
+              invoice: 'io.cozy.files:testfileid',
+              cozyMetadata: {
+                createdByApp: 'testapp'
+              }
+            }
+          ]
+        } else if (query.doctype === 'io.cozy.accounts') {
+          return [
+            {
+              _id: 'testaccountid',
+              _type: 'io.cozy.accounts',
+              auth: {
+                accountName: 'testaccountname'
+              },
+              cozyMetadata: {
+                sourceAccountIdentifier: 'testaccountsourceaccountidentifier'
+              }
+            }
+          ]
+        } else if (query.doctype === 'io.cozy.files') {
+          return [
+            {
+              _id: 'testfileid',
+              _type: 'io.cozy.files',
+              cozyMetadata: {
+                sourceAccount: 'testaccountid'
+              }
+            }
+          ]
+        }
+      }),
+      saveAll: jest.fn()
+    }
+    await normalizeBills(client)
+    expect(client.saveAll).toHaveBeenCalledWith([
+      {
+        _id: 'billid',
+        _type: 'io.cozy.bills',
+        invoice: 'io.cozy.files:testfileid',
+        cozyMetadata: {
+          createdByApp: 'testapp',
+          sourceAccountIdentifier: 'testaccountsourceaccountidentifier'
+        }
+      }
+    ])
+  })
+})


### PR DESCRIPTION
This service will normalize the cozyMetadata.sourceAccountIdentifier
attribute in io.cozy.identities,io.cozy.bills,io.cozy.accounts doctypes.

This attribute is needed for debugging purpose for identities and bills
and having this directly specified in accounts without needing any
algorithm is easier to use.

This service must be run manually at the moment since we don't want tu
run it multiple times for every konnector which updates all these
doctypes at one and I did not find a way to specify a unique @event trigger
for multiple doctypes.



```
### ✨ Features

* Add sourceAccountIdentifierNormalizer service
```
