### PR TITLE
feat: Update cozy-ui to 110.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cozy-sharing": "^15.0.0",
     "cozy-stack-client": "^48.0.0",
     "cozy-tsconfig": "1.2.0",
-    "cozy-ui": "^109.1.1",
+    "cozy-ui": "^110.1.0",
     "date-fns": "2.28.0",
     "es-abstract": "1.20.2",
     "form-data": "2.5.1",

--- a/src/components/AppWrapper.jsx
+++ b/src/components/AppWrapper.jsx
@@ -64,6 +64,7 @@ const Inner = ({ children, lang, context }) => (
     <RealTimeQueries doctype="io.cozy.jobs" />
     <RealTimeQueries doctype="io.cozy.triggers" />
     <RealTimeQueries doctype="io.cozy.konnectors" />
+    <RealTimeQueries doctype="io.cozy.settings" />
     {process.env.NODE_ENV !== 'production' ? <CozyDevtools /> : null}
   </I18n>
 )

--- a/src/components/AppWrapper.spec.jsx
+++ b/src/components/AppWrapper.spec.jsx
@@ -18,6 +18,7 @@ const mockClient = {
 
 jest.mock('cozy-client', () => ({
   __esModule: true,
+  ...jest.requireActual('cozy-client'),
   CozyProvider: ({ children }) => children,
   RealTimeQueries: ({ doctype }) => (
     <div data-testid="RealTimeQueries">{doctype}</div>

--- a/src/components/ShortcutLink.spec.jsx
+++ b/src/components/ShortcutLink.spec.jsx
@@ -1,22 +1,19 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import AppLike from 'test/AppLike'
 
 import { ShortcutLink } from './ShortcutLink'
 import { useFetchShortcut } from 'cozy-client'
-import CozyTheme from 'cozy-ui/transpiled/react/providers/CozyTheme'
 
 jest.mock('cozy-client', () => {
   return {
+    ...jest.requireActual('cozy-client'),
     useClient: () => {},
     useFetchShortcut: jest.fn(),
     withClient: jest.fn()
   }
 })
-
-jest.mock('cozy-ui/transpiled/react/providers/Breakpoints', () => () => ({
-  isMobile: false
-}))
 
 describe('ShortcutLink', () => {
   it('should render a shortcut link with shortcut name initial', () => {
@@ -27,9 +24,9 @@ describe('ShortcutLink', () => {
     const file = { _id: '123', name: 'cozy.io.url', type: 'file' }
 
     render(
-      <CozyTheme>
+      <AppLike>
         <ShortcutLink file={file} />
-      </CozyTheme>
+      </AppLike>
     )
 
     expect(screen.getByRole('heading', { level: 6 })).toHaveTextContent(
@@ -53,9 +50,9 @@ describe('ShortcutLink', () => {
     const file = { _id: '123', name: 'cozy.io.url', type: 'file' }
 
     render(
-      <CozyTheme>
+      <AppLike>
         <ShortcutLink file={file} />
-      </CozyTheme>
+      </AppLike>
     )
 
     expect(screen.getByRole('heading', { level: 6 })).toHaveTextContent(

--- a/src/components/Shortcuts/__snapshots__/ShortcutsView.spec.jsx.snap
+++ b/src/components/Shortcuts/__snapshots__/ShortcutsView.spec.jsx.snap
@@ -3,9 +3,7 @@
 exports[`Shortcuts Should display a shortcut directory with its files 1`] = `
 Object {
   "asFragment": [Function],
-  "baseElement": <body
-    class="CozyTheme--light-normal"
-  >
+  "baseElement": <body>
     <div>
       <div
         class="CozyTheme--light-normal u-dc"
@@ -208,9 +206,7 @@ Object {
 exports[`Shortcuts Should display multiple sections for multiple directories 1`] = `
 Object {
   "asFragment": [Function],
-  "baseElement": <body
-    class="CozyTheme--light-normal"
-  >
+  "baseElement": <body>
     <div>
       <div
         class="CozyTheme--light-normal u-dc"

--- a/test/AppLike.jsx
+++ b/test/AppLike.jsx
@@ -32,17 +32,17 @@ class AppLike extends React.Component {
 
   render() {
     return (
-      <CozyTheme>
-        <BreakpointsProvider>
-          <CozyProvider client={this.props.client || defaultClient}>
+      <BreakpointsProvider>
+        <CozyProvider client={this.props.client || defaultClient}>
+          <CozyTheme>
             <ReduxProvider store={this.props.store || defaultClient.store}>
               <I18n dictRequire={() => enLocale} lang="en">
                 <BackupDataProvider>{this.props.children}</BackupDataProvider>
               </I18n>
             </ReduxProvider>
-          </CozyProvider>
-        </BreakpointsProvider>
-      </CozyTheme>
+          </CozyTheme>
+        </CozyProvider>
+      </BreakpointsProvider>
     )
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6220,10 +6220,10 @@ cozy-tsconfig@1.2.0:
   resolved "https://registry.yarnpkg.com/cozy-tsconfig/-/cozy-tsconfig-1.2.0.tgz#17e61f960f139fae4d26cbac2254b9ab632b269e"
   integrity sha512-TRHnY9goF3FzVlUbP7BcHxuN2XAA4AmppT4fHHZmTKaSwYTByVR1Al+riFMDbce94kJZ1wzl9WNLWQuqzGZ6Cw==
 
-cozy-ui@^109.1.1:
-  version "109.1.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-109.1.1.tgz#c2fd1c95b8f490b1a9dfd93cec7be096d2de7b33"
-  integrity sha512-hBR3qmtcvEhV4D08SwYz/eZvWFoCJM0Wfw7rPLYifGgawo388VZTpzxZxFHKFBK9Y0AbQAXQxYqd7oq9nUlcQA==
+cozy-ui@^110.1.0:
+  version "110.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-110.1.0.tgz#3881ca8945a41848558f8c8133d8fb611b1d6195"
+  integrity sha512-mjC1snnTFMOWbIa6pbqmeUuHCo0Fy+VieH6jLuMWrlz7cgi0pLqWQS3/B4qexkuF4v5DVqjGhc4krRz25If9Ig==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"


### PR DESCRIPTION
To better support dark mode (flagship app and dark mode button in cozy-settings).



```
### ✨ Features

*

### 🐛 Bug Fixes

*

### 🔧 Tech

* Update cozy-ui to 110.1.0 (better dark mode support)
```
