### PR TITLE
fix: Upgrade harvest to 23.0.1 (SCR-508)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cozy-device-helper": "2.7.0",
     "cozy-doctypes": "1.83.8",
     "cozy-flags": "3.2.2",
-    "cozy-harvest-lib": "^23.0.0",
+    "cozy-harvest-lib": "^23.0.1",
     "cozy-intent": "^2.19.2",
     "cozy-interapp": "^0.9.0",
     "cozy-keys-lib": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5980,10 +5980,10 @@ cozy-flags@3.2.2:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-23.0.0.tgz#33dd73e513eb0b24e82c2d0813c384179005a9a3"
-  integrity sha512-Q5UpF7M13I/4HMfA5adkOvt3277N6IQZDlmz94f+fVcVr/CZrT5pA+hB4dLG6pdWjMN/2/09210XiWba+2/Y5w==
+cozy-harvest-lib@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-23.0.1.tgz#8aa710fd0b07bafaf9ceca98f6801f538c977fc1"
+  integrity sha512-Hwrd7Mxzs3g8Z2CGmZrJoukg1Z63HA+Vp7xreJs75jUA96VdF1zj5PAxoREr7jyxI5a3I372FLaAolNbWujk/Q==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
To transmit correct account identifiers on reconnect
https://github.com/cozy/cozy-libs/pull/2528

```
### 🐛 Bug Fixes

* transmit correct account identifiers on reconnect [PR](https://github.com/cozy/cozy-libs/pull/2528)

```
