### PR TITLE
fix: Make the search work for cozy-apps again

### DIFF
--- a/src/assistant/Search/getIconForSearchResult.js
+++ b/src/assistant/Search/getIconForSearchResult.js
@@ -19,7 +19,7 @@ import EncryptedFolderIcon from './EncryptedFolderIcon'
 import { getFileMimetype } from './getFileMimetype'
 
 export const getIconForSearchResult = searchResult => {
-  if (searchResult.doc.type === 'io.cozy.apps') {
+  if (searchResult.doc._type === 'io.cozy.apps') {
     return {
       type: 'app',
       app: searchResult.doc

--- a/src/assistant/Search/getIconForSearchResult.js
+++ b/src/assistant/Search/getIconForSearchResult.js
@@ -52,7 +52,8 @@ export const getIconForSearchResult = searchResult => {
   }
 
   return {
-    type: 'unknown'
+    type: 'component',
+    component: IconFiles
   }
 }
 


### PR DESCRIPTION
Since the search engine now uses a local PouchDB, the documents are not JSON-API compliant, so we should rely on `_type` instead of `type`

With previous implementation, we failed to compute icon for cozy-apps due to missing `doc.type` attribute, and returned the `unknown` type. This type was not handled by the `<ResultMenuItem>` item and the application would crash

This PR fixes the usage of the `_type` attribute but also return a default icon instead of `unknown` to prevent future crashes