### PR TITLE
feat(search): Change search attribute names

### DIFF
--- a/src/assistant/Search/getIconForSearchResult.js
+++ b/src/assistant/Search/getIconForSearchResult.js
@@ -26,14 +26,14 @@ export const getIconForSearchResult = searchResult => {
     }
   }
 
-  if (searchResult.type === 'notes') {
+  if (searchResult.slug === 'notes') {
     return {
       type: 'component',
       component: IconNote
     }
   }
 
-  if (searchResult.type === 'drive') {
+  if (searchResult.slug === 'drive') {
     return {
       type: 'component',
       component: getDriveMimeTypeIcon(
@@ -44,7 +44,7 @@ export const getIconForSearchResult = searchResult => {
     }
   }
 
-  if (searchResult.type === 'contacts') {
+  if (searchResult.slug === 'contacts') {
     return {
       type: 'component',
       component: ContactsIcon

--- a/src/assistant/Search/useFetchResult.jsx
+++ b/src/assistant/Search/useFetchResult.jsx
@@ -28,12 +28,16 @@ export const useFetchResult = searchValue => {
       const searchResults = await dataProxy.search(searchValue)
 
       const results = searchResults.map(r => {
+        // Begin Retrocompatibility code, to be removed when following PR is merged: https://github.com/cozy/cozy-web-data-proxy/pull/10
+        r.slug = r.slug || r.type
+        r.subTitle = r.subTitle || r.name
+        // End Retrocompatibility code
         const icon = getIconForSearchResult(r)
         return {
           id: r.doc._id,
           icon: icon,
           primary: r.title,
-          secondary: r.name,
+          secondary: r.subTitle,
           onClick: () => {
             window.open(r.url)
           }


### PR DESCRIPTION
In cozy/cozy-libs#2603 we renamed some of the API's attributes for better readability

This commit adapt to those changes and handle retrocompatibility until the change is deployed in cozy-web-data-proxy

Related PR: cozy/cozy-libs#2603
Related PR: cozy/cozy-web-data-proxy#10
