### PR TITLE
Assistant: Change flags name

### DIFF
--- a/src/assistant/ResultMenu/ResultMenuContent.jsx
+++ b/src/assistant/ResultMenu/ResultMenuContent.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import flag from 'cozy-flags'
 import List from 'cozy-ui/transpiled/react/List'
 import Circle from 'cozy-ui/transpiled/react/Circle'
 import PaperplaneIcon from 'cozy-ui/transpiled/react/Icons/Paperplane'
@@ -46,17 +47,19 @@ const ResultMenuContent = ({ onClick }) => {
 
   return (
     <List>
-      <ResultMenuItem
-        icon={
-          <Circle size="small">
-            <Icon icon={PaperplaneIcon} size={isMobile ? 12 : undefined} />
-          </Circle>
-        }
-        primaryText={searchValue}
-        query={searchValue}
-        secondaryText={t('assistant.search.result')}
-        onClick={onClick}
-      />
+      {flag('cozy.assistant.enabled') && (
+        <ResultMenuItem
+          icon={
+            <Circle size="small">
+              <Icon icon={PaperplaneIcon} size={isMobile ? 12 : undefined} />
+            </Circle>
+          }
+          primaryText={searchValue}
+          query={searchValue}
+          secondaryText={t('assistant.search.result')}
+          onClick={onClick}
+        />
+      )}
       {dataProxyServicesAvailable && <SearchResult />}
     </List>
   )

--- a/src/assistant/Search/SearchBar.jsx
+++ b/src/assistant/Search/SearchBar.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import flag from 'cozy-flags'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import { useSearch } from './SearchProvider'
@@ -21,6 +22,8 @@ const SearchBar = () => {
   }
 
   const handleClick = () => {
+    if (!flag('cozy.assistant.enabled')) return
+
     const conversationId = makeConversationId()
     onAssistantExecute({ value: inputValue, conversationId })
     navigate(`assistant/${conversationId}`)

--- a/src/assistant/Views/SearchDialog.jsx
+++ b/src/assistant/Views/SearchDialog.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import flag from 'cozy-flags'
 import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 
 import SearchProvider from '../Search/SearchProvider'
@@ -40,7 +41,9 @@ const SearchDialog = () => {
       content={
         <>
           {searchValue !== '' && <ResultMenuContent onClick={handleClick} />}
-          <SearchSubmitFab searchValue={searchValue} onClick={handleClick} />
+          {flag('cozy.assistant.enabled') && (
+            <SearchSubmitFab searchValue={searchValue} onClick={handleClick} />
+          )}
         </>
       }
       onClose={handleClose}

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -28,13 +28,13 @@ const Home = ({ setAppsReady, wrapper }) => {
       <Main className="u-flex-grow-1">
         <ScrollToTopOnMount target={wrapper} />
         {pathname === '/connected' && <Announcements />}
-        {flag('cozy.search.enabled') && !isMobile && (
+        {flag('cozy.searchbar.enabled') && !isMobile && (
           <AssistantWrapperDesktop />
         )}
         <Content
           className={cx('u-flex u-flex-column u-ph-1', {
             [styles['homeMainContent--withAssistant']]:
-              isMobile && flag('cozy.search.enabled'),
+              isMobile && flag('cozy.searchbar.enabled'),
             [styles['homeMainContent--immersive']]:
               getFlagshipMetadata().immersive
           })}

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -28,13 +28,13 @@ const Home = ({ setAppsReady, wrapper }) => {
       <Main className="u-flex-grow-1">
         <ScrollToTopOnMount target={wrapper} />
         {pathname === '/connected' && <Announcements />}
-        {flag('cozy.assistant.enabled') && !isMobile && (
+        {flag('cozy.search.enabled') && !isMobile && (
           <AssistantWrapperDesktop />
         )}
         <Content
           className={cx('u-flex u-flex-column u-ph-1', {
             [styles['homeMainContent--withAssistant']]:
-              isMobile && flag('cozy.assistant.enabled'),
+              isMobile && flag('cozy.search.enabled'),
             [styles['homeMainContent--immersive']]:
               getFlagshipMetadata().immersive
           })}

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -95,7 +95,9 @@ const App = ({ accounts, konnectors, triggers }) => {
     : null
   const context = useQuery(contextQuery.definition, contextQuery.options)
 
-  const showAssistantForMobile = flag('cozy.assistant.enabled') && isMobile
+  const showAssistantForMobile = isFlagshipApp()
+    ? flag('cozy.search.enabled-for-flagship')
+    : flag('cozy.search.enabled') && isMobile
 
   useEffect(() => {
     setIsFetching(

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -96,8 +96,8 @@ const App = ({ accounts, konnectors, triggers }) => {
   const context = useQuery(contextQuery.definition, contextQuery.options)
 
   const showAssistantForMobile = isFlagshipApp()
-    ? flag('cozy.search.enabled-for-flagship')
-    : flag('cozy.search.enabled') && isMobile
+    ? flag('cozy.searchbar.enabled-for-flagship')
+    : flag('cozy.searchbar.enabled') && isMobile
 
   useEffect(() => {
     setIsFetching(

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -95,6 +95,8 @@ const App = ({ accounts, konnectors, triggers }) => {
     : null
   const context = useQuery(contextQuery.definition, contextQuery.options)
 
+  const showAssistantForMobile = flag('cozy.assistant.enabled') && isMobile
+
   useEffect(() => {
     setIsFetching(
       [accounts, konnectors, triggers, context].some(collection =>
@@ -112,6 +114,7 @@ const App = ({ accounts, konnectors, triggers }) => {
     const flags = toFlagNames(context.attributes.features)
     enableFlags(flags)
   }
+
   useEffect(() => {
     setIsReady(
       appsReady &&
@@ -194,7 +197,7 @@ const App = ({ accounts, konnectors, triggers }) => {
         </div>
         <FooterLogo />
       </MainView>
-      {flag('cozy.assistant.enabled') && isMobile && <AssistantWrapperMobile />}
+      {showAssistantForMobile && <AssistantWrapperMobile />}
       {isFlagshipApp() && <DefaultRedirectionSnackbar />}
       {flag(FLAG_FAB_BUTTON_ENABLED) && isMobile && <AddButton />}
     </>

--- a/src/dataproxy/DataProxyProvider.jsx
+++ b/src/dataproxy/DataProxyProvider.jsx
@@ -27,7 +27,7 @@ export const DataProxyProvider = React.memo(({ children }) => {
 
     const initIframe = async () => {
       try {
-        if (!flag('cozy.assistant.withSearchResult')) {
+        if (!flag('cozy.search.with-result')) {
           log.log(
             'Dataproxy features will be disabled due to missing feature flags'
           )

--- a/src/dataproxy/DataProxyProvider.jsx
+++ b/src/dataproxy/DataProxyProvider.jsx
@@ -27,7 +27,7 @@ export const DataProxyProvider = React.memo(({ children }) => {
 
     const initIframe = async () => {
       try {
-        if (!flag('cozy.search.with-result')) {
+        if (!flag('cozy.search.enabled')) {
           log.log(
             'Dataproxy features will be disabled due to missing feature flags'
           )


### PR DESCRIPTION
Permet d'apporter un peu plus de granularité dans la gestion des fonctionnalités

`cozy.searchbar.enabled`: Affiche la barre de recherche (uniquement desktop/mobile web)
`cozy.searchbar.enabled-for-flagship`: Affiche la barre de recherche (uniquement flagship app)
`cozy.search.enabled`: Active la fonction de recherche
`cozy.assistant.enabled`: Active la fonctionnalité "Cozy Assistant"
