### PR TITLE
fix: remove isSuggestion check in sectionview

### DIFF
--- a/src/components/KonnectorTile.jsx
+++ b/src/components/KonnectorTile.jsx
@@ -122,14 +122,14 @@ const getFirstUserError = triggers => {
  * @param {boolean} props.isInMaintenance Is in maintenance
  * @param {boolean} props.loading isLoading ?
  * @param {import('cozy-client/types/types').IOCozyKonnector} props.konnector
- * @param {boolean} [props.isSuggestion=false] The Konnector is not installed and is displayed as a suggestion
+ * @param {boolean} [props.shouldOpenStore=false] The Konnector should open the store when clicked (ie it's a forced suggestion)
  * @returns
  */
 export const KonnectorTile = ({
   konnector,
   isInMaintenance,
   loading,
-  isSuggestion = false
+  shouldOpenStore = false
 }) => {
   const allTriggers =
     // @ts-ignore
@@ -162,7 +162,7 @@ export const KonnectorTile = ({
 
   // Navigate to the store if the konnector is a suggestion (ie not installed)
   const handleSuggestionClick = event => {
-    if (!isSuggestion) return // Should not happen but just in case
+    if (!shouldOpenStore) return // Should not happen but just in case
 
     event.preventDefault() // Prevent the default behavior of NavLink to avoid navigating to the konnector hash
 
@@ -190,7 +190,7 @@ export const KonnectorTile = ({
         konnector
       })}
       className="scale-hover"
-      {...(isSuggestion ? { onClick: handleSuggestionClick } : {})}
+      {...(shouldOpenStore ? { onClick: handleSuggestionClick } : {})}
     >
       <SquareAppIcon
         app={konnector}

--- a/src/components/Sections/SectionView.tsx
+++ b/src/components/Sections/SectionView.tsx
@@ -23,10 +23,10 @@ export const SectionBody = ({ section }: SectionViewProps): JSX.Element => {
   const isGroupMode =
     (section && computeGroupMode(isMobile, section)) === GroupMode.GROUPED
   const { t } = useI18n()
-  const isSuggestionModal = Boolean(
+  const shouldOpenStoreModal = Boolean(
     section.type === 'category' && section.pristine
   )
-  const { isRunning, isSuggested } = useSections()
+  const { isRunning } = useSections()
 
   return (
     <div
@@ -41,7 +41,7 @@ export const SectionBody = ({ section }: SectionViewProps): JSX.Element => {
       {(section.items as IOCozyKonnector[]).map((item, index) =>
         item.type === 'konnector' ? (
           <KonnectorTile
-            isSuggestion={isSuggestionModal || isSuggested(item.slug)}
+            shouldOpenStore={shouldOpenStoreModal}
             key={item.slug}
             konnector={item}
             isInMaintenance={false}
@@ -52,7 +52,7 @@ export const SectionBody = ({ section }: SectionViewProps): JSX.Element => {
         )
       )}
 
-      {!isSuggestionModal && section.type === 'category' && (
+      {!shouldOpenStoreModal && section.type === 'category' && (
         <AddServiceTile label={t('add_service')} category={section.name} />
       )}
     </div>


### PR DESCRIPTION
Made naming clearer about what it does
Also removed the logic that would consider a suggested
konnector (from doctype) the same as a suggested konnector
(from front-end point of view).
So now when opening a suggested konnector that is also not connected,
we are not redirected to the store.