### PR TITLE
feat(Assistant): Adjust result menu height to cut the last element

### DIFF
--- a/src/assistant/ResultMenu/styles.styl
+++ b/src/assistant/ResultMenu/styles.styl
@@ -2,9 +2,9 @@
   overflow hidden
   margin 0 auto
   max-width 50rem
-  max-height 18rem
+  max-height 16.5rem
   border-radius 0 0 28px 28px
 
   &-inner
-    max-height 18rem
+    max-height 16.5rem
     overflow auto


### PR DESCRIPTION
and suggest scrolling, which is particularly useful on mobile because scrollbars are hidden
