### PR TITLE
fix: Avoid rendering at focus

### DIFF
--- a/src/containers/ReloadFocus.jsx
+++ b/src/containers/ReloadFocus.jsx
@@ -13,12 +13,14 @@ class RealoadFocus extends React.Component {
   componentDidMount() {
     const client = this.props.client
     window.addEventListener('focus', () => {
-      client.query(makeJobsQuery.definition(), makeJobsQuery.options)
-      client.query(
-        makeTriggersWithJobStatusQuery.definition(),
-        makeTriggersWithJobStatusQuery.options
-      )
-      client.query(makeAppsQuery.definition(), makeAppsQuery.options)
+      // FIXME: do not use query options here, because of https://github.com/cozy/cozy-client/issues/931
+      // Especially for the apps query, the fetchPolicy is always applied here, because it is called
+      // elsewhere, making the query's lastUpdate very close in time.
+      // And because of this, the home is rendered after each focus, as the same query gives different
+      // result (a complete response, vs an early empty return in this case)
+      client.query(makeJobsQuery.definition())
+      client.query(makeTriggersWithJobStatusQuery.definition())
+      client.query(makeAppsQuery.definition())
     })
   }
 


### PR DESCRIPTION
At each new focus, a full render was triggered, making a visual reload for the user.
To fix this, we do not use query options in the ReloadFocus component, because of: https://github.com/cozy/cozy-client/issues/931 Especially for the apps query, the fetchPolicy is always applied here, because it is called elsewhere, making the query's lastUpdate very close in time. And because of this, the home is rendered after each focus, as the same query gives different result (a complete response, vs an early empty return in this case)



```
### ✨ Features

*

### 🐛 Bug Fixes

* Do not reload home at focus

### 🔧 Tech

*
```
