### PR TITLE
fix(Assistant): We wasn't scrolling to the end of the instant message

### DIFF
--- a/src/assistant/Conversations/ChatConversation.jsx
+++ b/src/assistant/Conversations/ChatConversation.jsx
@@ -12,6 +12,7 @@ import ChatRealtimeAnswer from './ChatRealtimeAnswer'
 const ChatConversation = ({ conversation, myself }) => {
   const { assistantState } = useAssistant()
   const listRef = useRef()
+  const instantMessageKeysCount = Object.keys(assistantState.message).length
 
   // test on role === user to be sure the last response is inside io.cozy.ai.chat.conversations
   const showRealtimeMessage =
@@ -21,11 +22,11 @@ const ChatConversation = ({ conversation, myself }) => {
 
   useEffect(() => {
     // force scroll down if new message of change in AI instant response
-    listRef.current?.lastElementChild?.scrollIntoView({ block: 'end' })
+    listRef.current?.lastElementChild?.scrollIntoView(false)
   }, [
     conversation?.messages?.length,
     assistantState.status,
-    assistantState.message
+    instantMessageKeysCount
   ])
 
   return (

--- a/src/assistant/Conversations/Sources/Sources.jsx
+++ b/src/assistant/Conversations/Sources/Sources.jsx
@@ -22,6 +22,11 @@ const Sources = ({ messageId, files }) => {
     setShowSources(v => !v)
   }
 
+  // we want to scroll down to the sources button when it is displayed
+  useEffect(() => {
+    ref.current?.scrollIntoView(false)
+  }, [])
+
   useEffect(() => {
     if (showSources) {
       const sourcesBottom = ref.current.getBoundingClientRect().bottom


### PR DESCRIPTION
```
### ✨ Features

* We want to scroll down to the sources button when it is displayed

### 🐛 Bug Fixes

* We wasn't scrolling to the end of the instant message
```