### PR TITLE
[SCR-442] fix: Do not fail service on non existing invoice files

### DIFF
--- a/src/targets/services/sourceAccountIdentifierNormalizer.js
+++ b/src/targets/services/sourceAccountIdentifierNormalizer.js
@@ -25,6 +25,7 @@ const main = async () => {
     await main()
   } catch (error) {
     log('critical', error.message)
+    process.exit(1)
   }
 })()
 

--- a/src/targets/services/sourceAccountIdentifierNormalizer.js
+++ b/src/targets/services/sourceAccountIdentifierNormalizer.js
@@ -3,9 +3,14 @@
  * cozyMetadata.sourceAccountIdentifier when possible
  *
  */
-import CozyClient, { Q, models } from 'cozy-client'
+import CozyClient from 'cozy-client'
 import logger from 'cozy-logger'
 import polyfillFetch from './polyfillFetch'
+import {
+  normalizeIdentities,
+  normalizeBills,
+  normalizeAccounts
+} from './sourceAccountIdentifierNormalizerHelper'
 
 const log = logger.namespace('sourceAccountIdentifierNormalizer')
 
@@ -28,159 +33,3 @@ const main = async () => {
     process.exit(1)
   }
 })()
-
-async function createBillsFilesMap({ client, bills }) {
-  const billsInvoicesIds = bills.map(bill => {
-    return bill.invoice?.split(':').pop()
-  })
-  const files = await client.queryAll(
-    Q('io.cozy.files').getByIds(billsInvoicesIds)
-  )
-  return files.reduce((map, file) => {
-    map.set(file._id, file)
-    return map
-  }, new Map())
-}
-
-async function createBillsAndFilesAccountsMap({
-  client,
-  bills,
-  billsFilesMap
-}) {
-  const billsAndFilesAccountIds = [
-    ...bills.map(bill => bill?.cozyMetadata?.sourceAccount).filter(Boolean),
-    ...Array.from(billsFilesMap.values())
-      .map(file => file?.cozyMetadata?.sourceAccount)
-      .filter(Boolean)
-  ]
-  const billsAndFilesAccounts = await client.queryAll(
-    Q('io.cozy.accounts').getByIds(billsAndFilesAccountIds)
-  )
-  return billsAndFilesAccounts.reduce((map, account) => {
-    map.set(account._id, account)
-    return map
-  }, new Map())
-}
-
-export async function normalizeIdentities(client) {
-  const identities = await client.queryAll(
-    Q('io.cozy.identities').partialIndex({
-      'cozyMetadata.sourceAccountIdentifier': { $exists: false },
-      identifier: { $exists: true }
-    })
-  )
-
-  const normalizedIdentities = identities
-    .map(identity => ({
-      ...identity,
-      cozyMetadata: {
-        ...identity.cozyMetadata,
-        sourceAccountIdentifier: identity.identifier
-      }
-    }))
-    .filter(Boolean)
-
-  if (normalizedIdentities.length > 0) {
-    await client.saveAll(normalizedIdentities)
-  }
-  log('info', `Normalized ${normalizedIdentities.length}/${identities.length}`)
-}
-
-export async function normalizeBills(client) {
-  const bills = await client.queryAll(
-    Q('io.cozy.bills').partialIndex({
-      'cozyMetadata.sourceAccountIdentifier': { $exists: false }
-    })
-  )
-
-  const billsFilesMap = await createBillsFilesMap({ client, bills })
-  const billsAndFilesAccountsMap = await createBillsAndFilesAccountsMap({
-    client,
-    bills,
-    billsFilesMap
-  })
-
-  const normalizedBills = bills
-    .map(bill => {
-      let sourceAccountIdentifier = null
-      if (bill.sourceAccountIdentifier) {
-        sourceAccountIdentifier = bill.sourceAccountIdentifier
-      } else if (bill.cozyMetadata?.sourceAccount) {
-        const account = billsAndFilesAccountsMap.get(
-          bill.cozyMetadata.sourceAccount
-        )
-        if (account) {
-          if (account.cozyMetadata?.sourceAccountIdentifier) {
-            sourceAccountIdentifier =
-              account.cozyMetadata.sourceAccountIdentifier
-          } else {
-            const accountName = models.account.getAccountName(account)
-            sourceAccountIdentifier =
-              accountName !== account._id ? accountName : null
-          }
-        }
-      } else if (!sourceAccountIdentifier && bill.invoice) {
-        const fileId = bill.invoice?.split(':').pop()
-        const file = billsFilesMap.get(fileId)
-        if (file?.cozyMetadata?.sourceAccountIdentifier) {
-          sourceAccountIdentifier = file.cozyMetadata.sourceAccountIdentifier
-        } else if (file?.cozyMetadata?.sourceAccount) {
-          const account = billsAndFilesAccountsMap.get(
-            file.cozyMetadata.sourceAccount
-          )
-          if (account) {
-            if (account.cozyMetadata?.sourceAccountIdentifier) {
-              sourceAccountIdentifier =
-                account.cozyMetadata.sourceAccountIdentifier
-            } else {
-              const accountName = models.account.getAccountName(account)
-              sourceAccountIdentifier =
-                accountName !== account._id ? accountName : null
-            }
-          }
-        }
-      }
-      if (!sourceAccountIdentifier) {
-        return false
-      }
-      return {
-        ...bill,
-        cozyMetadata: { ...bill.cozyMetadata, sourceAccountIdentifier }
-      }
-    })
-    .filter(Boolean)
-
-  log('info', `Normalized ${normalizedBills.length}/${bills.length}`)
-  if (normalizedBills.length > 0) {
-    await client.saveAll(normalizedBills)
-  }
-}
-
-export async function normalizeAccounts(client) {
-  const accounts = await client.queryAll(
-    Q('io.cozy.accounts').partialIndex({
-      'cozyMetadata.sourceAccountIdentifier': { $exists: false }
-    })
-  )
-
-  const normalizedAccounts = accounts
-    .map(account => {
-      const accountName = models.account.getAccountName(account)
-      const sourceAccountIdentifier =
-        accountName !== account._id ? accountName : null
-      if (!sourceAccountIdentifier) {
-        return false
-      }
-
-      return {
-        ...account,
-        cozyMetadata: { ...account.cozyMetadata, sourceAccountIdentifier }
-      }
-    })
-    .filter(Boolean)
-
-  log('info', `Normalized ${normalizedAccounts.length}/${accounts.length}`)
-  if (normalizedAccounts.length > 0) {
-    await client.saveAll(normalizedAccounts)
-  }
-}

