### PR TITLE
fix: use `fullWidth`  to handle  minWidth VO-892

### DIFF
--- a/src/components/Sections/SectionDialog.tsx
+++ b/src/components/Sections/SectionDialog.tsx
@@ -45,6 +45,7 @@ const SectionDialog = (): JSX.Element | null => {
           />
         }
         onClose={handleGoBack}
+        fullWidth
       />
     </CozyTheme>
   )

--- a/src/cozy-ui.d.ts
+++ b/src/cozy-ui.d.ts
@@ -31,6 +31,7 @@ declare module 'cozy-ui/transpiled/react/CozyDialogs' {
     size?: 'small' | 'medium' | 'large'
     title?: ReactNode
     fullScreen?: boolean
+    fullWidth?: boolean
   }
 
   const Dialog: (props: DialogProps) => JSX.Element

--- a/src/styles/lists.styl
+++ b/src/styles/lists.styl
@@ -14,7 +14,6 @@
     grid-auto-rows minmax(rem(91), auto)
     grid-gap rem(10) 0
     justify-content center
-    min-width 320px
 
     &.detailed
         grid-template-columns repeat(3, detailedAppTileWithGutter)


### PR DESCRIPTION
Using px value was unfit for small screens;
Instead, using fullWidth prop from material-ui.
This does not make the component take all the screen, just the full width available to it.
https://v4.mui.com/api/dialog/