### PR TITLE
fix: Enforce absolute URL for default wallpaper

### DIFF
--- a/src/components/BackgroundContainer.tsx
+++ b/src/components/BackgroundContainer.tsx
@@ -1,16 +1,17 @@
 import React from 'react'
 import cx from 'classnames'
 
-import { useWallpaperContext } from 'hooks/useWallpaperContext'
 import { useCozyTheme } from 'cozy-ui/transpiled/react/providers/CozyTheme'
 
-import DefaultWallpaper from 'assets/images/default-wallpaper.svg'
+import { useDefaultWallpaper } from 'hooks/useDefaultWallpaper'
+import { useWallpaperContext } from 'hooks/useWallpaperContext'
 
 export const BackgroundContainer = (): JSX.Element => {
   const {
     data: { binaryCustomWallpaper, isCustomWallpaper }
   } = useWallpaperContext()
   const { type } = useCozyTheme()
+  const defaultWallpaper = useDefaultWallpaper()
 
   return (
     <div
@@ -31,8 +32,8 @@ export const BackgroundContainer = (): JSX.Element => {
       <div />
       <div />
       <div />
-      {!isCustomWallpaper && (
-        <img className="home-default-background--img" src={DefaultWallpaper} />
+      {!isCustomWallpaper && defaultWallpaper && (
+        <img className="home-default-background--img" src={defaultWallpaper} />
       )}
     </div>
   )

--- a/src/hooks/useDefaultWallpaper.tsx
+++ b/src/hooks/useDefaultWallpaper.tsx
@@ -1,0 +1,23 @@
+import { useClient, generateWebLink } from 'cozy-client'
+
+import DefaultWallpaper from 'assets/images/default-wallpaper.svg'
+
+export const useDefaultWallpaper = (): string | undefined => {
+  const client = useClient()
+
+  const wallpaper = client
+    ? generateWebLink({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+        cozyUrl: client.getStackClient().uri,
+        pathname: DefaultWallpaper,
+        hash: '',
+        searchParams: [],
+        slug: 'home',
+        // @ts-expect-error subdomain is not typed
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        subDomainType: client.getInstanceOptions().subdomain
+      })
+    : undefined
+
+  return wallpaper
+}

--- a/test/AppLike.jsx
+++ b/test/AppLike.jsx
@@ -21,7 +21,9 @@ const fakeDefaultReduxState = {
 }
 const reduxStore = createStore(() => fakeDefaultReduxState)
 
-const defaultClient = createMockClient({})
+const defaultClient = createMockClient({
+  clientOptions: { uri: 'https://claude.mycozy.cloud' }
+})
 defaultClient.ensureStore()
 
 const mockSharingContextValue = {


### PR DESCRIPTION
Because we use `import from` notation for the default wallpaper's svg the result is a relative URL

On the Flagship app, the relative URL won't work on some iOS devices due to Webview that uses unsecure `http`. On those devices, the svg file would not load (however this works on some iOS devices but we don't know why)

By generating an absolute URL using the Cozy instance's URL, we ensure that secure `https` will be use instead