### PR TITLE
[VO-524 & VO-486] fix: Show account paywall even after focus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
-dist: focal
 language: node_js
-node_js:
-  - 16
-  - 20
+node_js: 16
+dist: jammy
 cache:
   npm: false
 branches:
@@ -25,19 +23,25 @@ env:
     # RUNDECK_TOKEN
     - secure: TIuR4l+T3XBBWT1Nz/C93b8DGXO1lom8TbUiWzTcdNXNXAHW2Q/k2qt0KdohYa0m9ULemknxYMewBVyeDbmQIJ1cx/+SrgnrWkcH8Pk6GWkY2ugzicwQPPvLPS/u+MMZC0w7tcOpPdeL1AYF+f+eQxgYvumCnzR/kKWajFaYEHRXWxSQNypsbbkAQmtD4nhtg934MdNamPMMZAV7v7Y7VvmUQeZKV3B63zCr5L28KD2S1yH5l3qFcKm3KFcK5VJgOAjmhUQSg0lBztV2gXMbS/EHecCsUJtu/29EzG/6bGhjP5NSYl6gO2BaemY85oWVK9aWpnuB1fMbnzdJb9+jD4C5NQmVWTLmwlBr1Sf5GrHX0Inc+QNn/XcFe0bUg40FqAjlPPMsNuPSn745QEq+B3IKZGF9o94DIMalZdGoM6CGSqh0hDJ7B6e/7K5vEfw2PZQoVwKfzstrc6EUadkXohtdgv8+b33KHRfOH4A8171LrQn9a4J+SOcns31iGMg/0MXfA+bMZkGrwCQxcnKQ13Epvs3qDaOflbdE0YKOAsUpMDO3zLcY7uVu3FjsBp6x8PL6pYF3iKfp7jD6OSEpGBl39eUMavL8hv+2LFo1O/aiUZJ/9fLPoCqZ/Cbp87T8VMVHHiRfqWs+W0AWRCJs0BpY1qFnOxti/ZrXNo/T1qQ=
 stages:
- - lint
+ - prebuild
  - build
 jobs:
   include:
     - name: Lint
-      stage: lint
-      node_js:
-        - 16
+      stage: "prebuild"
+      node_js: 16
       script: yarn lint
+    - name: "Unit tests node 16"
+      stage: "prebuild"
+      node_js: 16
+      script: yarn test
+    - name: "Unit tests node 20"
+      stage: "prebuild"
+      node_js: 20
+      script: yarn test
     - name: Build
       stage: build
-      node_js:
-        - 16
+      node_js: 16
       before_install:
         - 'if [ "$TRAVIS_SECURE_ENV_VARS" != "false" ]; then openssl aes-256-cbc -K $encrypted_8431ed5600b0_key -iv $encrypted_8431ed5600b0_iv -in ./scripts/id_rsa.enc -out /tmp/deploy_rsa -d; fi'
         - 'if [ "$TRAVIS_SECURE_ENV_VARS" != "false" ]; then eval "$(ssh-agent -s)"; fi'

--- a/src/components/appEntryPoint.jsx
+++ b/src/components/appEntryPoint.jsx
@@ -19,7 +19,8 @@ const appEntryPoint = queryConnect({
     fetchPolicy: OLDER_THAN_THIRTY_SECONDS
   },
   triggers: {
-    query: () => Q(TRIGGER_DOCTYPE).where({ worker: ['client', 'konnector'] }),
+    query: () =>
+      Q(TRIGGER_DOCTYPE).where({ worker: { $in: ['client', 'konnector'] } }),
     as: 'io.cozy.triggers/by_worker_client_konnector',
     fetchPolicy: OLDER_THAN_THIRTY_SECONDS
   }

--- a/src/containers/ReloadFocus.jsx
+++ b/src/containers/ReloadFocus.jsx
@@ -9,11 +9,13 @@ class RealoadFocus extends React.Component {
   componentDidMount() {
     const client = this.props.client
     window.addEventListener('focus', () => {
-      client.query(Q('io.cozy.jobs')),
-        client.query(
-          Q('io.cozy.triggers').where({ worker: ['client', 'konnector'] })
-        ),
-        client.query(Q('io.cozy.apps'))
+      client.query(Q('io.cozy.jobs'))
+      client.query(
+        Q('io.cozy.triggers').where({
+          worker: { $in: ['client', 'konnector'] }
+        })
+      )
+      client.query(Q('io.cozy.apps'))
     })
   }
 


### PR DESCRIPTION
When focusing the home, we make a query to update data. We had a wrong query definition which couldn't be handle by [sift](https://github.com/crcn/sift.js) as it requires MongoDB operators. This query overwrites the results of previous queries on the doctype `io.cozy.triggers`. When the paywall was checked, it was found that the user had no account.

```
### 🐛 Bug Fixes

* Show account paywall even after focus

### 🔧 Tech

* Make unit test in node 20
```
