### PR TITLE
feat: Improve triggers query performances

### DIFF
--- a/src/components/Sections/SectionsContext.tsx
+++ b/src/components/Sections/SectionsContext.tsx
@@ -13,6 +13,7 @@ import {
   useAppsInMaintenance,
   useClient,
   useQuery,
+  useQueryAll,
   useSettings
 } from 'cozy-client'
 import {
@@ -85,17 +86,17 @@ export const SectionsProvider = ({
   const client = useClient()
   const { t } = useI18n()
 
-  const { data: allTriggers } = useQuery(
+  const { data: allTriggers } = useQueryAll(
     _makeTriggersQuery.definition(),
     _makeTriggersQuery.options
   ) as { data: IOCozyTrigger[] }
 
-  const { data: accounts } = useQuery(
+  const { data: accounts } = useQueryAll(
     _makeAccountsQuery.definition(),
     _makeAccountsQuery.options
   ) as { data: IOCozyAccount[] }
 
-  const { data: konnectors } = useQuery(
+  const { data: konnectors } = useQueryAll(
     konnectorsConn.query,
     konnectorsConn
   ) as { data: IOCozyKonnector[] }

--- a/src/queries.js
+++ b/src/queries.js
@@ -15,9 +15,15 @@ export const konnectorsConn = {
 }
 
 export const makeTriggersQuery = {
-  definition: () => Q('io.cozy.triggers'),
+  definition: () => {
+    return Q('io.cozy.triggers')
+      .partialIndex({
+        worker: 'konnector'
+      })
+      .limitBy(1000)
+  },
   options: {
-    as: 'io.cozy.triggers',
+    as: 'io.cozy.triggers/worker=konnector',
     fetchPolicy: defaultFetchPolicy
   }
 }


### PR DESCRIPTION
We used to query all triggers, in order to determine which konnectors accounts are connected, to adapt display on the homepage.

However, this query can be very time-consuming: it takes ~10s on an instance with 700+ triggers. This is due to the stack computing job information from each trigger.
As we do not need such information here, we force the generic `/data` route, rather than the specialized `/jobs/triggers` route.

:warning: https://github.com/cozy/cozy-client/pull/1571 should be merged first, and cozy-client updated accordingly

```
### ✨ Features

* Improve triggers retrieval

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```
