### PR TITLE
Revert "fix: Change shortcut metadata format"

### DIFF
--- a/src/components/ShortcutLink.jsx
+++ b/src/components/ShortcutLink.jsx
@@ -33,7 +33,7 @@ export const ShortcutLink = ({
    */
   const icon = get(file, 'attributes.metadata.icon')
   const iconMimeType = get(file, 'attributes.metadata.iconMimeType')
-  const description = get(file, 'attributes.metadata.target.description')
+  const description = get(file, 'attributes.metadata.description')
 
   return (
     <Link


### PR DESCRIPTION
This reverts commit 07109a638bc4dacc8f218ba85a805f1866658bac. There are existing shortcuts that rely on `metadata.description`. Therefore, we revert this change.



```
### ✨ Features

*

### 🐛 Bug Fixes

* Use `metadata.description` rather than `metadata.target.description`

### 🔧 Tech

*
```
