### PR TITLE
fix: Correct spacing for shortcuts list

### DIFF
--- a/src/components/Sections/GroupedSectionsView.tsx
+++ b/src/components/Sections/GroupedSectionsView.tsx
@@ -2,7 +2,6 @@ import React, { useRef, useState } from 'react'
 import cx from 'classnames'
 
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
-import { isTwakeTheme } from 'cozy-ui/transpiled/react/helpers/isTwakeTheme'
 
 import { GroupedSectionViewProps } from 'components/Sections/SectionsTypes'
 import { SectionHeader } from 'components/Sections/SectionHeader'
@@ -29,11 +28,7 @@ export const GroupedSectionView = ({
 
       <div
         className={cx(
-          'shortcuts-list u-w-100 u-mh-auto u-flex-justify-center',
-          {
-            'shortcuts-list--gutter': isTwakeTheme(),
-            'u-mv-3 u-mv-2-t ': !isTwakeTheme()
-          }
+          'shortcuts-list shortcuts-list--gutter u-w-100 u-mh-auto u-mv-3 u-mv-2-t u-flex-justify-center'
         )}
       >
         {sections.map(section => (

--- a/src/components/Sections/SectionView.tsx
+++ b/src/components/Sections/SectionView.tsx
@@ -5,7 +5,6 @@ import { useQuery } from 'cozy-client'
 import type { IOCozyKonnector } from 'cozy-client/types/types'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
-import { isTwakeTheme } from 'cozy-ui/transpiled/react/helpers/isTwakeTheme'
 
 import AddServiceTile from 'components/AddServiceTile'
 import KonnectorTile from 'components/KonnectorTile'
@@ -38,10 +37,9 @@ export const SectionBody = ({ section }: SectionViewProps): JSX.Element => {
   return (
     <div
       className={cx(
-        'shortcuts-list u-w-100',
+        'shortcuts-list shortcuts-list--gutter u-w-100',
         {
-          'u-mv-3 u-mv-2-t u-mh-auto u-flex-justify-center': !isGroupMode,
-          'shortcuts-list--gutter': isTwakeTheme()
+          'u-mv-3 u-mv-2-t u-mh-auto u-flex-justify-center': !isGroupMode
         },
         { detailed: currentDisplayMode === DisplayMode.DETAILED }
       )}

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -8,8 +8,6 @@ import keyBy from 'lodash/keyBy'
 import has from 'lodash/has'
 
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
-import Divider from 'cozy-ui/transpiled/react/Divider'
-import { isTwakeTheme } from 'cozy-ui/transpiled/react/helpers/isTwakeTheme'
 
 import AddServiceTile from 'components/AddServiceTile'
 import KonnectorTile from 'components/KonnectorTile'
@@ -66,12 +64,10 @@ export const Services = () => {
 
   return (
     <div className="services-list-wrapper u-m-auto u-w-100">
-      {!isTwakeTheme() && <Divider className="u-mv-0" />}
       <div
-        className={cx('services-list u-w-100 u-mh-auto u-flex-justify-center', {
-          'services-list--gutter': isTwakeTheme(),
-          'u-mv-3 u-mv-2-t': !isTwakeTheme()
-        })}
+        className={cx(
+          'services-list services-list--gutter u-w-100 u-mh-auto u-mv-3 u-mv-2-t u-flex-justify-center'
+        )}
       >
         {konnectors}
         {<AddServiceTile label={t('add_service')} />}

--- a/src/components/Shortcuts/ShortcutsView.jsx
+++ b/src/components/Shortcuts/ShortcutsView.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import cx from 'classnames'
 
 import Divider from 'cozy-ui/transpiled/react/Divider'
-import { isTwakeTheme } from 'cozy-ui/transpiled/react/helpers/isTwakeTheme'
 
 import { ShortcutLink } from 'components/ShortcutLink'
 
@@ -19,11 +18,7 @@ export const ShortcutsView = ({ shortcutsDirectories }) => {
           </Divider>
           <div
             className={cx(
-              'shortcuts-list u-w-100 u-mh-auto u-flex-justify-center',
-              {
-                'shortcuts-list--gutter': isTwakeTheme(),
-                'u-mv-3 u-mv-2-t': !isTwakeTheme()
-              }
+              'shortcuts-list shortcuts-list--gutter u-w-100 u-mh-auto u-mv-3 u-mv-2-t u-flex-justify-center'
             )}
           >
             {directory.items.map(shortcut => (

--- a/src/components/Shortcuts/__snapshots__/ShortcutsView.spec.jsx.snap
+++ b/src/components/Shortcuts/__snapshots__/ShortcutsView.spec.jsx.snap
@@ -17,7 +17,7 @@ Object {
             List title
           </h6>
           <div
-            class="shortcuts-list u-w-100 u-mh-auto u-flex-justify-center u-mv-3 u-mv-2-t"
+            class="shortcuts-list shortcuts-list--gutter u-w-100 u-mh-auto u-mv-3 u-mv-2-t u-flex-justify-center"
           >
             <a
               class="MuiTypography-root MuiLink-root MuiLink-underlineNone scale-hover MuiTypography-colorPrimary"
@@ -90,7 +90,7 @@ Object {
           List title
         </h6>
         <div
-          class="shortcuts-list u-w-100 u-mh-auto u-flex-justify-center u-mv-3 u-mv-2-t"
+          class="shortcuts-list shortcuts-list--gutter u-w-100 u-mh-auto u-mv-3 u-mv-2-t u-flex-justify-center"
         >
           <a
             class="MuiTypography-root MuiLink-root MuiLink-underlineNone scale-hover MuiTypography-colorPrimary"
@@ -220,7 +220,7 @@ Object {
             a
           </h6>
           <div
-            class="shortcuts-list u-w-100 u-mh-auto u-flex-justify-center u-mv-3 u-mv-2-t"
+            class="shortcuts-list shortcuts-list--gutter u-w-100 u-mh-auto u-mv-3 u-mv-2-t u-flex-justify-center"
           >
             <a
               class="MuiTypography-root MuiLink-root MuiLink-underlineNone scale-hover MuiTypography-colorPrimary"
@@ -286,7 +286,7 @@ Object {
             c
           </h6>
           <div
-            class="shortcuts-list u-w-100 u-mh-auto u-flex-justify-center u-mv-3 u-mv-2-t"
+            class="shortcuts-list shortcuts-list--gutter u-w-100 u-mh-auto u-mv-3 u-mv-2-t u-flex-justify-center"
           >
             <a
               class="MuiTypography-root MuiLink-root MuiLink-underlineNone scale-hover MuiTypography-colorPrimary"
@@ -359,7 +359,7 @@ Object {
           a
         </h6>
         <div
-          class="shortcuts-list u-w-100 u-mh-auto u-flex-justify-center u-mv-3 u-mv-2-t"
+          class="shortcuts-list shortcuts-list--gutter u-w-100 u-mh-auto u-mv-3 u-mv-2-t u-flex-justify-center"
         >
           <a
             class="MuiTypography-root MuiLink-root MuiLink-underlineNone scale-hover MuiTypography-colorPrimary"
@@ -425,7 +425,7 @@ Object {
           c
         </h6>
         <div
-          class="shortcuts-list u-w-100 u-mh-auto u-flex-justify-center u-mv-3 u-mv-2-t"
+          class="shortcuts-list shortcuts-list--gutter u-w-100 u-mh-auto u-mv-3 u-mv-2-t u-flex-justify-center"
         >
           <a
             class="MuiTypography-root MuiLink-root MuiLink-underlineNone scale-hover MuiTypography-colorPrimary"


### PR DESCRIPTION
During Twake migration to fit new UI requirements :
- first we modified shortcuts-list and services-list to reduce spacing
- but then we allowed to completely remove these lists with a flag `home.apps.only-one-list` to display apps, shortcuts and services in only one list

So the previous spacing reduction is not useful anymore for Twake UI and on the contraty breaks spacing when using the
`home.detailed-sections-dev` flag and `home.detailed-services-dev` flag