### PR TITLE
[VO-1073] fix: Adapts the data format for shortcuts

### DIFF
--- a/src/components/ShortcutLink.jsx
+++ b/src/components/ShortcutLink.jsx
@@ -33,7 +33,7 @@ export const ShortcutLink = ({
    */
   const icon = get(file, 'attributes.metadata.icon')
   const iconMimeType = get(file, 'attributes.metadata.iconMimeType')
-  const description = get(file, 'attributes.metadata.description')
+  const description = get(file, 'attributes.metadata.target.description')
 
   return (
     <Link


### PR DESCRIPTION
This RP adapts the data format of shortcuts once their metadata has been standardised ([PR on cozy-doctypes](https://github.com/cozy/cozy-doctypes/pull/268)).

**Related PRs :**
- https://github.com/konnectors/toutatice/pull/482