### PR TITLE
feat(Assistant): Replace search result bottomsheet in mobile by modal

### DIFF
--- a/src/assistant/AssistantDialog.jsx
+++ b/src/assistant/AssistantDialog.jsx
@@ -1,14 +1,16 @@
 import React from 'react'
 
 import { FixedActionsDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import Conversation from './Conversations/Conversation'
+import ConversationSearchBar from './Conversations/ConversationSearchBar'
 import AssistantProvider, { useAssistant } from './AssistantProvider'
 import SearchProvider from './SearchProvider'
-import ConversationSearchBar from './Conversations/ConversationSearchBar'
 
 const AssistantDialog = ({ onClose }) => {
   const { assistantState } = useAssistant()
+  const { isMobile } = useBreakpoints()
 
   return (
     <FixedActionsDialog
@@ -18,12 +20,39 @@ const AssistantDialog = ({ onClose }) => {
       componentsProps={{
         divider: { className: 'u-dn' }
       }}
-      content={<Conversation id={assistantState.conversationId} />}
+      content={
+        <>
+          {isMobile && !assistantState.conversationId && (
+            <div className="u-mt-2">
+              <ConversationSearchBar
+                assistantStatus={assistantState.status}
+                conversationId={assistantState.conversationId}
+                hasArrowDown
+                autoFocus
+                onClose={onClose}
+              />
+            </div>
+          )}
+          <Conversation id={assistantState.conversationId} />
+        </>
+      }
       actions={
-        <ConversationSearchBar
-          assistantStatus={assistantState.status}
-          conversationId={assistantState.conversationId}
-        />
+        isMobile ? (
+          assistantState.conversationId && (
+            <ConversationSearchBar
+              assistantStatus={assistantState.status}
+              conversationId={assistantState.conversationId}
+              autoFocus={!isMobile}
+              onClose={onClose}
+            />
+          )
+        ) : (
+          <ConversationSearchBar
+            assistantStatus={assistantState.status}
+            conversationId={assistantState.conversationId}
+            autoFocus
+          />
+        )
       }
       onClose={onClose}
     />

--- a/src/assistant/Conversations/ConversationSearchBar.jsx
+++ b/src/assistant/Conversations/ConversationSearchBar.jsx
@@ -17,9 +17,14 @@ import SuggestionsPlaceholder from './SuggestionsPlaceholder'
 
 import styles from './styles.styl'
 
-const ConversationSearchBar = ({ assistantStatus, conversationId }) => {
+const ConversationSearchBar = ({
+  assistantStatus,
+  conversationId,
+  autoFocus,
+  hasArrowDown,
+  onClose
+}) => {
   const { t } = useI18n()
-  const resultPaneAnchorRef = useRef()
   const { assistantState, onAssistantExecute } = useAssistant()
   const { setSearchValue, delayedSetSearchValue } = useSearch()
   const [inputValue, setInputValue] = useState('')
@@ -58,7 +63,7 @@ const ConversationSearchBar = ({ assistantStatus, conversationId }) => {
     })
 
   return (
-    <div ref={resultPaneAnchorRef} className="u-w-100 u-maw-7 u-mh-auto">
+    <div className="u-w-100 u-maw-7 u-mh-auto">
       <SearchBar
         className={styles['conversationSearchBar']}
         icon={null}
@@ -74,7 +79,7 @@ const ConversationSearchBar = ({ assistantStatus, conversationId }) => {
             inputProps: {
               className: styles['conversationSearchBar-input']
             },
-            autoFocus: true,
+            autoFocus,
             startAdornment: showSuggestions && (
               <SuggestionsPlaceholder inputValue={inputValue} />
             ),
@@ -103,6 +108,7 @@ const ConversationSearchBar = ({ assistantStatus, conversationId }) => {
                   >
                     <Icon
                       icon={ArrowUpIcon}
+                      rotate={hasArrowDown ? 180 : 0}
                       size={12}
                       color={
                         inputValue
@@ -124,7 +130,7 @@ const ConversationSearchBar = ({ assistantStatus, conversationId }) => {
         onChange={handleChange}
       />
       {!conversationId && (
-        <ResultMenu anchorRef={resultPaneAnchorRef} onClick={handleClick} />
+        <ResultMenu onClick={handleClick} onClose={onClose} />
       )}
     </div>
   )

--- a/src/assistant/ResultMenu/ResultMenu.jsx
+++ b/src/assistant/ResultMenu/ResultMenu.jsx
@@ -1,9 +1,7 @@
 import React from 'react'
 
-import BottomSheet, {
-  BottomSheetItem
-} from 'cozy-ui/transpiled/react/BottomSheet'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
+import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Paper from 'cozy-ui/transpiled/react/Paper'
 
 import { useSearch } from '../SearchProvider'
@@ -11,7 +9,7 @@ import ResultMenuContent from './ResultMenuContent'
 
 import styles from './styles.styl'
 
-const ResultMenu = ({ anchorRef, onClick }) => {
+const ResultMenu = ({ onClick, onClose }) => {
   const { isMobile } = useBreakpoints()
   const { searchValue } = useSearch()
 
@@ -19,15 +17,20 @@ const ResultMenu = ({ anchorRef, onClick }) => {
 
   if (isMobile)
     return (
-      <BottomSheet
-        portalProps={{ container: anchorRef?.current }}
-        settings={{ hasMinHeightOffset: true }}
-        offset={70}
-      >
-        <BottomSheetItem disableGutters>
-          <ResultMenuContent onClick={onClick} />
-        </BottomSheetItem>
-      </BottomSheet>
+      <Dialog
+        open
+        transitionDuration={0}
+        disablePortal
+        disableAutoFocus
+        hideBackdrop
+        componentsProps={{
+          dialogTitle: { style: { height: '6.5rem' } },
+          divider: { className: 'u-dn' }
+        }}
+        title={' '}
+        content={<ResultMenuContent hasArrowDown onClick={onClick} />}
+        onClose={onClose}
+      />
     )
 
   return (

--- a/src/assistant/ResultMenu/ResultMenuContent.jsx
+++ b/src/assistant/ResultMenu/ResultMenuContent.jsx
@@ -33,7 +33,7 @@ const SearchResult = () => {
   ))
 }
 
-const ResultMenuContent = ({ onClick }) => {
+const ResultMenuContent = ({ hasArrowDown, onClick }) => {
   const { searchValue } = useSearch()
 
   return (
@@ -41,7 +41,11 @@ const ResultMenuContent = ({ onClick }) => {
       <ResultMenuItem
         icon={
           <Circle size="small">
-            <Icon icon={ArrowUpIcon} size={12} />
+            <Icon
+              icon={ArrowUpIcon}
+              size={12}
+              rotate={hasArrowDown ? 180 : 0}
+            />
           </Circle>
         }
         primaryText={searchValue}


### PR DESCRIPTION
Ce n'est pas une solution idéale, mais dans le temps imparti c'est la solution retenue. On modifie également l'Ui pour mettre l'input en haut de l'écran dû à un comportement forcé de l'affichage du clavier sur iOS cf https://martijnhols.nl/gists/how-to-detect-the-on-screen-keyboard-in-ios-safari

Cette partie sera totalement retravaillée dans un second temps très prochainement. Nous sommes encore au stade du prototype...