### PR TITLE
feat: Upgrade fixed cozy-dataproxy-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@sentry/react": "7.119.0",
     "cozy-bar": "^23.1.0",
     "cozy-client": "^60.9.0",
-    "cozy-dataproxy-lib": "^4.8.2",
+    "cozy-dataproxy-lib": "^4.11.0",
     "cozy-device-helper": "^3.8.0",
     "cozy-devtools": "^1.3.0",
     "cozy-doctypes": "^1.97.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5094,10 +5094,10 @@ cozy-client@^60.9.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-dataproxy-lib@^4.8.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/cozy-dataproxy-lib/-/cozy-dataproxy-lib-4.8.2.tgz#b58f1984847bf167dedea0c34d1205958a60d3dd"
-  integrity sha512-KZOaY949M3v1W478v8UlVZwDzlbAVqjcTnIWok0psxr6EkX+NwTWHr9kqHWrX+Y086S7PJkcAhZCP/XbOmqAbQ==
+cozy-dataproxy-lib@^4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/cozy-dataproxy-lib/-/cozy-dataproxy-lib-4.11.0.tgz#89cd935486517574ce1e648aab62209638afa4ab"
+  integrity sha512-4XMP8axtvpOnwlmBHug8obGCt5zU/gXABt4RLqCLi4FlsVryAGw9QYZibUPNsirGrHiMdwXrC5rrDPWAFMUUvA==
   dependencies:
     comlink "4.4.1"
     flexsearch "0.7.43"


### PR DESCRIPTION
We had to revert the cozy-dataproxy-lib in
d7e55f9e99c27345eb6b335529cab99dc44a7198 
After fixing the issue in https://github.com/cozy/cozy-libs/pull/2829, we can now upgrade it again