### PR TITLE
fix: show items in maintenance if installed VO-949

### DIFF
--- a/src/components/Sections/lib/formatServicesSections.ts
+++ b/src/components/Sections/lib/formatServicesSections.ts
@@ -159,8 +159,13 @@ export const formatServicesSections = (
         // Filter out items that are in maintenance
         const availableItems = allItems.filter(isAvailable)
 
+        // Filter out items that are in maintenance but keep installed ones
+        const availableOrInstalledItems = allItems.filter(
+          item => isAvailable(item) || isInstalled(item)
+        )
+
         // Filter out items that are installed
-        const installedItems = availableItems.filter(isInstalled)
+        const installedItems = availableOrInstalledItems.filter(isInstalled)
 
         // Get suggested konnectors that are also in available items, enhancing their names
         const suggestedKonnectorsWithName = getEnhancedSuggestedKonnectors(


### PR DESCRIPTION
Item in maintenance and installed: display
Item in maintenance not installed: do not display
Item in maintenance in pristine category: do not display