--- a/src/targets/services/sourceAccountIdentifierNormalizer.js
+++ b/src/targets/services/sourceAccountIdentifierNormalizer.js
@@ -123,7 +123,7 @@ export async function normalizeBills(client) {
         const file = billsFilesMap.get(fileId)
         if (file?.cozyMetadata?.sourceAccountIdentifier) {
           sourceAccountIdentifier = file.cozyMetadata.sourceAccountIdentifier
-        } else if (file.cozyMetadata?.sourceAccount) {
+        } else if (file?.cozyMetadata?.sourceAccount) {
           const account = billsAndFilesAccountsMap.get(
             file.cozyMetadata.sourceAccount
           )

--- a/src/targets/services/sourceAccountIdentifierNormalizerHelper.js
+++ b/src/targets/services/sourceAccountIdentifierNormalizerHelper.js
@@ -83,9 +83,10 @@ export async function normalizeBills(client) {
       } else if (!sourceAccountIdentifier && bill.invoice) {
         const fileId = bill.invoice?.split(':').pop()
         const file = billsFilesMap.get(fileId)
-        if (file?.cozyMetadata?.sourceAccountIdentifier) {
+        const fileCozyMetadata = file?.cozyMetadata
+        if (fileCozyMetadata?.sourceAccountIdentifier) {
           sourceAccountIdentifier = file.cozyMetadata.sourceAccountIdentifier
-        } else if (file?.cozyMetadata?.sourceAccount) {
+        } else if (fileCozyMetadata?.sourceAccount) {
           const account = billsAndFilesAccountsMap.get(
             file.cozyMetadata.sourceAccount
           )

--- a/src/targets/services/sourceAccountIdentifierNormalizerHelper.js
+++ b/src/targets/services/sourceAccountIdentifierNormalizerHelper.js
@@ -1,0 +1,160 @@
+import logger from 'cozy-logger'
+import { Q, models } from 'cozy-client'
+
+const log = logger.namespace('sourceAccountIdentifierNormalizer')
+
+async function createBillsAndFilesAccountsMap({
+  client,
+  bills,
+  billsFilesMap
+}) {
+  const billsAndFilesAccountIds = [
+    ...bills.map(bill => bill?.cozyMetadata?.sourceAccount).filter(Boolean),
+    ...Array.from(billsFilesMap.values())
+      .map(file => file?.cozyMetadata?.sourceAccount)
+      .filter(Boolean)
+  ]
+  const billsAndFilesAccounts = await client.queryAll(
+    Q('io.cozy.accounts').getByIds(billsAndFilesAccountIds)
+  )
+  return billsAndFilesAccounts.reduce((map, account) => {
+    map.set(account._id, account)
+    return map
+  }, new Map())
+}
+
+export async function normalizeIdentities(client) {
+  const identities = await client.queryAll(
+    Q('io.cozy.identities').partialIndex({
+      'cozyMetadata.sourceAccountIdentifier': { $exists: false },
+      identifier: { $exists: true }
+    })
+  )
+
+  const normalizedIdentities = identities
+    .map(identity => ({
+      ...identity,
+      cozyMetadata: {
+        ...identity.cozyMetadata,
+        sourceAccountIdentifier: identity.identifier
+      }
+    }))
+    .filter(Boolean)
+
+  if (normalizedIdentities.length > 0) {
+    await client.saveAll(normalizedIdentities)
+  }
+  log('info', `Normalized ${normalizedIdentities.length}/${identities.length}`)
+}
+
+export async function normalizeBills(client) {
+  const bills = await client.queryAll(
+    Q('io.cozy.bills').partialIndex({
+      'cozyMetadata.sourceAccountIdentifier': { $exists: false }
+    })
+  )
+
+  const billsFilesMap = await createBillsFilesMap({ client, bills })
+  const billsAndFilesAccountsMap = await createBillsAndFilesAccountsMap({
+    client,
+    bills,
+    billsFilesMap
+  })
+
+  const normalizedBills = bills
+    .map(bill => {
+      let sourceAccountIdentifier = null
+      if (bill.sourceAccountIdentifier) {
+        sourceAccountIdentifier = bill.sourceAccountIdentifier
+      } else if (bill.cozyMetadata?.sourceAccount) {
+        const account = billsAndFilesAccountsMap.get(
+          bill.cozyMetadata.sourceAccount
+        )
+        if (account) {
+          if (account.cozyMetadata?.sourceAccountIdentifier) {
+            sourceAccountIdentifier =
+              account.cozyMetadata.sourceAccountIdentifier
+          } else {
+            const accountName = models.account.getAccountName(account)
+            sourceAccountIdentifier =
+              accountName !== account._id ? accountName : null
+          }
+        }
+      } else if (!sourceAccountIdentifier && bill.invoice) {
+        const fileId = bill.invoice?.split(':').pop()
+        const file = billsFilesMap.get(fileId)
+        if (file?.cozyMetadata?.sourceAccountIdentifier) {
+          sourceAccountIdentifier = file.cozyMetadata.sourceAccountIdentifier
+        } else if (file?.cozyMetadata?.sourceAccount) {
+          const account = billsAndFilesAccountsMap.get(
+            file.cozyMetadata.sourceAccount
+          )
+          if (account) {
+            if (account.cozyMetadata?.sourceAccountIdentifier) {
+              sourceAccountIdentifier =
+                account.cozyMetadata.sourceAccountIdentifier
+            } else {
+              const accountName = models.account.getAccountName(account)
+              sourceAccountIdentifier =
+                accountName !== account._id ? accountName : null
+            }
+          }
+        }
+      }
+      if (!sourceAccountIdentifier) {
+        return false
+      }
+      return {
+        ...bill,
+        cozyMetadata: { ...bill.cozyMetadata, sourceAccountIdentifier }
+      }
+    })
+    .filter(Boolean)
+
+  log('info', `Normalized ${normalizedBills.length}/${bills.length}`)
+  if (normalizedBills.length > 0) {
+    await client.saveAll(normalizedBills)
+  }
+}
+
+export async function normalizeAccounts(client) {
+  const accounts = await client.queryAll(
+    Q('io.cozy.accounts').partialIndex({
+      'cozyMetadata.sourceAccountIdentifier': { $exists: false }
+    })
+  )
+
+  const normalizedAccounts = accounts
+    .map(account => {
+      const accountName = models.account.getAccountName(account)
+      const sourceAccountIdentifier =
+        accountName !== account._id ? accountName : null
+      if (!sourceAccountIdentifier) {
+        return false
+      }
+
+      return {
+        ...account,
+        cozyMetadata: { ...account.cozyMetadata, sourceAccountIdentifier }
+      }
+    })
+    .filter(Boolean)
+
+  log('info', `Normalized ${normalizedAccounts.length}/${accounts.length}`)
+  if (normalizedAccounts.length > 0) {
+    await client.saveAll(normalizedAccounts)
+  }
+}
+
+async function createBillsFilesMap({ client, bills }) {
+  const billsInvoicesIds = bills.map(bill => {
+    return bill.invoice?.split(':').pop()
+  })
+  const files = await client.queryAll(
+    Q('io.cozy.files').getByIds(billsInvoicesIds)
+  )
+  return files.reduce((map, file) => {
+    map.set(file._id, file)
+    return map
+  }, new Map())
+}

--- a/src/targets/services/sourceAccountIdentifierNormalizerHelper.spec.js
+++ b/src/targets/services/sourceAccountIdentifierNormalizerHelper.spec.js
@@ -1,7 +1,7 @@
 import {
   normalizeIdentities,
   normalizeBills
-} from './sourceAccountIdentifierNormalizer'
+} from './sourceAccountIdentifierNormalizerHelper'
 
 describe('normalizeIdentities', () => {
   it('should normalize identities with the identifier attribute', async () => {


### PR DESCRIPTION
Protect sourceAccountIdentifierNormalizer service against references to non-existing files as invoice in bills (when the user removes the files himself

- fix: Make the service job fail on errors



```
### 🐛 Bug Fixes

* sourceAccountIdentifierNormalizer service: handle bills with non existing invoice files
* sourceAccountIdentifierNormalizer service: script error now make the service fail
```
