### PR TITLE
fix: Disable DataProxy's iframe when running inside of Flagship app

### DIFF
--- a/src/dataproxy/DataProxyProvider.jsx
+++ b/src/dataproxy/DataProxyProvider.jsx
@@ -2,6 +2,7 @@ import * as Comlink from 'comlink'
 import React, { useContext, useState, useEffect } from 'react'
 
 import { useClient } from 'cozy-client'
+import { isFlagshipApp } from 'cozy-device-helper'
 import flag from 'cozy-flags'
 import Minilog from 'cozy-minilog'
 
@@ -66,7 +67,11 @@ export const DataProxyProvider = React.memo(({ children }) => {
       }
     }
 
-    initIframe()
+    if (isFlagshipApp()) {
+      setDataProxyServicesAvailable(false)
+    } else {
+      initIframe()
+    }
   }, [client])
 
   const onIframeLoaded = () => {


### PR DESCRIPTION
When running inside of Flagship app, we don't want to load the DataProxy's iframe

Instead we want to use the Flagship app's API

For now this API does not exist, so we just disable the DataProxy feature

We could have enabled the iframe until the native API is implemented, but for now this would introduce an infinite nested iframes bug as the Flagship app's WebViews intercept all requests to `/` or `/index.html` and inject the cozy-home code



```
### ✨ Features

*

### 🐛 Bug Fixes

* Disable DataProxy in Flagship app

### 🔧 Tech

*
```
