### PR TITLE
fix: Show Divider in group mode

### DIFF
--- a/src/components/Sections/SectionHeader.tsx
+++ b/src/components/Sections/SectionHeader.tsx
@@ -37,7 +37,11 @@ export const SectionHeader = ({
           ) : (
             <div className="u-ellipsis u-mr-half">{section?.name}</div>
           )
-        ) : null}
+        ) : (
+          <Divider className="u-mv-0 u-flex-grow-1" variant="subtitle2">
+            {section?.name}
+          </Divider>
+        )}
 
         {!isCategory && section && (
           <Button


### PR DESCRIPTION
This was removed by mistake in 93d41d35d5fa7da55306419ba6e4d099f5c21391.