### PR TITLE
fix: Remove color-scheme and use default value

### DIFF
--- a/src/targets/browser/index.ejs
+++ b/src/targets/browser/index.ejs
@@ -10,7 +10,6 @@
   <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
   <meta name="msapplication-TileColor" content="#2b5797">
   <meta name="theme-color" content="#ffffff">
-  <meta name="color-scheme" content="light dark" />
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, viewport-fit=cover">
   <link rel="preload" href="//{{.Domain}}/assets/fonts/Lato-Bold.immutable.woff2" as="font" type="font/woff2"
     crossorigin>

--- a/src/targets/intents/index.ejs
+++ b/src/targets/intents/index.ejs
@@ -6,7 +6,6 @@
 {{.Favicon}}
 <meta name="msapplication-TileColor" content="#2b5797">
 <meta name="theme-color" content="#ffffff">
-<meta name="color-scheme" content="light dark" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="preload" href="//{{.Domain}}/assets/fonts/Lato-Bold.immutable.woff2" as="font" type="font/woff2"
     crossorigin>


### PR DESCRIPTION
because of `mix-blend-mode multiply` on .App, there is a conflict that causes a black veil to appear on the application on Chrome
