### PR TITLE
fix: Avoid to make the background image too dark in dark mode

### DIFF
--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -24,6 +24,9 @@ body
         overflow auto
 
 .App
+    // Avoid mix-blend-mode from background-container to be linked to the background color of the body.
+    // Must not be responsive to the theme.
+    background-color white
     background-repeat no-repeat
     background-size cover
     background-position center


### PR DESCRIPTION
We use a combination of backdrop-filter and mix-blend-mode to darken the background image. However, this take into account the background color of the body which is white in light mode and a strong gray in dark mode.

So here we override the background color in .App to white. It has no effect on the container using .App, but it avoid mix-blend-mode to be linked to the background color of the body.

```
### ✨ Features

*

### 🐛 Bug Fixes

* Background was too dark in dark mode

### 🔧 Tech

*
```
