### PR TITLE
fix: handle long detailed items in grid VO-959

### DIFF
--- a/src/styles/lists.styl
+++ b/src/styles/lists.styl
@@ -21,7 +21,7 @@
     // Caution: this section is full of magic numbers
     // TODO: refactor this to use computed values to avoid glitches in the grid system
     &.detailed
-        grid-template-columns repeat(3, 1fr)
+        grid-template-columns repeat(3, minmax(0, 1fr))
         column-gap appGridGutter
         width: calc(100% - 2rem) !important // @stylint ignore
 
@@ -31,7 +31,7 @@
         grid-gap rem(5) 0
 
         &.detailed
-            grid-template-columns 1fr
+            grid-template-columns minmax(0, 1fr)
             column-gap 0
             width: calc(100% - 1.25rem) !important // @stylint ignore
 


### PR DESCRIPTION
Use minmax instead of full
both desktop and mobile

![image](https://github.com/user-attachments/assets/27f37e83-fe2c-4803-9b38-f5f300350602)
